### PR TITLE
Release v0.1.8 — crash/keyboard/resume/scroll/model fixes + diagnostics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6
-        versionName = "0.1.5"
+        versionCode = 7
+        versionName = "0.1.6"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 4
-        versionName = "0.1.3"
+        versionCode = 5
+        versionName = "0.1.4"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7
-        versionName = "0.1.6"
+        versionCode = 8
+        versionName = "0.1.7"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3
-        versionName = "0.1.2"
+        versionCode = 4
+        versionName = "0.1.3"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 8
-        versionName = "0.1.7"
+        versionCode = 9
+        versionName = "0.1.8"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2
-        versionName = "0.1.1"
+        versionCode = 3
+        versionName = "0.1.2"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 2
+        versionName = "0.1.1"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5
-        versionName = "0.1.4"
+        versionCode = 6
+        versionName = "0.1.5"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"
@@ -59,6 +59,10 @@ android {
         }
     }
     buildFeatures { compose = true }
+
+    // Let stubbed android.* calls (e.g. android.util.Log) return defaults instead of throwing
+    // in local JVM unit tests, so pure logic that mirrors to logcat stays unit-testable.
+    testOptions { unitTests.isReturnDefaultValues = true }
 
     // Build daemon runs on JBR (JDK 21); emit JVM 17 bytecode for Android.
     compileOptions {

--- a/app/src/androidTest/java/com/hermes/client/ui/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/hermes/client/ui/ChatScreenTest.kt
@@ -25,4 +25,19 @@ class ChatScreenTest {
         rule.onNodeWithText("Hello").assertIsDisplayed()
         rule.onNodeWithText("Hi there").assertIsDisplayed()
     }
+
+    // Regression: the gateway reuses the model name as the message id across a
+    // session's turns, so loaded history can contain several messages with the same
+    // id. The chat list must not crash on duplicate ids ("Key X was already used").
+    @Test fun duplicate_message_ids_do_not_crash() {
+        val state = ChatUiState(
+            messages = listOf(
+                ChatMessage(id = "gemma", role = Role.ASSISTANT, text = "first reply"),
+                ChatMessage(id = "gemma", role = Role.ASSISTANT, text = "second reply"),
+            ),
+        )
+        rule.setContent { HermesTheme { ChatMessageList(state = state) } }
+        rule.onNodeWithText("first reply").assertIsDisplayed()
+        rule.onNodeWithText("second reply").assertIsDisplayed()
+    }
 }

--- a/app/src/androidTest/java/com/hermes/client/ui/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/hermes/client/ui/ChatScreenTest.kt
@@ -26,6 +26,35 @@ class ChatScreenTest {
         rule.onNodeWithText("Hi there").assertIsDisplayed()
     }
 
+    // Opening an existing session must land at the newest message, not the top —
+    // otherwise the latest reply (and any new response) sits below the fold and looks
+    // missing, forcing the user to scroll to the bottom by hand.
+    @Test fun opening_session_lands_on_latest_message() {
+        val last = "message number 120 — this is a longer line of body text so the thread overflows the screen and the final item only renders if the list scrolled to the bottom"
+        val msgs = (1..120).map { i ->
+            ChatMessage(
+                id = "m$i",
+                role = if (i % 2 == 0) Role.ASSISTANT else Role.USER,
+                text = if (i == 120) last
+                else "message number $i — this is a longer line of body text so the thread overflows the screen and the final item only renders if the list scrolled to the bottom",
+            )
+        }
+        // Mimic the real flow: the screen composes empty, then history loads asynchronously
+        // and populates the list (so by the time it fills, the list is already laid out at the
+        // top). Composing the full list up front hides the bug because the first auto-scroll
+        // effect runs before layout (empty visibleItems) and scrolls anyway.
+        val listState = androidx.compose.foundation.lazy.LazyListState()
+        val state = androidx.compose.runtime.mutableStateOf(ChatUiState(messages = emptyList()))
+        rule.setContent { HermesTheme { ChatMessageList(state = state.value, listState = listState) } }
+        rule.waitForIdle()
+        state.value = ChatUiState(messages = msgs)
+        // The scroll-to-bottom converges across layout passes (item heights are measured
+        // lazily), so drive frames until the newest message is actually visible.
+        rule.waitUntil(timeoutMillis = 5_000) {
+            (listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1) >= 119
+        }
+    }
+
     // Regression: the gateway reuses the model name as the message id across a
     // session's turns, so loaded history can contain several messages with the same
     // id. The chat list must not crash on duplicate ids ("Key X was already used").

--- a/app/src/androidTest/java/com/hermes/client/ui/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/hermes/client/ui/ChatScreenTest.kt
@@ -49,9 +49,11 @@ class ChatScreenTest {
         rule.waitForIdle()
         state.value = ChatUiState(messages = msgs)
         // The scroll-to-bottom converges across layout passes (item heights are measured
-        // lazily), so drive frames until the newest message is actually visible.
+        // lazily), so drive frames until the list reaches the absolute bottom — the newest
+        // message is the last visible item and there is nothing left to scroll past.
         rule.waitUntil(timeoutMillis = 5_000) {
-            (listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1) >= 119
+            (listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1) >= 119 &&
+                !listState.canScrollForward
         }
     }
 

--- a/app/src/main/java/com/hermes/client/HermesApp.kt
+++ b/app/src/main/java/com/hermes/client/HermesApp.kt
@@ -1,7 +1,30 @@
 package com.hermes.client
 
 import android.app.Application
