### PR TITLE
ci: group Dependabot updates + ignore breaking/pinned bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,33 @@
-# Dependabot: weekly checks for vulnerable / outdated dependencies.
+# Dependabot: weekly dependency checks, grouped into a single PR per ecosystem
+# to avoid PR noise. Security alerts stay enabled separately (repo settings).
 version: 2
 updates:
   - package-ecosystem: gradle
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
     target-branch: develop
     labels: ["dependencies"]
+    open-pull-requests-limit: 5
+    groups:
+      gradle:
+        patterns: ["*"]
+    ignore:
+      # The toolchain is intentionally pinned for AGP 8.x compatibility
+      # (see gradle/libs.versions.toml). Skip breaking majors and the specific
+      # packages whose newer versions require AGP 9.x / a newer Kotlin metadata.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.android.application"
+      - dependency-name: "org.jetbrains.kotlin*"
+      - dependency-name: "com.google.dagger:hilt*"
+      - dependency-name: "androidx.core:core-ktx"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     target-branch: develop
     labels: ["dependencies", "ci"]
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,11 @@ updates:
       # packages whose newer versions require AGP 9.x / a newer Kotlin metadata.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      - dependency-name: "com.android.application"
-      - dependency-name: "org.jetbrains.kotlin*"
-      - dependency-name: "com.google.dagger:hilt*"
+      - dependency-name: "com.android.application*"   # AGP plugin id + marker artifact
+      - dependency-name: "org.jetbrains.kotlin:*"     # Kotlin libs (NOT kotlinx serialization/coroutines)
+      - dependency-name: "org.jetbrains.kotlin.*"     # Kotlin Gradle plugin ids
+      - dependency-name: "com.google.dagger:hilt*"    # Hilt libraries
+      - dependency-name: "com.google.dagger.hilt*"    # Hilt Gradle plugin id
       - dependency-name: "androidx.core:core-ktx"
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Reconfigures Dependabot to group updates into one PR per ecosystem and ignore semver-major bumps plus the AGP/Kotlin/Hilt/core-ktx packages pinned for AGP 8.x compatibility. Security alerts stay on. Closes the version-update PR noise.