### PR TITLE
Security standards: pre-push gates, CodeQL, Dependabot, branch protection

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Mandatory pre-push gate (see CLAUDE.md):
+#   * secret/password scan on every push
+#   * dependency vulnerability check when pushing to master/main
+# Enable once per clone:  git config core.hooksPath .githooks
+set -uo pipefail
+
+repo_slug="adebnar/hermes-android"
+zero="0000000000000000000000000000000000000000"
+red=$'\033[31m'; grn=$'\033[32m'; ylw=$'\033[33m'; rst=$'\033[0m'
+fail(){ echo "${red}✗ pre-push blocked:${rst} $*" >&2; exit 1; }
+
+pushing_master=0
+while read -r local_ref local_oid remote_ref remote_oid; do
+  [ -z "${local_ref:-}" ] && continue
+  case "$remote_ref" in
+    refs/heads/master|refs/heads/main) pushing_master=1 ;;
+  esac
+done
+
+# 1) Secret scan (always)
+if command -v gitleaks >/dev/null 2>&1; then
+  echo "${grn}▶ gitleaks secret scan…${rst}"
+  if ! gitleaks git --no-banner --redact >/dev/null 2>&1; then
+    gitleaks git --no-banner --redact 2>&1 | tail -20 >&2
+    fail "gitleaks found a potential secret/password. Remove & rotate it before pushing."
+  fi
+  echo "${grn}✓ no secrets detected${rst}"
+else
+  echo "${ylw}⚠ gitleaks not installed — local secret scan skipped (CI still scans). Install: brew install gitleaks${rst}" >&2
+fi
+
+# 2) Dependency vulnerability check (master/main only)
+if [ "$pushing_master" = "1" ]; then
+  echo "${grn}▶ dependency vulnerability check (master)…${rst}"
+  if command -v gh >/dev/null 2>&1; then
+    n=$(gh api "repos/${repo_slug}/dependabot/alerts" --jq \
+      '[.[] | select(.state=="open" and (.security_advisory.severity=="high" or .security_advisory.severity=="critical"))] | length' 2>/dev/null || echo "skip")
+    if [ "$n" = "skip" ]; then
+      echo "${ylw}⚠ could not query Dependabot alerts — verify manually before release.${rst}" >&2
+    elif [ "${n:-0}" -gt 0 ] 2>/dev/null; then
+      fail "${n} open HIGH/CRITICAL Dependabot alert(s). Resolve before releasing to master."
+    else
+      echo "${grn}✓ no open high/critical Dependabot alerts${rst}"
+    fi
+  fi
+  if command -v osv-scanner >/dev/null 2>&1; then
+    osv-scanner --recursive . || fail "osv-scanner found vulnerable dependencies."
+  fi
+fi
+
+echo "${grn}✓ pre-push checks passed${rst}"
+exit 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot: weekly checks for vulnerable / outdated dependencies.
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    target-branch: develop
+    labels: ["dependencies"]
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: develop
+    labels: ["dependencies", "ci"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+# Static code-scanning for security vulnerabilities in the Kotlin/Java sources.
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: manual
+      - run: chmod +x ./gradlew
+      - name: Build for analysis
+        run: ./gradlew :app:assembleDebug --no-daemon
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,35 @@
+name: Security
+
+# Secret scanning + dependency-graph submission so Dependabot sees all (transitive) deps.
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dependency-graph:
+    # Submit the Gradle dependency graph to GitHub on master so Dependabot
+    # evaluates the full (transitive) tree for advisories.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/dependency-submission@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# Hermes for Android — Project Standards
+
+These rules are **mandatory** for any agent or contributor working in this repo. They keep
+`master` production-grade and the app free of leaked secrets and known-vulnerable
+dependencies. An agent (Claude Code or otherwise) MUST follow them exactly.
+
+---
+
+## Branch workflow
+
+| Branch | Role | Rule |
+|--------|------|------|
+| `master` | Production / stable | **Protected.** Never commit or push directly. Changes land via PR only. |
+| `develop` | Beta / integration | New work lands here first. Safe to push. |
+| `feature/*` | Short-lived work | Branch off `develop`; open a PR into `develop`. |
+
+Releases: tag `vX.Y.Z` on `master` (stable) or `vX.Y.Z-beta.N` on `develop` (beta
+pre-release). Tag pushes trigger the signed-APK release workflow.
+
+---
+
+## Mandatory gates before pushing
+
+### 1. Approval to push to `master` / `main` — REQUIRED
+- **NEVER push to `master` without explicit, per-push approval from the user in the
+  conversation.** Approval for one push does NOT carry to the next.
+- The default target for any push is `develop` or a `feature/*` branch.
+- Reaching `master` is done through a **pull request** with passing checks — never a direct
+  push. `master` is branch-protected on GitHub to enforce this.
+
+### 2. Secret / password scan before EVERY push — REQUIRED
+Run before any `git push`:
+```bash
+gitleaks git --no-banner --redact      # scans the commits being pushed
+```
+If gitleaks reports **any** finding, STOP — do not push. Remove the secret, rotate it, and
+rewrite history if it was already committed. Never commit `keystore.properties`, `*.jks`,
+`local.properties`, `.env`, API tokens, the Hermes session token, or anything under
+`~/.secrets`.
+
+### 3. Dependency / vulnerability check before pushing to `master` — REQUIRED
+Before any change reaches `master`, confirm there are no known-vulnerable dependencies:
+```bash
+# Authoritative — GitHub's GHSA advisory database:
+gh api repos/adebnar/hermes-android/dependabot/alerts \
+  --jq '[.[] | select(.state=="open")] | map({pkg:.dependency.package.name, sev:.security_advisory.severity})'
+# Optional local scan (if installed):
+osv-scanner --recursive .
+```
+Any **open HIGH or CRITICAL** alert blocks the release. Upgrade or replace the dependency
+first.
+
+---
+
+## Automated enforcement (already wired)
+
+- **`.githooks/pre-push`** — runs the secret scan on every push and the dependency check on
+  `master` pushes. Enable once per clone:
+  ```bash
+  git config core.hooksPath .githooks
+  ```
+- **GitHub Actions** — `ci.yml` (build + unit test), `codeql.yml` (code scanning),
+  `security.yml` (gitleaks + dependency submission for the Dependabot graph).
+- **GitHub repo settings** — Dependabot alerts + automated security fixes, secret scanning
+  with push protection, and `master` branch protection (PR + passing checks required).
+
+---
+
+## Build & signing
+
+- Build with a **JDK 21** toolchain via `JAVA_HOME`. Do **not** hardcode
+  `org.gradle.java.home` — it breaks CI and clones.
+- Release signing reads the gitignored `keystore.properties`; signing secrets never enter
+  git.
+- Full build, release, token, and setup docs live in [README.md](README.md).
+
+---
+
+## Agent etiquette
+
+- No AI/assistant attribution in commits, files, or PRs (no "Co-Authored-By", "Generated
+  with", "Claude", etc.).
+- Run the build and unit tests before claiming work is complete.
+- Prefer small, reviewable commits with clear messages.


### PR DESCRIPTION
Adds the project security standard and enforcement.

**Gates (see CLAUDE.md)**
- Approval required to push to `master` (now branch-protected; direct pushes blocked).
- Secret/password scan before every push (`.githooks/pre-push` + gitleaks CI).
- Dependency vulnerability check before master (Dependabot alerts + CodeQL + dep-graph submission).

**Repo settings enabled:** Dependabot alerts + auto-fixes, secret scanning + push protection, master branch protection (PR + `build` check, force-push/deletion disabled, admins enforced).

No app code changes; CI builds and unit tests unaffected.