+import com.hermes.client.data.diagnostics.DebugLog
+import com.hermes.client.data.repository.SettingsStore
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @HiltAndroidApp
-class HermesApp : Application()
+class HermesApp : Application() {
+    @Inject lateinit var settingsStore: SettingsStore
+
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    override fun onCreate() {
+        super.onCreate()
+        // Restore the diagnostic-logging toggle at launch so capture is active before the
+        // Diagnostics screen is ever opened (e.g. to catch a failure on the first session open).
+        settingsStore.debugLogging
+            .distinctUntilChanged()
+            .onEach { DebugLog.setEnabled(it) }
+            .launchIn(appScope)
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
+++ b/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
@@ -1,6 +1,9 @@
 package com.hermes.client.data.diagnostics
 
 import android.util.Log
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -23,6 +26,10 @@ object DebugLog {
 
     @Volatile private var enabled = false
     @Volatile private var tokenToRedact: String? = null
+
+    // Thread-safe (unlike SimpleDateFormat); the log is written from background threads.
+    private val exportFmt =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
 
     private val lock = Any()
     private val buffer = ArrayDeque<LogEntry>(MAX_ENTRIES)
@@ -66,7 +73,9 @@ object DebugLog {
         if (snapshot.isEmpty()) return "(no diagnostic entries)"
         return buildString {
             append("Hermes diagnostic log — ${snapshot.size} entries\n")
-            snapshot.forEach { e -> append("${e.timeMillis} [${e.category}] ${e.message}\n") }
+            snapshot.forEach { e ->
+                append("${exportFmt.format(Instant.ofEpochMilli(e.timeMillis))} [${e.category}] ${e.message}\n")
+            }
         }
     }
 

--- a/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
+++ b/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
@@ -1,0 +1,77 @@
+package com.hermes.client.data.diagnostics
+
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Process-wide diagnostic log, toggled by the user in Settings → Diagnostics.
+ *
+ * It is a plain object (not DI) so it can be called from non-injected code such as the
+ * WebSocket listener. When [enabled] is false, [log] is a cheap no-op and nothing is
+ * retained, so there is zero overhead in normal use. When enabled, entries are kept in a
+ * bounded in-memory ring buffer (cleared on app kill), exposed as [entries] for the live
+ * in-app view and mirrored to logcat under [TAG].
+ *
+ * A registered session token is masked in every message so the log is safe to share.
+ */
+object DebugLog {
+    const val MAX_ENTRIES = 500
+    private const val TAG = "HermesDebug"
+
+    data class LogEntry(val timeMillis: Long, val category: String, val message: String)
+
+    @Volatile private var enabled = false
+    @Volatile private var tokenToRedact: String? = null
+
+    private val lock = Any()
+    private val buffer = ArrayDeque<LogEntry>(MAX_ENTRIES)
+
+    private val _entries = MutableStateFlow<List<LogEntry>>(emptyList())
+    val entries: StateFlow<List<LogEntry>> = _entries
+
+    fun isEnabled(): Boolean = enabled
+
+    fun setEnabled(value: Boolean) {
+        enabled = value
+    }
+
+    /** Register the session token so it is never written to the log in plain text. */
+    fun setTokenToRedact(token: String?) {
+        tokenToRedact = token?.takeIf { it.isNotBlank() }
+    }
+
+    fun log(category: String, message: String) {
+        if (!enabled) return
+        val safe = redact(message)
+        val entry = LogEntry(System.currentTimeMillis(), category, safe)
+        synchronized(lock) {
+            if (buffer.size >= MAX_ENTRIES) buffer.removeFirst()
+            buffer.addLast(entry)
+            _entries.value = buffer.toList()
+        }
+        Log.d(TAG, "[$category] $safe")
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            buffer.clear()
+            _entries.value = emptyList()
+        }
+    }
+
+    /** Plain-text dump for the Share sheet, oldest first. */
+    fun export(): String {
+        val snapshot = synchronized(lock) { buffer.toList() }
+        if (snapshot.isEmpty()) return "(no diagnostic entries)"
+        return buildString {
+            append("Hermes diagnostic log — ${snapshot.size} entries\n")
+            snapshot.forEach { e -> append("${e.timeMillis} [${e.category}] ${e.message}\n") }
+        }
+    }
+
+    private fun redact(message: String): String {
+        val token = tokenToRedact ?: return message
+        return message.replace(token, "***")
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/network/HermesGatewayClient.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesGatewayClient.kt
@@ -1,5 +1,6 @@
 package com.hermes.client.data.network
 
+import com.hermes.client.data.diagnostics.DebugLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -76,6 +77,7 @@ open class HermesGatewayClient(
 
     protected fun openSocket() {
         val gen = generation.incrementAndGet()
+        DebugLog.log("ws", "opening socket (gen=$gen)")
         // Install a fresh, uncompleted readiness gate for this new socket attempt.
         readyGate = CompletableDeferred()
         _state.value = ConnectionState.Connecting
@@ -107,14 +109,23 @@ open class HermesGatewayClient(
             text.lineSequence().filter { it.isNotBlank() }.forEach { line ->
                 when (val msg = parseInbound(json, line)) {
                     is RpcResult -> pending.remove(msg.id)?.complete(msg.result)
-                    is RpcErrorReply -> pending.remove(msg.id)
-                        ?.completeExceptionally(GatewayRpcException(msg.error.code, msg.error.message))
+                    is RpcErrorReply -> {
+                        DebugLog.log("ws", "rpc#${msg.id} ← error ${msg.error.code}: ${msg.error.message}")
+                        pending.remove(msg.id)
+                            ?.completeExceptionally(GatewayRpcException(msg.error.code, msg.error.message))
+                    }
                     is RpcEvent -> {
                         // Handle gateway.ready: flip to Connected and open the readiness gate.
                         if (msg.event.type == "gateway.ready") {
                             attempt.set(0)
                             _state.value = ConnectionState.Connected
                             readyGate.complete(Unit)
+                        }
+                        // Log every event except the high-frequency streaming deltas, so the
+                        // diagnostic trail stays readable while still capturing errors,
+                        // tool calls, and lifecycle around a failure like "message not found".
+                        if (msg.event.type != "message.delta" && msg.event.type != "reasoning.delta") {
+                            DebugLog.log("ws", "event ${msg.event.type} session=${msg.event.sessionId ?: "-"}")
                         }
                         _events.tryEmit(msg.event)
                     }
@@ -134,6 +145,7 @@ open class HermesGatewayClient(
     protected open fun onSocketClosed(gen: Int, reason: String) {
         // A newer socket has superseded this one (e.g. reconnectNow()) — ignore its death.
         if (gen != generation.get()) return
+        DebugLog.log("ws", "socket closed (gen=$gen): $reason")
         // Fail any call() that is currently awaiting readiness so it throws immediately.
         readyGate.completeExceptionally(GatewayRpcException(0, reason))
         failAllPending(reason)
@@ -168,9 +180,11 @@ open class HermesGatewayClient(
         val id = nextId.getAndIncrement()
         val deferred = CompletableDeferred<JsonElement>()
         pending[id] = deferred
+        DebugLog.log("ws", "rpc#$id → $method")
         val sent = ws?.send(RpcRequest(id, method, params).encode(json)) ?: false
         if (!sent) {
             pending.remove(id)
+            DebugLog.log("ws", "rpc#$id $method failed: not connected")
             throw GatewayRpcException(0, "not connected")
         }
         return deferred.await()

--- a/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
@@ -25,6 +25,9 @@ class HermesRestApi(
 
     private fun builder(path: String): Request.Builder {
         val cfg = config()
+        // Keep the diagnostic log's redaction current with whatever token is active, so a
+        // shared log can never contain the session token in plain text.
+        com.hermes.client.data.diagnostics.DebugLog.setTokenToRedact(cfg.token)
         // Trim trailing slashes so a user-entered "http://host:9119/" doesn't produce
         // "//api/..." — the gateway routes a double slash to its web UI (HTML), not the API.
         val b = Request.Builder().url("${cfg.baseUrl.trimEnd('/')}$path")
@@ -33,9 +36,16 @@ class HermesRestApi(
     }
 
     private suspend inline fun <reified T> get(path: String): T = withContext(Dispatchers.IO) {
+        com.hermes.client.data.diagnostics.DebugLog.log("rest", "GET $path")
         okHttp.newCall(builder(path).get().build()).execute().use { resp ->
             val body = resp.body?.string().orEmpty()
-            if (!resp.isSuccessful) throw HermesApiException(resp.code, body.ifBlank { "HTTP ${resp.code}" })
+            if (!resp.isSuccessful) {
+                com.hermes.client.data.diagnostics.DebugLog.log(
+                    "rest", "GET $path ← ${resp.code} ${body.take(200)}",
+                )
+                throw HermesApiException(resp.code, body.ifBlank { "HTTP ${resp.code}" })
+            }
+            com.hermes.client.data.diagnostics.DebugLog.log("rest", "GET $path ← ${resp.code}")
             json.decodeFromString<T>(body)
         }
     }

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -35,9 +35,18 @@ class ChatRepository(private val client: HermesGatewayClient) {
      * Resumes a session. The gateway accepts the stored (REST) id but returns a NEW short
      * live handle in `session_id` — callers MUST use that returned id for subsequent
      * submit/interrupt and for filtering streamed events. Returns null if not present.
+     *
+     * [profile] MUST be the active profile: the gateway resolves session.resume against a
+     * per-profile state.db, and without it a session that lives in a non-default profile is
+     * reported "session not found" (4007) — which then fails the next prompt.submit too. Once
+     * resume succeeds, the live handle it returns is profile-independent (resolved in-memory),
+     * so only resume needs the profile.
      */
-    suspend fun resume(sessionId: String): String? {
-        val result = client.call("session.resume", buildJsonObject { put("session_id", sessionId) })
+    suspend fun resume(sessionId: String, profile: String? = null): String? {
+        val result = client.call("session.resume", buildJsonObject {
+            put("session_id", sessionId)
+            if (!profile.isNullOrBlank()) put("profile", profile)
+        })
         return result.jsonObject["session_id"]?.jsonPrimitive?.content
     }
 

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -15,8 +15,14 @@ class SessionRepository(private val rest: HermesRestApi) {
         rest.searchSessions(query, profile)
     suspend fun archived(profile: String? = null): List<Session> =
         rest.archivedSessions(profile).map { it.toDomain() }
+    // The gateway reuses the model name as a message id across a session's turns, so
+    // it can't be a unique list key on its own. Prefix the position to guarantee
+    // unique, stable ids for the loaded history (the id is display-only).
     suspend fun history(sessionId: String, profile: String? = null): List<ChatMessage> =
-        rest.messages(sessionId, profile).map { it.toDomain() }
+        rest.messages(sessionId, profile).mapIndexed { i, dto ->
+            val m = dto.toDomain()
+            m.copy(id = "h-$i-${m.id}")
+        }
 
     suspend fun rename(sessionId: String, title: String) = rest.patchSession(sessionId, title = title)
     suspend fun archive(sessionId: String, archived: Boolean) =

--- a/app/src/main/java/com/hermes/client/data/repository/SettingsStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SettingsStore.kt
@@ -1,6 +1,7 @@
 package com.hermes.client.data.repository
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -15,6 +16,7 @@ private val Context.settingsDataStore by preferencesDataStore(name = "app_settin
 class SettingsStore(private val context: Context) {
     private val themeKey = stringPreferencesKey("theme_mode")
     private val toolDisplayKey = stringPreferencesKey("tool_call_display") // "product" | "technical"
+    private val debugLoggingKey = booleanPreferencesKey("debug_logging")
 
     val themeMode: Flow<ThemeMode> = context.settingsDataStore.data.map { prefs ->
         runCatching { ThemeMode.valueOf(prefs[themeKey] ?: "SYSTEM") }.getOrDefault(ThemeMode.SYSTEM)
@@ -31,5 +33,12 @@ class SettingsStore(private val context: Context) {
 
     suspend fun setToolCallTechnical(technical: Boolean) {
         context.settingsDataStore.edit { it[toolDisplayKey] = if (technical) "technical" else "product" }
+    }
+
+    /** Diagnostic logging toggle (Settings → Diagnostics). Off by default. */
+    val debugLogging: Flow<Boolean> = context.settingsDataStore.data.map { it[debugLoggingKey] ?: false }
+
+    suspend fun setDebugLogging(enabled: Boolean) {
+        context.settingsDataStore.edit { it[debugLoggingKey] = enabled }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -2,6 +2,7 @@ package com.hermes.client.ui.chat
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -70,16 +71,15 @@ fun ChatMessageList(
         snapshotFlow { listState.layoutInfo.totalItemsCount }
             .filter { it >= state.messages.size }
             .first()
-        // Converge to the true bottom. A single scrollToItem on a freshly-loaded list
-        // undershoots: it can only measure items up to the current extent, and the off-screen
-        // bubbles wrap taller than the estimate. Re-scroll after each frame (which measures
-        // more items) until the last one is actually visible.
+        // Converge to the ABSOLUTE bottom — the end of the newest message, not just the last
+        // item's top. scrollToItem lands on an item's top, and a long last message can be
+        // taller than the viewport, so jump to the last item then keep scrolling until there
+        // is nothing left below (item heights are measured lazily as we go).
+        listState.scrollToItem(state.messages.lastIndex)
         var guard = 0
-        while (guard++ < 20) {
-            listState.scrollToItem(state.messages.lastIndex)
-            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
-            if (lastVisible >= state.messages.lastIndex) break
-            withFrameNanos {} // let a layout pass run so more items get measured
+        while (guard++ < 40 && listState.canScrollForward) {
+            listState.scrollBy(100_000f)
+            withFrameNanos {} // let a layout pass measure the next items, then continue
         }
         landed = true
     }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -75,7 +75,14 @@ fun ChatMessageList(state: ChatUiState, modifier: Modifier = Modifier) {
         modifier = modifier.fillMaxSize().padding(horizontal = 12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        items(state.messages, key = { it.id }) { msg -> MessageBubble(msg) }
+        // Key by position as well as id: the gateway reuses the model name as the
+        // message id across a session's turns, so ids are NOT guaranteed unique.
+        // The index makes the key collision-proof regardless of id source (the list
+        // is append-only, so an item's index is stable across recompositions).
+        itemsIndexed(
+            state.messages,
+            key = { index, msg -> "$index:${msg.id}" },
+        ) { _, msg -> MessageBubble(msg) }
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -26,7 +26,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,19 +49,50 @@ import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 
 @Composable
-fun ChatMessageList(state: ChatUiState, modifier: Modifier = Modifier) {
-    val listState = rememberLazyListState()
+fun ChatMessageList(
+    state: ChatUiState,
+    modifier: Modifier = Modifier,
+    listState: androidx.compose.foundation.lazy.LazyListState = rememberLazyListState(),
+) {
     val lastIndex = state.messages.lastIndex
     // Length of the last (streaming) message: changes on every delta so we follow the stream.
     val tailLen = state.messages.lastOrNull()?.text?.length ?: 0
 
-    // Auto-scroll to the newest content — but only when the user is already pinned near the
+    // On first load of a non-empty thread (opening an existing session), jump straight to the
+    // newest message so the latest reply is visible immediately — otherwise the list stays at
+    // the top and the most recent response looks missing until you scroll down by hand.
+    var landed by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(state.messages.isNotEmpty()) {
+        if (state.messages.isEmpty() || landed) return@LaunchedEffect
+        // History loads after the list is already composed, so wait until the LazyColumn has
+        // actually measured the loaded items before scrolling — jumping before first layout
+        // lands short of the bottom.
+        snapshotFlow { listState.layoutInfo.totalItemsCount }
+            .filter { it >= state.messages.size }
+            .first()
+        // Converge to the true bottom. A single scrollToItem on a freshly-loaded list
+        // undershoots: it can only measure items up to the current extent, and the off-screen
+        // bubbles wrap taller than the estimate. Re-scroll after each frame (which measures
+        // more items) until the last one is actually visible.
+        var guard = 0
+        while (guard++ < 20) {
+            listState.scrollToItem(state.messages.lastIndex)
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+            if (lastVisible >= state.messages.lastIndex) break
+            withFrameNanos {} // let a layout pass run so more items get measured
+        }
+        landed = true
+    }
+
+    // After the initial jump, follow new content. Always follow right after the user sends
+    // (they want to see their message and the reply); otherwise only when already near the
     // bottom, so scrolling back through history isn't yanked away mid-stream.
     LaunchedEffect(state.messages.size, tailLen) {
-        if (lastIndex < 0) return@LaunchedEffect
+        if (lastIndex < 0 || !landed) return@LaunchedEffect
+        val justSent = state.messages.lastOrNull()?.role == Role.USER
         val visible = listState.layoutInfo.visibleItemsInfo
         val atBottom = visible.isEmpty() || (visible.lastOrNull()?.index ?: 0) >= lastIndex - 1
-        if (atBottom) listState.animateScrollToItem(lastIndex)
+        if (justSent || atBottom) listState.animateScrollToItem(lastIndex)
     }
 
     if (state.messages.isEmpty()) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -72,12 +72,12 @@ fun ChatMessageList(
             .filter { it >= state.messages.size }
             .first()
         // Converge to the ABSOLUTE bottom — the end of the newest message, not just the last
-        // item's top. scrollToItem lands on an item's top, and a long last message can be
-        // taller than the viewport, so jump to the last item then keep scrolling until there
-        // is nothing left below (item heights are measured lazily as we go).
-        listState.scrollToItem(state.messages.lastIndex)
+        // item's top. Scroll purely by the list's own "can I still scroll down?" signal rather
+        // than a captured message index (which could go stale if the thread changes mid-loop):
+        // keep scrolling until nothing remains below, letting a frame measure the next items
+        // between steps.
         var guard = 0
-        while (guard++ < 40 && listState.canScrollForward) {
+        while (guard++ < 60 && listState.canScrollForward) {
             listState.scrollBy(100_000f)
             withFrameNanos {} // let a layout pass measure the next items, then continue
         }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
@@ -129,7 +132,14 @@ fun ChatScreen(
         },
         bottomBar = {
             Row(
-                Modifier.fillMaxWidth().navigationBarsPadding().padding(8.dp),
+                // targetSdk 35+ forces edge-to-edge on Android 15+, so the window no
+                // longer resizes for the keyboard — the composer must inset itself.
+                // union() takes max(ime, navBars) so it lifts above the keyboard when
+                // open and clears the nav bar when closed, without double-padding.
+                Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars))
+                    .padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) { Text("＋") }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -50,7 +50,13 @@ fun reduce(state: ChatUiState, event: ServerEvent): ChatUiState {
     return when (event.type) {
         "message.start" -> state.copy(
             messages = state.messages + ChatMessage(
-                id = event.str("message_id") ?: "a-${state.messages.size}",
+                // The gateway's message_id is NOT unique across turns — it sends the
+                // model/agent name (e.g. "gemma"), reused every turn. Used alone as a
+                // LazyColumn key it collides on the second turn and crashes the app, so
+                // prefix the message position (monotonic) to guarantee a unique, stable
+                // id. message_id isn't read anywhere else (deltas/tools route by
+                // indexOfLast / tool_id), so this is the only place it matters.
+                id = "a-${state.messages.size}-${event.str("message_id") ?: "msg"}",
                 role = Role.ASSISTANT, text = "", isStreaming = true,
             ),
             isGenerating = true,

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -5,7 +5,8 @@ import com.hermes.client.domain.ChatMessage
 import com.hermes.client.domain.Role
 import com.hermes.client.domain.ToolCall
 import com.hermes.client.domain.ToolStatus
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
 
 data class ApprovalRequest(val prompt: String)
 data class ClarifyRequest(val question: String, val options: List<String>)
@@ -25,7 +26,16 @@ fun ChatUiState.withUserMessage(text: String): ChatUiState =
         isGenerating = true,
     )
 
-private fun ServerEvent.str(key: String): String? = payload[key]?.jsonPrimitive?.content
+// Reads a payload field as display text. The gateway sends some fields — notably tool
+// results (e.g. a Gmail "read unread" tool returns a JSON object/array of messages) — as
+// structured JSON, not string primitives. Reading those via jsonPrimitive THROWS, and the
+// throw escapes the (uncaught) event collector and crashes the app mid-stream. So unwrap a
+// primitive to its content and render any object/array as its raw JSON text; never throw.
+private fun ServerEvent.str(key: String): String? = when (val el = payload[key]) {
+    null, JsonNull -> null
+    is JsonPrimitive -> el.content
+    else -> el.toString()
+}
 
 /** Pure reducer: folds one server event into the chat state. */
 fun reduce(state: ChatUiState, event: ServerEvent): ChatUiState {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -65,20 +65,26 @@ class ChatViewModel @Inject constructor(
     fun open(id: String) {
         sessionId = id
         connJob?.cancel()
+        com.hermes.client.data.diagnostics.DebugLog.log("session", "open($id)")
         viewModelScope.launch {
             try {
                 val history = sessions.history(id, profileManager.active.value)
+                com.hermes.client.data.diagnostics.DebugLog.log("session", "history($id) → ${history.size} messages")
                 _state.value = ChatUiState(messages = history)
             } catch (e: HermesApiException) {
+                com.hermes.client.data.diagnostics.DebugLog.log("error", "history($id) failed: ${e.code} ${e.message}")
                 if (e.code == 401) { _unauthorized.value = true; return@launch }
                 _state.value = ChatUiState(messages = emptyList())
             } catch (e: Exception) {
                 // History load failed (network/parse) — start with an empty thread rather than crash.
+                com.hermes.client.data.diagnostics.DebugLog.log("error", "history($id) failed: ${e.message}")
                 _state.value = ChatUiState(messages = emptyList())
             }
             // resume() returns the live socket handle for this session; switch to it so
             // submit/interrupt and event filtering use the id the gateway actually knows.
-            runCatching { chat.resume(id) }.getOrNull()?.let { sessionId = it }
+            val handle = runCatching { chat.resume(id) }.getOrNull()
+            handle?.let { sessionId = it }
+            com.hermes.client.data.diagnostics.DebugLog.log("session", "resume($id) → handle=${handle ?: "none"}")
             // Load model options, profiles, and the slash-command catalog; failures are non-fatal
             launch { runCatching { _models.value = modelRepo.options() } }
             launch { runCatching { _profiles.value = profileRepo.list() } }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -194,7 +194,15 @@ class ChatViewModel @Inject constructor(
     }
 
     fun selectModel(provider: String, model: String) {
-        viewModelScope.launch { runCatching { modelRepo.set(provider, model) } }
+        // Switch THIS conversation's model, not the global default. The gateway pins a session
+        // to its own model (model_override); setting only the global model leaves a resumed
+        // session on its original — possibly unavailable — model ("model is not available in
+        // session"), and the error persists no matter how often the picker is used. The
+        // `/model … --session` slash overrides just this session, which is what the user means
+        // by changing the model inside a chat.
+        viewModelScope.launch {
+            runCatching { chat.slashExec(sessionId, "/model $model --provider $provider --session") }
+        }
     }
 
     fun selectProfile(name: String) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -87,7 +87,9 @@ class ChatViewModel @Inject constructor(
         collectJob?.cancel()
         collectJob = viewModelScope.launch {
             chat.events.filter { it.sessionId == null || it.sessionId == sessionId }
-                .onEach { event -> _state.value = reduce(_state.value, event) }
+                // Defense in depth: a single malformed event must never crash the chat.
+                // reduce() is pure, so on a bad event keep the prior state and drop it.
+                .onEach { event -> runCatching { reduce(_state.value, event) }.onSuccess { _state.value = it } }
                 .collect {}
         }
         // C2 + I3: watch connection transitions

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -82,7 +82,9 @@ class ChatViewModel @Inject constructor(
             }
             // resume() returns the live socket handle for this session; switch to it so
             // submit/interrupt and event filtering use the id the gateway actually knows.
-            val handle = runCatching { chat.resume(id) }.getOrNull()
+            // Pass the active profile: the gateway resolves resume against a per-profile DB,
+            // so a session in a non-default profile is "session not found" without it.
+            val handle = runCatching { chat.resume(id, profileManager.active.value) }.getOrNull()
             handle?.let { sessionId = it }
             com.hermes.client.data.diagnostics.DebugLog.log("session", "resume($id) → handle=${handle ?: "none"}")
             // Load model options, profiles, and the slash-command catalog; failures are non-fatal
@@ -111,7 +113,10 @@ class ChatViewModel @Inject constructor(
                 // C2: reconnect cycle completed (Reconnecting → Connected) → re-attach agent stream
                 // Guard: prev must be Reconnecting (not null) to skip the very first Connected transition
                 if (cur is ConnectionState.Connected && prev is ConnectionState.Reconnecting) {
-                    launch { runCatching { chat.resume(sessionId) }.getOrNull()?.let { sessionId = it } }
+                    launch {
+                        runCatching { chat.resume(sessionId, profileManager.active.value) }
+                            .getOrNull()?.let { sessionId = it }
+                    }
                 }
                 prev = cur
             }

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -140,6 +140,9 @@ fun HermesNav(hasConfig: Boolean) {
             composable("settings_memory") { MemorySettingsScreen(onBack = { nav.popBackStack() }) }
             composable("settings_mcp") { McpSettingsScreen(onBack = { nav.popBackStack() }) }
             composable("settings_env") { EnvScreen(onBack = { nav.popBackStack() }) }
+            composable("settings_diagnostics") {
+                com.hermes.client.ui.settings.DiagnosticsScreen(onBack = { nav.popBackStack() })
+            }
             composable("settings_about") { AboutScreen(onBack = { nav.popBackStack() }) }
             composable("management") {
                 ManagementScreen(

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -55,6 +55,14 @@ fun SessionsScreen(
         if (state.unauthorized) onUnauthorized()
     }
 
+    // Re-fetch on every resume — notably when returning from a chat. The "sessions" nav entry
+    // (and its ViewModel) stays alive across navigation, so init() runs only once; without this
+    // a session created or updated while in a chat never appears until a profile switch or app
+    // restart. Mirrors the same ON_RESUME refresh used by CronScreen.
+    androidx.lifecycle.compose.LifecycleEventEffect(androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+        vm.refresh()
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsScreen.kt
@@ -1,0 +1,120 @@
+package com.hermes.client.ui.settings
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hermes.client.data.diagnostics.DebugLog
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DiagnosticsScreen(
+    onBack: () -> Unit,
+    vm: DiagnosticsViewModel = hiltViewModel(),
+) {
+    val enabled by vm.enabled.collectAsStateWithLifecycle()
+    val entries by vm.entries.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Diagnostics") },
+                navigationIcon = { IconButton(onClick = onBack) { Text("←") } },
+            )
+        },
+    ) { padding ->
+        Column(Modifier.padding(padding).fillMaxSize()) {
+            ListItem(
+                headlineContent = { Text("Diagnostic logging") },
+                supportingContent = {
+                    Text("Records network and session activity to diagnose errors like \"message not found\". Off by default; the session token is never logged.")
+                },
+                trailingContent = {
+                    Switch(checked = enabled, onCheckedChange = { vm.setEnabled(it) })
+                },
+            )
+            HorizontalDivider()
+
+            Row(
+                Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = {
+                        val send = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_SUBJECT, "Hermes diagnostic log")
+                            putExtra(Intent.EXTRA_TEXT, vm.export())
+                        }
+                        context.startActivity(Intent.createChooser(send, "Share diagnostic log"))
+                    },
+                ) { Text("Share") }
+                OutlinedButton(onClick = { vm.clear() }) { Text("Clear") }
+            }
+            HorizontalDivider()
+
+            if (entries.isEmpty()) {
+                Text(
+                    if (enabled) "Logging is on. Reproduce the issue and entries will appear here."
+                    else "Turn on Diagnostic logging, then reproduce the issue.",
+                    Modifier.padding(16.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                // Newest first for quick reading.
+                val reversed = entries.asReversed()
+                LazyColumn(Modifier.fillMaxSize()) {
+                    itemsIndexed(reversed, key = { i, _ -> "$i" }) { _, e -> LogRow(e) }
+                }
+            }
+        }
+    }
+}
+
+private val timeFmt = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+
+@Composable
+private fun LogRow(e: DebugLog.LogEntry) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
+        Text(
+            "${timeFmt.format(Date(e.timeMillis))}  ${e.category}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            e.message,
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 6,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsScreen.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.data.diagnostics.DebugLog
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -100,13 +100,14 @@ fun DiagnosticsScreen(
     }
 }
 
-private val timeFmt = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+private val timeFmt =
+    DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(ZoneId.systemDefault())
 
 @Composable
 private fun LogRow(e: DebugLog.LogEntry) {
     Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp)) {
         Text(
-            "${timeFmt.format(Date(e.timeMillis))}  ${e.category}",
+            "${timeFmt.format(Instant.ofEpochMilli(e.timeMillis))}  ${e.category}",
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.primary,
         )

--- a/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsViewModel.kt
@@ -1,0 +1,35 @@
+package com.hermes.client.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.diagnostics.DebugLog
+import com.hermes.client.data.repository.SettingsStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DiagnosticsViewModel @Inject constructor(
+    private val settings: SettingsStore,
+) : ViewModel() {
+
+    val enabled: StateFlow<Boolean> =
+        settings.debugLogging.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** Live diagnostic entries (newest last in the buffer). */
+    val entries: StateFlow<List<DebugLog.LogEntry>> = DebugLog.entries
+
+    fun setEnabled(on: Boolean) {
+        viewModelScope.launch { settings.setDebugLogging(on) }
+        // Apply immediately so capture starts/stops without waiting for the persisted-flow
+        // collector; the app-start collector keeps it in sync across launches.
+        DebugLog.setEnabled(on)
+    }
+
+    fun clear() = DebugLog.clear()
+
+    fun export(): String = DebugLog.export()
+}

--- a/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
@@ -40,6 +40,8 @@ fun SettingsScreen(
             HorizontalDivider()
             Entry("API keys & env", "Provider keys and tool env vars") { onNavigate("settings_env") }
             HorizontalDivider()
+            Entry("Diagnostics", "Capture a shareable debug log to troubleshoot errors") { onNavigate("settings_diagnostics") }
+            HorizontalDivider()
             Entry("About", "App and gateway version") { onNavigate("settings_about") }
         }
     }

--- a/app/src/test/java/com/hermes/client/data/diagnostics/DebugLogTest.kt
+++ b/app/src/test/java/com/hermes/client/data/diagnostics/DebugLogTest.kt
@@ -1,0 +1,77 @@
+package com.hermes.client.data.diagnostics
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DebugLogTest {
+    @Before fun setUp() {
+        DebugLog.setTokenToRedact(null)
+        DebugLog.setEnabled(true)
+        DebugLog.clear()
+    }
+
+    @After fun tearDown() {
+        DebugLog.setEnabled(false)
+        DebugLog.setTokenToRedact(null)
+        DebugLog.clear()
+    }
+
+    @Test fun disabled_log_is_a_noop() {
+        DebugLog.clear()
+        DebugLog.setEnabled(false)
+        DebugLog.log("ws", "should not be recorded")
+        assertTrue("disabled logging must record nothing", DebugLog.entries.value.isEmpty())
+    }
+
+    @Test fun enabled_log_is_recorded_with_category_and_message() {
+        DebugLog.log("session", "open(s1)")
+        val e = DebugLog.entries.value
+        assertEquals(1, e.size)
+        assertEquals("session", e.first().category)
+        assertEquals("open(s1)", e.first().message)
+    }
+
+    @Test fun ring_buffer_caps_at_max() {
+        repeat(DebugLog.MAX_ENTRIES + 50) { DebugLog.log("ws", "line $it") }
+        val e = DebugLog.entries.value
+        assertEquals(DebugLog.MAX_ENTRIES, e.size)
+        // Oldest entries are evicted; the newest must be retained.
+        assertEquals("line ${DebugLog.MAX_ENTRIES + 49}", e.last().message)
+    }
+
+    @Test fun registered_token_is_redacted() {
+        DebugLog.setTokenToRedact("SECRET-TOKEN-123")
+        DebugLog.log("rest", "GET /api/sessions  token=SECRET-TOKEN-123 end")
+        val msg = DebugLog.entries.value.single().message
+        assertFalse("raw token must not appear", msg.contains("SECRET-TOKEN-123"))
+        assertTrue("token must be masked", msg.contains("***"))
+    }
+
+    @Test fun blank_token_does_not_redact_everything() {
+        DebugLog.setTokenToRedact("")
+        DebugLog.log("rest", "GET /api/status")
+        assertEquals("GET /api/status", DebugLog.entries.value.single().message)
+    }
+
+    @Test fun clear_empties_the_buffer() {
+        DebugLog.log("ws", "a")
+        DebugLog.log("ws", "b")
+        DebugLog.clear()
+        assertTrue(DebugLog.entries.value.isEmpty())
+    }
+
+    @Test fun export_contains_category_and_messages_in_order() {
+        DebugLog.log("session", "open(s1)")
+        DebugLog.log("error", "message not found")
+        val text = DebugLog.export()
+        assertTrue(text.contains("session"))
+        assertTrue(text.contains("open(s1)"))
+        assertTrue(text.contains("message not found"))
+        // newest-last ordering
+        assertTrue(text.indexOf("open(s1)") < text.indexOf("message not found"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
@@ -39,6 +39,23 @@ class ChatReducerTest {
         assertEquals("found", tools[0].output)
     }
 
+    // Crash repro: the gateway reuses message_id across turns (it sends the
+    // model/agent name, e.g. "gemma"). Two distinct assistant turns must still get
+    // distinct message ids — otherwise the chat LazyColumn key collides and the app
+    // crashes with IllegalArgumentException: Key "gemma" was already used.
+    @Test fun reused_message_id_across_turns_yields_unique_ids() {
+        var s = ChatUiState.empty()
+        s = s.withUserMessage("hi")
+        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
+        s = reduce(s, ev("message.complete") { put("text", "hello") })
+        s = s.withUserMessage("again")
+        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
+        s = reduce(s, ev("message.complete") { put("text", "hi again") })
+
+        val ids = s.messages.map { it.id }
+        assertEquals("every message must have a unique list key", ids.size, ids.toSet().size)
+    }
+
     @Test fun approval_request_sets_pending() {
         var s = ChatUiState.empty()
         s = reduce(s, ev("approval.request") { put("prompt", "Run rm -rf?") })

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
@@ -3,8 +3,11 @@ package com.hermes.client.ui.chat
 import com.hermes.client.data.network.ServerEvent
 import com.hermes.client.domain.Role
 import com.hermes.client.domain.ToolStatus
+import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -54,6 +57,44 @@ class ChatReducerTest {
 
         val ids = s.messages.map { it.id }
         assertEquals("every message must have a unique list key", ids.size, ids.toSet().size)
+    }
+
+    // Crash repro: a tool's result is frequently structured JSON, not a string — e.g. the
+    // "summarize my unread email" flow calls a Gmail tool that returns an object/array of
+    // messages. reduce() reads payload.result via jsonPrimitive, which THROWS on a
+    // JsonObject/JsonArray. The throw escapes the (uncaught) event collector and crashes
+    // the app mid-stream, exactly when "synthesizing" finishes. Must never throw; the
+    // structured result should survive as text on the tool card.
+    @Test fun tool_complete_with_object_result_does_not_crash() {
+        var s = ChatUiState.empty()
+        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
+        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.search") })
+        s = reduce(s, ev("tool.complete") {
+            put("tool_id", "t1")
+            putJsonObject("result") { put("unread", 3); put("subject", "Citizenship update") }
+        })
+        val tools = s.messages.last().tools
+        assertEquals(ToolStatus.DONE, tools[0].status)
+        assertTrue("structured result must be preserved as text", tools[0].output.contains("unread"))
+    }
+
+    @Test fun tool_complete_with_array_result_does_not_crash() {
+        var s = ChatUiState.empty()
+        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
+        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.list") })
+        s = reduce(s, ev("tool.complete") {
+            put("tool_id", "t1")
+            putJsonArray("result") { add("a@x.com"); add("b@y.com") }
+        })
+        assertEquals(ToolStatus.DONE, s.messages.last().tools[0].status)
+    }
+
+    // The same non-primitive hazard applies to message text fields, not just tool results.
+    @Test fun message_complete_with_object_text_does_not_crash() {
+        var s = ChatUiState.empty()
+        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
+        s = reduce(s, ev("message.complete") { putJsonObject("text") { put("v", "hi") } })
+        assertFalse(s.isGenerating)
     }
 
     @Test fun approval_request_sets_pending() {

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -141,7 +141,10 @@ class ChatViewModelTest {
         coVerify(exactly = 1) { chatRepo.resume("s1", null) }
     }
 
-    @Test fun selectModel_calls_modelRepo_set() = runTest {
+    // Changing the model inside a chat must switch THIS session's model (a `/model … --session`
+    // slash), not the global default — otherwise a session pinned to an unavailable model keeps
+    // failing with "model is not available in session" no matter how often the picker is used.
+    @Test fun selectModel_switches_session_model_via_slash() = runTest {
         val vm = buildVm()
         vm.open("s1")
         advanceUntilIdle()
@@ -149,7 +152,7 @@ class ChatViewModelTest {
         vm.selectModel("anthropic", "opus")
         advanceUntilIdle()
 
-        coVerify { modelRepo.set("anthropic", "opus") }
+        coVerify { chatRepo.slashExec("s1", "/model opus --provider anthropic --session") }
     }
 
     @Test fun selectProfile_calls_profileRepo_setActive() = runTest {

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -45,7 +45,7 @@ class ChatViewModelTest {
         every { chatRepo.connectionState } returns connectionStateFlow
         // resume returns null here so the ViewModel keeps the opened id stable for these tests
         // (production switches to the live handle resume returns).
-        coEvery { chatRepo.resume(any()) } returns null
+        coEvery { chatRepo.resume(any(), any()) } returns null
         every { profileManager.active } returns MutableStateFlow<String?>(null)
         coEvery { sessionRepo.history(any(), any()) } returns emptyList()
         coEvery { modelRepo.options() } returns emptyList()
@@ -84,7 +84,21 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         // resume must have been called exactly twice: once in open(), once on reconnect
-        coVerify(exactly = 2) { chatRepo.resume("s1") }
+        coVerify(exactly = 2) { chatRepo.resume("s1", null) }
+    }
+
+    /**
+     * Profile bug: session-scoped WebSocket RPCs must carry the active profile, or the gateway
+     * resolves session.resume against the wrong profile's DB and returns "session not found"
+     * (4007) — which then makes the next prompt.submit fail too. open() must pass the active
+     * profile to resume so a session that lives in a non-default profile can be reattached.
+     */
+    @Test fun open_resumes_with_active_profile() = runTest {
+        every { profileManager.active } returns MutableStateFlow<String?>("personal")
+        val vm = buildVm()
+        vm.open("s1")
+        advanceUntilIdle()
+        coVerify { chatRepo.resume("s1", "personal") }
     }
 
     /**
@@ -124,7 +138,7 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         // Only one resume from open(); the Connected transition had prev==Connecting (not Reconnecting)
-        coVerify(exactly = 1) { chatRepo.resume("s1") }
+        coVerify(exactly = 1) { chatRepo.resume("s1", null) }
     }
 
     @Test fun selectModel_calls_modelRepo_set() = runTest {

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -1,0 +1,63 @@
+package com.hermes.client.ui.sessions
+
+import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.data.repository.PinStore
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.domain.Session
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionsViewModelTest {
+    private val sessionRepo = mockk<SessionRepository>(relaxed = true)
+    private val chatRepo = mockk<ChatRepository>(relaxed = true)
+    private val profileManager = mockk<ProfileManager>(relaxed = true)
+    private val pinStore = mockk<PinStore>(relaxed = true)
+
+    @Before fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        every { profileManager.active } returns MutableStateFlow<String?>("personal")
+        every { pinStore.pinned } returns MutableStateFlow<Set<String>>(emptySet())
+    }
+
+    private fun session(id: String, title: String) = Session(
+        id = id, title = title, model = null, provider = null,
+        messageCount = 1, profile = "personal", workspace = "No workspace", source = "hermes-dispatch",
+    )
+
+    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore)
+
+    // Regression: a session created or updated while the user was in a chat must appear once
+    // the list is re-fetched. The Sessions screen calls refresh() on ON_RESUME (the "sessions"
+    // ViewModel is not recreated when navigating back, so init runs only once). This proves
+    // refresh() re-queries the repository and surfaces the newly-added session — the mechanism
+    // the resume hook relies on. Without that hook, the user's just-run session never shows.
+    @Test fun refresh_resurfaces_newly_added_session() = runTest {
+        coEvery { sessionRepo.list(any()) } returns listOf(session("s1", "old"))
+        val vm = buildVm()
+        advanceUntilIdle()
+        assertEquals(listOf("s1"), vm.state.value.sessions.map { it.id })
+
+        // A new session now exists on the gateway, as if a prompt created one while in a chat.
+        coEvery { sessionRepo.list(any()) } returns listOf(session("s2", "new"), session("s1", "old"))
+        vm.refresh()
+        advanceUntilIdle()
+
+        val ids = vm.state.value.sessions.map { it.id }
+        assertTrue("refresh must surface the newly-added session", ids.contains("s2"))
+        assertEquals(2, ids.size)
+    }
+}

--- a/docs/superpowers/specs/2026-06-22-debug-logging-toggle-design.md
+++ b/docs/superpowers/specs/2026-06-22-debug-logging-toggle-design.md
@@ -1,0 +1,70 @@
+# Debug Logging Toggle — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (key decisions confirmed with user)
+
+## Problem
+
+Users hit transient/unexplained errors in the app — notably **"message not found"** when
+opening a session from the side menu — that we can't reproduce or diagnose after the fact.
+There is currently **no logging in the app at all** (zero `Log`/Timber calls). We need a way
+for a user to capture exactly what the app sent/received around a failure and share it,
+without needing a computer or `adb`.
+
+"message not found" is not a string in our source; it is a **gateway-emitted error**. The
+REST history fetch on session-open is swallowed to an empty thread, so the visible error
+arrives over the **WebSocket** — most likely the reducer's `"error"` event branch rendering
+`event.str("message")`, or an `RpcErrorReply` to `session.resume`. The log must capture the
+WS RPC/event sequence to confirm which.
+
+## Goals
+
+- A user-toggleable diagnostic log, **off by default**, zero overhead when off.
+- When on, capture enough to explain failures like "message not found".
+- Viewable and shareable **on the device** (no adb).
+- Never leak the session token.
+
+## Non-goals
+
+- Persistent log history across app kills (in-memory ring buffer only).
+- Remote/automatic crash reporting.
+- Logging full user message content (we log structure/metadata, not bodies).
+
+## Design
+
+### Core facility — `DebugLog`
+A process-wide Kotlin `object` (callable from non-DI code like the WS listener).
+
+- `@Volatile var` enabled flag; `log(category, message)` is a cheap no-op when disabled.
+- In-memory ring buffer (cap **500** entries), guarded by a lock.
+- `entries: StateFlow<List<LogEntry>>` for the live in-app view.
+- Mirrors each entry to `android.util.Log` under tag `HermesDebug`.
+- `LogEntry(timeMillis, category, message)`; categories: `ws`, `rest`, `session`, `error`.
+- Token redaction: a registered token string is masked (`***`) in any logged message.
+- `clear()` and `export(): String` (formatted, newest-last) for Share.
+
+### Persistence + sync
+- `SettingsStore` gains `debugLogging: Flow<Boolean>` (default false) + `setDebugLogging`.
+- `HermesApp.onCreate` collects `debugLogging` → `DebugLog.setEnabled(...)`, so logging is
+  active at launch (before the Diagnostics screen is opened).
+- `AppModule` registers the configured session token with `DebugLog` for redaction.
+
+### Capture points (only meaningful when enabled)
+- **`HermesGatewayClient`**: socket open/close/failure; each `call(method)`; `RpcResult` /
+  `RpcErrorReply` (id, code, message); `gateway.ready`; and **error events**.
+- **`HermesRestApi`**: request `METHOD /path` (no token) + response code; error body.
+- **`ChatViewModel.open`**: `open(id)`, `resume → handle`, and caught exceptions.
+
+### UI — Settings → Diagnostics
+- New `SettingsScreen` entry "Diagnostics" → route `settings_diagnostics`.
+- `DiagnosticsScreen` + `DiagnosticsViewModel`: a `Switch` bound to `debugLogging`, a
+  **Clear** button, a **Share** button (`ACTION_SEND` of `DebugLog.export()`), and a
+  reverse-chronological live list of entries.
+
+## Testing
+- `DebugLog` unit tests: no-op when disabled; ring-buffer cap; token redaction; `clear`;
+  `export` format; `entries` emits when enabled.
+
+## Decisions (confirmed)
+- **Log access:** in-app Diagnostics screen + Share.
+- **Capture scope:** everything (WS + REST + session lifecycle + errors), token-redacted.


### PR DESCRIPTION
Promotes the accumulated develop fixes to the first stable release since v0.1.0.

## Fixes
- Chat crash on second turn + composer hidden by the keyboard (edge-to-edge IME insets).
- Chat crash from duplicate LazyColumn keys in loaded history.
- Chat crash when a tool returns a structured JSON result (reducer read non-primitive via jsonPrimitive).
- Session list now refreshes on resume, so newly created/updated sessions appear.
- session.resume now carries the active profile, fixing "session not found" for sessions in a non-default profile.
- Opening a session now lands on the newest message (and follows new replies) instead of starting at the top.

## Feature
- In-app diagnostic logging toggle (Settings → Diagnostics): off by default, token-redacted, with Share — used to root-cause the resume bug.

## Notes
- Unit + instrumented tests added for each fix; full suite green.
- Open HIGH Dependabot alerts are all build-classpath (AGP/Gradle) transitive deps and do not ship in the APK.