### PR TITLE
Release v0.1.12 — archived sessions, search, server/token settings, basic-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ on your phone:
 1. On your Android phone, open the release link above and tap the `.apk` file to download it.
 2. When prompted, allow installs from your browser or Files app ("Install unknown apps").
 3. Open the downloaded `.apk` and tap **Install**.
-4. Launch **Hermes** and complete the one-time [setup](#first-run-setup) (gateway URL + token).
+4. Launch **Hermes** and complete the one-time [setup](#first-run-setup) — gateway URL plus
+   either a session token (loopback) or a username/password (password-protected dashboard).
 
 > The APK is signed with the project's release key. Because it's installed outside the
 > Play Store, Android may warn about an app from an unknown developer — that's expected.
@@ -48,7 +49,9 @@ on your phone:
 - **Chat** — streaming responses, model picker, slash commands (`/…`) with an inline
   command palette, `@` file mentions/path completion, image attachments, tool-call
   approval and clarification prompts.
-- **Sessions** — grouped by workspace, with pinning and a session-admin view.
+- **Sessions** — grouped by workspace, with **search** (instant title filter + gateway
+  message-content search), pinning, **archive / unarchive / delete** (an Archived view from
+  the Sessions top bar), and a session-admin view. Opening a session lands on the newest reply.
 - **Models & profiles** — switch the active model or tenant profile on the fly; the active
   profile is shown in the chat top bar.
 - **Cron** — list, create, edit, pause/resume, run-now, and delete scheduled jobs, with
@@ -56,8 +59,10 @@ on your phone:
 - **Usage** — daily token chart and per-model breakdown.
 - **Messaging** — enable/disable platform integrations with a guided setup flow for the
   required credentials.
-- **Settings** — appearance (System/Light/Dark + tool-call verbosity), memory, MCP
-  servers, and API keys/environment variables. Configuration edits are written to the
+- **Settings** — **Server & token** (edit the gateway URL and token, or username/password for
+  a password-protected dashboard, then reconnect), appearance (System/Light/Dark + tool-call
+  verbosity), memory, MCP servers, API keys/environment variables, and **Diagnostics** (a
+  toggleable, token-redacted, shareable debug log). Configuration edits are written to the
   live gateway config.
 - **Reliability** — automatic reconnect with offline banner and manual retry; expired
   tokens route back to the setup screen.
@@ -71,8 +76,8 @@ on your phone:
 | UI | Jetpack Compose + Material 3, `ModalNavigationDrawer` wrapping a Navigation-Compose `NavHost` |
 | State | MVVM — `ViewModel` + `StateFlow`, `collectAsStateWithLifecycle` |
 | DI | Hilt |
-| Networking | OkHttp — REST over HTTP and a WebSocket JSON-RPC stream to the gateway |
-| Local storage | DataStore (device-local prefs: token, theme, tool-call display) |
+| Networking | OkHttp — REST + a WebSocket JSON-RPC stream to the gateway. Auth is either the loopback session token, or (gated dashboard) a cookie-jar session with 401 re-login and per-socket WS tickets |
+| Local storage | EncryptedSharedPreferences (credentials: URL, token, username/password); DataStore (theme, tool-call display, diagnostics toggle) |
 
 Package layout under `app/src/main/java/com/hermes/client/`:
 
@@ -97,7 +102,8 @@ vector in `app/src/main/res/drawable/`.
 
 - Android Studio (bundled JBR / JDK 21)
 - Android SDK with `compileSdk` 36 / build-tools 36.x
-- A reachable Hermes gateway and a session token
+- A reachable Hermes gateway and credentials (a session token, or username/password for a
+  password-protected dashboard)
 
 Toolchain is pinned in `gradle/libs.versions.toml`: AGP 8.13.2, Kotlin 2.2.21,
 Gradle 8.14.5. `minSdk` 26, `targetSdk` 36.
@@ -155,30 +161,46 @@ adb install -r app/build/outputs/apk/release/app-release.apk
 
 ## First-run setup
 
-On first launch the app shows a **Setup** screen with two fields:
+On first launch the app shows a **Setup** screen. You can change any of these later from
+**Settings → Server & token** (URL, token, or username/password), then **Save & reconnect**.
 
-1. **Gateway URL** — where your Hermes gateway is reachable from the phone, e.g.
+1. **Gateway URL** — where your Hermes dashboard is reachable from the phone, e.g.
    `http://100.x.x.x:9119` (its Tailscale address) or `http://192.168.x.x:9119` on the
    same Wi-Fi. See [Connecting](#connecting) below.
-2. **Session token** — sent to the gateway as the `X-Hermes-Session-Token` header.
+2. **Auth** — depends on how the dashboard is bound:
+   - **Token mode** — a dashboard bound to **loopback** (`--host 127.0.0.1`) accepts the
+     **session token** (sent as `X-Hermes-Session-Token`). Leave username/password blank.
+     See [Getting your token](#getting-your-hermes-token).
+   - **Password mode (gated)** — a dashboard bound to a **network address** (e.g. its
+     Tailscale IP) refuses the loopback token and requires an auth provider, so set
+     **Username + Password**. The app logs in (`POST /auth/password-login`), holds the
+     rotating session cookie, and mints a per-connection WebSocket ticket automatically.
+     Leave the token blank.
 
-Credentials are stored locally on the device (DataStore). An expired/invalid token
-(HTTP 401) routes you back to Setup automatically.
+Credentials are stored **encrypted** on the device. On an expired/invalid session (HTTP 401)
+the app re-authenticates automatically in password mode, or routes back to Setup in token mode.
 
 ### Getting your Hermes token
 
-The app authenticates to the gateway with its **dashboard session token**. By default the
-gateway mints a *new random token every time it starts*, which is awkward to copy. To get a
-**stable** token you can paste into the app, set it yourself before starting the Hermes
-dashboard / gateway:
+For a **loopback** dashboard, the app authenticates with the **dashboard session token**. By
+default the gateway mints a *new random token every time it starts*, which is awkward to copy.
+For a **stable** token, set it yourself before starting the dashboard:
 
 ```bash
 export HERMES_DASHBOARD_SESSION_TOKEN="choose-a-long-random-string"
 # then start the Hermes dashboard / web gateway as usual
 ```
 
-Use that same value as the **Session token** in the app's Setup screen. Treat it like a
-password — anyone with the token and network access to the gateway can drive your agent.
+Use that value as the **Token** in Setup. Treat it like a password — anyone with the token
+and network access to the gateway can drive your agent.
+
+### Password-protected (network-bound) dashboard
+
+Recent Hermes refuses to expose the dashboard on a non-loopback address without a configured
+auth provider. Enable the **basic-auth** provider in `~/.hermes/config.yaml`
+(`dashboard.basic_auth.username` + `password_hash`), bind the dashboard to your private
+address, then enter that username/password in the app. The app handles the cookie/refresh and
+WebSocket-ticket flow for you.
 
 📖 Full Hermes installation, gateway, and token docs:
 **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 9
-        versionName = "0.1.8"
+        versionCode = 10
+        versionName = "0.1.9"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 12
-        versionName = "0.1.11"
+        versionCode = 13
+        versionName = "0.1.12"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 10
-        versionName = "0.1.9"
+        versionCode = 11
+        versionName = "0.1.10"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 11
-        versionName = "0.1.10"
+        versionCode = 12
+        versionName = "0.1.11"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/data/auth/CredentialStore.kt
+++ b/app/src/main/java/com/hermes/client/data/auth/CredentialStore.kt
@@ -1,17 +1,29 @@
 package com.hermes.client.data.auth
 
-data class GatewayConfig(val baseUrl: String, val token: String) {
-    /**
-     * Derived WebSocket URL, e.g. http://host:9119 -> ws://host:9119/api/ws?token=...
-     * The token query param is omitted when no token is configured (gateways that
-     * don't enforce a session token, e.g. trusted tailnet setups).
-     */
-    val wsUrl: String
+data class GatewayConfig(
+    val baseUrl: String,
+    val token: String = "",
+    // Set for a network-exposed (gated) dashboard that requires a password provider. When a
+    // username is present the app authenticates via POST /auth/password-login (session cookies)
+    // plus a per-socket WS ticket, instead of the loopback session token.
+    val username: String = "",
+    val password: String = "",
+) {
+    /** True when this targets a gated dashboard (basic-auth); false for a loopback/token setup. */
+    val isGated: Boolean get() = username.isNotBlank()
+
+    /** Base WS endpoint with no auth query — the auth param (?token / ?ticket) is appended later. */
+    val wsBase: String
         get() {
             val ws = baseUrl.replaceFirst("https://", "wss://").replaceFirst("http://", "ws://")
-            val base = "${ws.trimEnd('/')}/api/ws"
-            return if (token.isBlank()) base else "$base?token=$token"
+            return "${ws.trimEnd('/')}/api/ws"
         }
+
+    /**
+     * Loopback WS URL using the session token, e.g. ws://host:9119/api/ws?token=...
+     * Only used in non-gated mode; gated mode appends a per-connect ?ticket= instead.
+     */
+    val wsUrl: String get() = if (token.isBlank()) wsBase else "$wsBase?token=$token"
 }
 
 interface CredentialStore {

--- a/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
+++ b/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
@@ -23,14 +23,20 @@ class EncryptedCredentialStore(context: Context) : CredentialStore {
 
     override fun load(): GatewayConfig? {
         val url = prefs.getString("base_url", null) ?: return null
-        val token = prefs.getString("token", null) ?: return null
-        return GatewayConfig(url, token)
+        return GatewayConfig(
+            baseUrl = url,
+            token = prefs.getString("token", null) ?: "",
+            username = prefs.getString("username", null) ?: "",
+            password = prefs.getString("password", null) ?: "",
+        )
     }
 
     override fun save(config: GatewayConfig) {
         prefs.edit()
             .putString("base_url", config.baseUrl)
             .putString("token", config.token)
+            .putString("username", config.username)
+            .putString("password", config.password)
             .apply()
     }
 

--- a/app/src/main/java/com/hermes/client/data/network/GatedAuth.kt
+++ b/app/src/main/java/com/hermes/client/data/network/GatedAuth.kt
@@ -1,0 +1,139 @@
+package com.hermes.client.data.network
+
+import com.hermes.client.data.auth.GatewayConfig
+import com.hermes.client.data.diagnostics.DebugLog
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import okhttp3.Authenticator
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.Route
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory cookie store for the gated dashboard's session cookies
+ * (`hermes_session_at` / `hermes_session_rt`). The dashboard rotates the access cookie on
+ * refresh by sending a new Set-Cookie, so we key by name and overwrite — the jar then carries
+ * whatever the server most recently issued. Cleared on logout / config change; a fresh login
+ * after an app restart repopulates it.
+ */
+class InMemoryCookieJar : CookieJar {
+    private val byHost = ConcurrentHashMap<String, ConcurrentHashMap<String, Cookie>>()
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        val jar = byHost.getOrPut(url.host) { ConcurrentHashMap() }
+        for (c in cookies) jar[c.name] = c
+    }
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val jar = byHost[url.host] ?: return emptyList()
+        val now = System.currentTimeMillis()
+        return jar.values.filter { it.expiresAt > now }
+    }
+
+    fun clear() = byHost.clear()
+}
+
+/**
+ * Authenticates against a gated (basic-auth) Hermes dashboard: POST /auth/password-login to mint
+ * session cookies, and POST /api/auth/ws-ticket for a single-use WebSocket ticket. REST requests
+ * then authenticate transparently via [cookieJar] on the shared OkHttp client.
+ */
+class GatedAuth(
+    private val json: Json,
+    private val configProvider: () -> GatewayConfig?,
+) {
+    val cookieJar = InMemoryCookieJar()
+
+    // A bare client (NO authenticator → no re-auth recursion) that shares the cookie jar so the
+    // login response's Set-Cookie lands where authenticated requests will read it.
+    private val loginClient by lazy { OkHttpClient.Builder().cookieJar(cookieJar).build() }
+
+    /** Log in with the stored username/password; session cookies land in [cookieJar]. */
+    fun login(): Boolean {
+        val cfg = configProvider() ?: return false
+        if (cfg.username.isBlank()) return false
+        val payload: JsonObject = buildJsonObject {
+            put("provider", "basic")
+            put("username", cfg.username)
+            put("password", cfg.password)
+        }
+        val req = Request.Builder()
+            .url("${cfg.baseUrl.trimEnd('/')}/auth/password-login")
+            .post(json.encodeToString(JsonObject.serializer(), payload).toRequestBody(JSON_MEDIA))
+            .build()
+        val ok = runCatching { loginClient.newCall(req).execute().use { it.isSuccessful } }
+            .getOrDefault(false)
+        DebugLog.log("ws", "gated login -> $ok")
+        return ok
+    }
+
+    /**
+     * Mint a single-use (30s) WS ticket. [client] must carry the cookie jar + authenticator so a
+     * missing session is recovered (401 → login → retry) before the ticket is issued.
+     */
+    fun wsTicket(client: OkHttpClient): String? {
+        val cfg = configProvider() ?: return null
+        val req = Request.Builder()
+            .url("${cfg.baseUrl.trimEnd('/')}/api/auth/ws-ticket")
+            .post(ByteArray(0).toRequestBody(null))
+            .build()
+        return runCatching {
+            client.newCall(req).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                val body = resp.body?.string().orEmpty()
+                json.parseToJsonElement(body).jsonObject["ticket"]?.jsonPrimitive?.content
+            }
+        }.getOrNull()
+    }
+
+    /**
+     * One-off login probe with explicit values for the setup "Test" button — uses a throwaway
+     * client so it neither persists creds nor disturbs the live session cookies.
+     */
+    fun probeLogin(baseUrl: String, username: String, password: String): Boolean {
+        val payload: JsonObject = buildJsonObject {
+            put("provider", "basic")
+            put("username", username)
+            put("password", password)
+        }
+        val req = Request.Builder()
+            .url("${baseUrl.trimEnd('/')}/auth/password-login")
+            .post(json.encodeToString(JsonObject.serializer(), payload).toRequestBody(JSON_MEDIA))
+            .build()
+        return runCatching {
+            OkHttpClient().newCall(req).execute().use { it.isSuccessful }
+        }.getOrDefault(false)
+    }
+
+    private companion object {
+        val JSON_MEDIA = "application/json".toMediaType()
+    }
+}
+
+/**
+ * On a 401 from the gated dashboard, log in once and retry the request — the cookie jar re-applies
+ * the freshly minted session cookies. A marker header prevents an infinite re-auth loop if the
+ * retry still fails (e.g. wrong password).
+ */
+class GatedAuthenticator(private val auth: GatedAuth) : Authenticator {
+    override fun authenticate(route: Route?, response: Response): Request? {
+        if (response.request.header(RETRY_MARKER) != null) return null
+        if (!auth.login()) return null
+        return response.request.newBuilder().header(RETRY_MARKER, "1").build()
+    }
+
+    private companion object {
+        const val RETRY_MARKER = "X-Hermes-Reauth"
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/network/GatedAuth.kt
+++ b/app/src/main/java/com/hermes/client/data/network/GatedAuth.kt
@@ -38,7 +38,8 @@ class InMemoryCookieJar : CookieJar {
     override fun loadForRequest(url: HttpUrl): List<Cookie> {
         val jar = byHost[url.host] ?: return emptyList()
         val now = System.currentTimeMillis()
-        return jar.values.filter { it.expiresAt > now }
+        // matches() enforces path/secure/domain rules; expiry guards rotated-out cookies.
+        return jar.values.filter { it.matches(url) && it.expiresAt > now }
     }
 
     fun clear() = byHost.clear()

--- a/app/src/main/java/com/hermes/client/data/network/HermesGatewayClient.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesGatewayClient.kt
@@ -42,7 +42,9 @@ open class HermesGatewayClient(
     private val json: Json,
     private val scope: CoroutineScope,
     private val backoff: BackoffPolicy = BackoffPolicy(),
-    private val wsUrlProvider: () -> String,
+    // suspend so gated mode can fetch a fresh single-use WS ticket (an HTTP round trip) before
+    // each connect; loopback mode returns immediately.
+    private val wsUrlProvider: suspend () -> String,
 ) {
     private val _events = MutableSharedFlow<ServerEvent>(extraBufferCapacity = 256)
     val events: SharedFlow<ServerEvent> = _events.asSharedFlow()
@@ -81,8 +83,21 @@ open class HermesGatewayClient(
         // Install a fresh, uncompleted readiness gate for this new socket attempt.
         readyGate = CompletableDeferred()
         _state.value = ConnectionState.Connecting
-        val request = Request.Builder().url(wsUrlProvider()).build()
-        ws = okHttp.newWebSocket(request, makeListener(gen))
+        // Resolve the URL off the calling thread: gated mode mints a WS ticket (HTTP) here. A
+        // failure (e.g. login/ticket error) routes through onSocketClosed so backoff retries.
+        scope.launch {
+            val url = try {
+                wsUrlProvider()
+            } catch (e: Exception) {
+                DebugLog.log("ws", "ws url/ticket failed (gen=$gen): ${e.message}")
+                onSocketClosed(gen, e.message ?: "ws url failed")
+                return@launch
+            }
+            // A newer socket may have superseded this one while we fetched the ticket.
+            if (gen != generation.get()) return@launch
+            val request = Request.Builder().url(url).build()
+            ws = okHttp.newWebSocket(request, makeListener(gen))
+        }
     }
 
     /**

--- a/app/src/main/java/com/hermes/client/data/network/HermesGatewayClient.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesGatewayClient.kt
@@ -93,8 +93,9 @@ open class HermesGatewayClient(
                 onSocketClosed(gen, e.message ?: "ws url failed")
                 return@launch
             }
-            // A newer socket may have superseded this one while we fetched the ticket.
-            if (gen != generation.get()) return@launch
+            // A newer socket may have superseded this one — or the client was closed — while we
+            // fetched the ticket. Either way, don't open a now-orphaned socket.
+            if (gen != generation.get() || manuallyClosed) return@launch
             val request = Request.Builder().url(url).build()
             ws = okHttp.newWebSocket(request, makeListener(gen))
         }

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -3,6 +3,8 @@ package com.hermes.client.di
 import android.content.Context
 import com.hermes.client.data.auth.CredentialStore
 import com.hermes.client.data.auth.EncryptedCredentialStore
+import com.hermes.client.data.network.GatedAuth
+import com.hermes.client.data.network.GatedAuthenticator
 import com.hermes.client.data.network.HermesGatewayClient
 import com.hermes.client.data.network.HermesRestApi
 import com.hermes.client.data.repository.ChatRepository
@@ -18,6 +20,7 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -36,9 +39,19 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+    fun provideGatedAuth(json: Json, store: CredentialStore): GatedAuth =
+        GatedAuth(json) { store.load() }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(gatedAuth: GatedAuth): OkHttpClient = OkHttpClient.Builder()
         .pingInterval(20, TimeUnit.SECONDS)
         .readTimeout(0, TimeUnit.SECONDS)
+        // Gated-dashboard auth: the cookie jar carries the session cookies on every REST call,
+        // and the authenticator re-logs-in and retries on a 401. In loopback/token mode the jar
+        // stays empty and the authenticator is a no-op (no username configured).
+        .cookieJar(gatedAuth.cookieJar)
+        .authenticator(GatedAuthenticator(gatedAuth))
         .build()
 
     @Provides
@@ -57,11 +70,24 @@ object AppModule {
         json: Json,
         scope: CoroutineScope,
         store: CredentialStore,
+        gatedAuth: GatedAuth,
     ): HermesGatewayClient = HermesGatewayClient(
         okHttp = okHttp,
         json = json,
         scope = scope,
-        wsUrlProvider = { store.load()?.wsUrl ?: error("no gateway configured") },
+        // Gated mode mints a fresh single-use WS ticket per connect; loopback mode appends the
+        // session token. The ticket POST goes through the authenticated client, so a missing
+        // session is recovered (401 → login → retry) before the socket opens.
+        wsUrlProvider = {
+            val cfg = store.load() ?: error("no gateway configured")
+            if (cfg.isGated) {
+                val ticket = withContext(Dispatchers.IO) { gatedAuth.wsTicket(okHttp) }
+                    ?: error("ws ticket unavailable")
+                "${cfg.wsBase}?ticket=$ticket"
+            } else {
+                cfg.wsUrl
+            }
+        },
     )
 
     @Provides

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -148,6 +148,9 @@ fun HermesNav(hasConfig: Boolean) {
             composable("settings_memory") { MemorySettingsScreen(onBack = { nav.popBackStack() }) }
             composable("settings_mcp") { McpSettingsScreen(onBack = { nav.popBackStack() }) }
             composable("settings_env") { EnvScreen(onBack = { nav.popBackStack() }) }
+            composable("settings_connection") {
+                com.hermes.client.ui.settings.ConnectionSettingsScreen(onBack = { nav.popBackStack() })
+            }
             composable("settings_diagnostics") {
                 com.hermes.client.ui.settings.DiagnosticsScreen(onBack = { nav.popBackStack() })
             }

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -84,6 +84,14 @@ fun HermesNav(hasConfig: Boolean) {
                 SessionsScreen(
                     onOpen = { id -> nav.navigate("chat/$id") },
                     onMenu = openDrawer,
+                    onOpenArchived = { nav.navigate("archived") },
+                    onUnauthorized = onUnauthorized,
+                )
+            }
+            composable("archived") {
+                com.hermes.client.ui.sessions.ArchivedSessionsScreen(
+                    onOpen = { id -> nav.navigate("chat/$id") },
+                    onBack = { nav.popBackStack() },
                     onUnauthorized = onUnauthorized,
                 )
             }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
@@ -1,0 +1,127 @@
+package com.hermes.client.ui.sessions
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hermes.client.domain.Session
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArchivedSessionsScreen(
+    onOpen: (String) -> Unit,
+    onBack: () -> Unit,
+    onUnauthorized: () -> Unit = {},
+    vm: ArchivedSessionsViewModel = hiltViewModel(),
+) {
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(state.unauthorized) { if (state.unauthorized) onUnauthorized() }
+    // Reload on resume so a session archived from the active list shows up here, and a restore
+    // disappears, without needing a profile switch or app restart.
+    androidx.lifecycle.compose.LifecycleEventEffect(androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+        vm.refresh()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Archived") },
+                navigationIcon = { IconButton(onClick = onBack) { Text("←") } },
+            )
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when {
+                state.loading && state.sessions.isEmpty() ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
+                state.sessions.isEmpty() -> Text(
+                    "No archived sessions.",
+                    Modifier.align(Alignment.Center).padding(24.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                else -> LazyColumn(Modifier.fillMaxSize()) {
+                    items(state.sessions, key = { it.id }) { s ->
+                        ArchivedRow(
+                            session = s,
+                            onOpen = { onOpen(s.id) },
+                            onUnarchive = { vm.unarchive(s.id) },
+                            onDelete = { vm.delete(s.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ArchivedRow(
+    session: Session,
+    onOpen: () -> Unit,
+    onUnarchive: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    var confirmingDelete by remember { mutableStateOf(false) }
+
+    Box {
+        ListItem(
+            headlineContent = { Text(session.title) },
+            supportingContent = { Text(session.model ?: "") },
+            // Tap opens the archived session; long-press opens the manage menu.
+            modifier = Modifier.combinedClickable(onClick = onOpen, onLongClick = { menuOpen = true }),
+        )
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text("Unarchive") },
+                onClick = { menuOpen = false; onUnarchive() },
+            )
+            DropdownMenuItem(
+                text = { Text("Delete") },
+                onClick = { menuOpen = false; confirmingDelete = true },
+            )
+        }
+    }
+
+    if (confirmingDelete) {
+        AlertDialog(
+            onDismissRequest = { confirmingDelete = false },
+            title = { Text("Delete session?") },
+            text = { Text("\"${session.title}\" will be permanently deleted.") },
+            confirmButton = {
+                TextButton(onClick = { confirmingDelete = false; onDelete() }) { Text("Delete") }
+            },
+            dismissButton = { TextButton(onClick = { confirmingDelete = false }) { Text("Cancel") } },
+        )
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
@@ -1,0 +1,59 @@
+package com.hermes.client.ui.sessions
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.network.HermesApiException
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.domain.Session
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ArchivedUiState(
+    val sessions: List<Session> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val unauthorized: Boolean = false,
+)
+
+@HiltViewModel
+class ArchivedSessionsViewModel @Inject constructor(
+    private val sessions: SessionRepository,
+    private val profileManager: ProfileManager,
+) : ViewModel() {
+    private val _state = MutableStateFlow(ArchivedUiState())
+    val state: StateFlow<ArchivedUiState> = _state.asStateFlow()
+
+    val activeProfile: StateFlow<String?> = profileManager.active
+
+    init {
+        // Reload whenever the active profile changes (including the first value), so the list
+        // is always scoped to the tenant selected in the drawer.
+        viewModelScope.launch { profileManager.active.collect { refresh() } }
+    }
+
+    fun refresh() = viewModelScope.launch {
+        _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
+        try {
+            _state.value = ArchivedUiState(sessions = sessions.archived(profileManager.active.value))
+        } catch (e: HermesApiException) {
+            if (e.code == 401) _state.value = ArchivedUiState(unauthorized = true)
+            else _state.value = ArchivedUiState(error = e.message ?: "Failed to load")
+        } catch (e: Exception) {
+            _state.value = ArchivedUiState(error = e.message ?: "Failed to load")
+        }
+    }
+
+    /** Restore an archived session to the active list, then refresh so it leaves this view. */
+    fun unarchive(sessionId: String) = viewModelScope.launch {
+        runCatching { sessions.archive(sessionId, archived = false) }.onSuccess { refresh() }
+    }
+
+    fun delete(sessionId: String) = viewModelScope.launch {
+        runCatching { sessions.delete(sessionId) }.onSuccess { refresh() }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -137,7 +137,9 @@ fun SessionsScreen(
                         // Gateway message-content search results (populated on the Search action).
                         if (messageResults.isNotEmpty()) {
                             item(key = "h-msg") { SectionHeader("Message matches", messageResults.size) }
-                            items(messageResults, key = { "m-${it.sessionId}-${it.snippet.orEmpty().take(24)}" }) { r ->
+                            // No custom key: results are transient and snippets can collide
+                            // (duplicate/empty), which would crash the list. Index keys are safe.
+                            items(messageResults) { r ->
                                 ListItem(
                                     headlineContent = {
                                         Text(r.snippet?.take(140)?.replace("\n", " ") ?: r.sessionId)

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -43,6 +43,7 @@ fun SessionsScreen(
     vm: SessionsViewModel = hiltViewModel(),
     onOpen: (String) -> Unit,
     onMenu: () -> Unit = {},
+    onOpenArchived: () -> Unit = {},
     onUnauthorized: () -> Unit = {},
 ) {
     val state by vm.state.collectAsStateWithLifecycle()
@@ -78,6 +79,7 @@ fun SessionsScreen(
                     }
                 },
                 navigationIcon = { IconButton(onClick = onMenu) { Text("☰") } },
+                actions = { TextButton(onClick = onOpenArchived) { Text("Archived") } },
             )
         },
         floatingActionButton = {

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -1,6 +1,7 @@
 package com.hermes.client.ui.sessions
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,14 +11,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -32,6 +37,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.domain.Session
@@ -49,6 +55,8 @@ fun SessionsScreen(
     val state by vm.state.collectAsStateWithLifecycle()
     val activeProfile by vm.activeProfile.collectAsStateWithLifecycle()
     val pinnedIds by vm.pinnedIds.collectAsStateWithLifecycle()
+    val query by vm.query.collectAsStateWithLifecycle()
+    val messageResults by vm.messageResults.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
 
     // I1: route to Setup when a 401 is received
@@ -90,18 +98,67 @@ fun SessionsScreen(
             )
         },
     ) { padding ->
-        Box(Modifier.padding(padding).fillMaxSize()) {
+        Column(Modifier.padding(padding).fillMaxSize()) {
+            // Search: typing filters the loaded list by title/workspace instantly; the keyboard
+            // Search action runs a full message-content search via the gateway.
+            OutlinedTextField(
+                value = query,
+                onValueChange = vm::onQueryChange,
+                placeholder = { Text("Search sessions…") },
+                singleLine = true,
+                trailingIcon = {
+                    if (query.isNotBlank()) {
+                        IconButton(onClick = { vm.onQueryChange("") }) { Text("✕") }
+                    }
+                },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { vm.searchMessages() }),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
+            )
+            Box(Modifier.fillMaxSize()) {
             when {
                 state.loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
                 state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
                 else -> {
-                    val pinned = state.sessions.filter { it.id in pinnedIds }
+                    val q = query.trim()
+                    // Instant client-side title/workspace filter over the loaded sessions.
+                    val matches = if (q.isEmpty()) state.sessions
+                    else state.sessions.filter {
+                        it.title.contains(q, ignoreCase = true) ||
+                            it.workspace.contains(q, ignoreCase = true)
+                    }
+                    val pinned = matches.filter { it.id in pinnedIds }
                     // Group the rest by workspace; "No workspace" sorts last.
-                    val groups = state.sessions.filterNot { it.id in pinnedIds }
+                    val groups = matches.filterNot { it.id in pinnedIds }
                         .groupBy { it.workspace }
                         .toSortedMap(compareBy({ it == "No workspace" }, { it }))
 
                     LazyColumn {
+                        // Gateway message-content search results (populated on the Search action).
+                        if (messageResults.isNotEmpty()) {
+                            item(key = "h-msg") { SectionHeader("Message matches", messageResults.size) }
+                            items(messageResults, key = { "m-${it.sessionId}-${it.snippet.orEmpty().take(24)}" }) { r ->
+                                ListItem(
+                                    headlineContent = {
+                                        Text(r.snippet?.take(140)?.replace("\n", " ") ?: r.sessionId)
+                                    },
+                                    supportingContent = { Text(r.model ?: r.role ?: "") },
+                                    modifier = Modifier.clickable { onOpen(r.sessionId) },
+                                )
+                                HorizontalDivider()
+                            }
+                        }
+                        // Hint when nothing matches by title — message search is one tap away.
+                        if (q.isNotEmpty() && matches.isEmpty() && messageResults.isEmpty()) {
+                            item(key = "no-title-match") {
+                                Text(
+                                    "No titles match \"$q\". Press search on the keyboard to search message text.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(16.dp),
+                                )
+                            }
+                        }
                         if (pinned.isNotEmpty()) {
                             item(key = "h-pinned") { SectionHeader("Pinned", pinned.size) }
                             items(pinned, key = { "p-${it.id}" }) { s ->
@@ -132,6 +189,7 @@ fun SessionsScreen(
                         }
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -3,6 +3,7 @@ package com.hermes.client.ui.sessions
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hermes.client.data.network.HermesApiException
+import com.hermes.client.data.network.SearchResultDto
 import com.hermes.client.data.repository.ChatRepository
 import com.hermes.client.data.repository.PinStore
 import com.hermes.client.data.repository.ProfileManager
@@ -71,6 +72,29 @@ class SessionsViewModel @Inject constructor(
         } catch (e: Exception) {
             _state.value = SessionsUiState(error = e.message ?: "Failed to load")
         }
+    }
+
+    // ── Search ──────────────────────────────────────────────────────────────────────────
+    // The title filter is applied to [state.sessions] in the UI as the query changes (instant,
+    // offline). A message-content search hits the gateway only on the explicit Search action.
+    private val _query = MutableStateFlow("")
+    val query: StateFlow<String> = _query.asStateFlow()
+
+    private val _messageResults = MutableStateFlow<List<SearchResultDto>>(emptyList())
+    val messageResults: StateFlow<List<SearchResultDto>> = _messageResults.asStateFlow()
+
+    fun onQueryChange(q: String) {
+        _query.value = q
+        if (q.isBlank()) _messageResults.value = emptyList()
+    }
+
+    /** Full-text search of message content across this profile's sessions. */
+    fun searchMessages() = viewModelScope.launch {
+        val q = _query.value.trim()
+        if (q.isBlank()) { _messageResults.value = emptyList(); return@launch }
+        runCatching { sessions.search(q, profileManager.active.value) }
+            .onSuccess { _messageResults.value = it }
+            .onFailure { _messageResults.value = emptyList() }
     }
 
     /** Returns the new session id, or null if creation failed (so the UI doesn't crash). */

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -88,13 +88,19 @@ class SessionsViewModel @Inject constructor(
         if (q.isBlank()) _messageResults.value = emptyList()
     }
 
-    /** Full-text search of message content across this profile's sessions. */
-    fun searchMessages() = viewModelScope.launch {
-        val q = _query.value.trim()
-        if (q.isBlank()) { _messageResults.value = emptyList(); return@launch }
-        runCatching { sessions.search(q, profileManager.active.value) }
-            .onSuccess { _messageResults.value = it }
-            .onFailure { _messageResults.value = emptyList() }
+    private var searchJob: kotlinx.coroutines.Job? = null
+
+    /** Full-text search of message content across this profile's sessions. Cancels any in-flight
+     *  search first so a slow older query can't overwrite newer results. */
+    fun searchMessages() {
+        searchJob?.cancel()
+        searchJob = viewModelScope.launch {
+            val q = _query.value.trim()
+            if (q.isBlank()) { _messageResults.value = emptyList(); return@launch }
+            runCatching { sessions.search(q, profileManager.active.value) }
+                .onSuccess { _messageResults.value = it }
+                .onFailure { _messageResults.value = emptyList() }
+        }
     }
 
     /** Returns the new session id, or null if creation failed (so the UI doesn't crash). */

--- a/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsScreen.kt
@@ -43,22 +43,38 @@ fun ConnectionSettingsScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
-                "The Hermes gateway this app connects to. Update the URL or token here if the " +
-                    "server moved or the token changed, then Save to reconnect.",
+                "The Hermes dashboard this app connects to. For a password-protected (network) " +
+                    "dashboard, set the URL plus username + password. For a local/loopback setup, " +
+                    "use the URL and token. Save to reconnect.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             OutlinedTextField(
                 value = state.url,
                 onValueChange = vm::onUrlChange,
-                label = { Text("Gateway URL (e.g. https://my-mac.ts.net)") },
+                label = { Text("Gateway URL (e.g. http://100.x.x.x:9119)") },
                 singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = state.username,
+                onValueChange = vm::onUsernameChange,
+                label = { Text("Username (for password-protected dashboards)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = state.password,
+                onValueChange = vm::onPasswordChange,
+                label = { Text("Password") },
+                singleLine = true,
+                visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth(),
             )
             OutlinedTextField(
                 value = state.token,
                 onValueChange = vm::onTokenChange,
-                label = { Text("Token (optional)") },
+                label = { Text("Token (loopback only — leave blank if using a password)") },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )

--- a/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsScreen.kt
@@ -1,0 +1,72 @@
+package com.hermes.client.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConnectionSettingsScreen(
+    onBack: () -> Unit,
+    vm: ConnectionSettingsViewModel = hiltViewModel(),
+) {
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Server & token") },
+                navigationIcon = { IconButton(onClick = onBack) { Text("‹") } },
+            )
+        },
+    ) { padding ->
+        Column(
+            Modifier.padding(padding).fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "The Hermes gateway this app connects to. Update the URL or token here if the " +
+                    "server moved or the token changed, then Save to reconnect.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = state.url,
+                onValueChange = vm::onUrlChange,
+                label = { Text("Gateway URL (e.g. https://my-mac.ts.net)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = state.token,
+                onValueChange = vm::onTokenChange,
+                label = { Text("Token (optional)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = { vm.test() }) { Text("Test") }
+                Button(onClick = { vm.save() }) { Text("Save & reconnect") }
+            }
+            state.testResult?.let { Text(it, style = MaterialTheme.typography.bodyMedium) }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hermes.client.data.auth.CredentialStore
 import com.hermes.client.data.auth.GatewayConfig
+import com.hermes.client.data.network.GatedAuth
 import com.hermes.client.data.network.HermesRestApi
 import com.hermes.client.data.repository.ChatRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +19,8 @@ import javax.inject.Inject
 data class ConnectionUiState(
     val url: String = "",
     val token: String = "",
+    val username: String = "",
+    val password: String = "",
     val testResult: String? = null,
     val saved: Boolean = false,
 )
@@ -30,29 +35,37 @@ class ConnectionSettingsViewModel @Inject constructor(
     private val store: CredentialStore,
     private val rest: HermesRestApi,
     private val chat: ChatRepository,
+    private val gatedAuth: GatedAuth,
 ) : ViewModel() {
     private val _state = MutableStateFlow(
-        store.load()?.let { ConnectionUiState(url = it.baseUrl, token = it.token) } ?: ConnectionUiState(),
+        store.load()?.let {
+            ConnectionUiState(url = it.baseUrl, token = it.token, username = it.username, password = it.password)
+        } ?: ConnectionUiState(),
     )
     val state: StateFlow<ConnectionUiState> = _state.asStateFlow()
 
-    fun onUrlChange(v: String) {
-        _state.value = _state.value.copy(url = v.trim(), saved = false, testResult = null)
-    }
+    fun onUrlChange(v: String) { _state.value = _state.value.copy(url = v.trim(), saved = false, testResult = null) }
+    fun onTokenChange(v: String) { _state.value = _state.value.copy(token = v.trim(), saved = false, testResult = null) }
+    fun onUsernameChange(v: String) { _state.value = _state.value.copy(username = v.trim(), saved = false, testResult = null) }
+    fun onPasswordChange(v: String) { _state.value = _state.value.copy(password = v, saved = false, testResult = null) }
 
-    fun onTokenChange(v: String) {
-        _state.value = _state.value.copy(token = v.trim(), saved = false, testResult = null)
-    }
-
-    /** Test connectivity with the entered values WITHOUT persisting them. */
+    /** Test with the entered values WITHOUT persisting: a login probe when a username is set,
+     *  otherwise a plain status check. */
     fun test() = viewModelScope.launch {
-        val ok = rest.statusFor(_state.value.url, _state.value.token)
-        _state.value = _state.value.copy(testResult = if (ok) "Connected ✓" else "Unreachable")
+        val s = _state.value
+        val ok = if (s.username.isNotBlank()) {
+            withContext(Dispatchers.IO) { gatedAuth.probeLogin(s.url, s.username, s.password) }
+        } else {
+            rest.statusFor(s.url, s.token)
+        }
+        _state.value = _state.value.copy(testResult = if (ok) "Connected ✓" else "Failed — check the details")
     }
 
-    /** Persist the new server/token, then reconnect — the socket URL is derived from config. */
+    /** Persist the new server/credentials, drop any stale session, then reconnect. */
     fun save() {
-        store.save(GatewayConfig(_state.value.url.trim(), _state.value.token.trim()))
+        val s = _state.value
+        store.save(GatewayConfig(s.url.trim(), s.token.trim(), s.username.trim(), s.password))
+        gatedAuth.cookieJar.clear() // force a fresh login with the new credentials
         runCatching { chat.reconnect() }
         _state.value = _state.value.copy(saved = true, testResult = "Saved — reconnecting")
     }

--- a/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsViewModel.kt
@@ -1,0 +1,59 @@
+package com.hermes.client.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.auth.CredentialStore
+import com.hermes.client.data.auth.GatewayConfig
+import com.hermes.client.data.network.HermesRestApi
+import com.hermes.client.data.repository.ChatRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ConnectionUiState(
+    val url: String = "",
+    val token: String = "",
+    val testResult: String? = null,
+    val saved: Boolean = false,
+)
+
+/**
+ * View/update the gateway URL + token after first-run setup. Mirrors SetupViewModel but is
+ * reachable from Settings and reconnects the live socket on save so a changed server/token
+ * takes effect without restarting the app.
+ */
+@HiltViewModel
+class ConnectionSettingsViewModel @Inject constructor(
+    private val store: CredentialStore,
+    private val rest: HermesRestApi,
+    private val chat: ChatRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(
+        store.load()?.let { ConnectionUiState(url = it.baseUrl, token = it.token) } ?: ConnectionUiState(),
+    )
+    val state: StateFlow<ConnectionUiState> = _state.asStateFlow()
+
+    fun onUrlChange(v: String) {
+        _state.value = _state.value.copy(url = v.trim(), saved = false, testResult = null)
+    }
+
+    fun onTokenChange(v: String) {
+        _state.value = _state.value.copy(token = v.trim(), saved = false, testResult = null)
+    }
+
+    /** Test connectivity with the entered values WITHOUT persisting them. */
+    fun test() = viewModelScope.launch {
+        val ok = rest.statusFor(_state.value.url, _state.value.token)
+        _state.value = _state.value.copy(testResult = if (ok) "Connected ✓" else "Unreachable")
+    }
+
+    /** Persist the new server/token, then reconnect — the socket URL is derived from config. */
+    fun save() {
+        store.save(GatewayConfig(_state.value.url.trim(), _state.value.token.trim()))
+        runCatching { chat.reconnect() }
+        _state.value = _state.value.copy(saved = true, testResult = "Saved — reconnecting")
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
@@ -32,6 +32,8 @@ fun SettingsScreen(
         },
     ) { padding ->
         Column(Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState())) {
+            Entry("Server & token", "Gateway URL and token this app connects to") { onNavigate("settings_connection") }
+            HorizontalDivider()
             Entry("Appearance", "Theme, light/dark, tool-call display") { onNavigate("settings_appearance") }
             HorizontalDivider()
             Entry("Models & memory", "Default model, memory toggles & budgets") { onNavigate("settings_memory") }

--- a/app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
@@ -34,13 +34,28 @@ fun SetupScreen(vm: SetupViewModel = hiltViewModel(), onSaved: () -> Unit) {
         OutlinedTextField(
             value = state.url,
             onValueChange = vm::onUrlChange,
-            label = { Text("Gateway URL (e.g. https://my-mac.ts.net:8443)") },
+            label = { Text("Gateway URL (e.g. http://100.x.x.x:9119)") },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = state.username,
+            onValueChange = vm::onUsernameChange,
+            label = { Text("Username (for password-protected dashboards)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = state.password,
+            onValueChange = vm::onPasswordChange,
+            label = { Text("Password") },
+            singleLine = true,
+            visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation(),
             modifier = Modifier.fillMaxWidth(),
         )
         OutlinedTextField(
             value = state.token,
             onValueChange = vm::onTokenChange,
-            label = { Text("Token (optional)") },
+            label = { Text("Token (loopback only — blank if using a password)") },
             modifier = Modifier.fillMaxWidth(),
         )
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt
@@ -4,17 +4,22 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hermes.client.data.auth.CredentialStore
 import com.hermes.client.data.auth.GatewayConfig
+import com.hermes.client.data.network.GatedAuth
 import com.hermes.client.data.network.HermesRestApi
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 data class SetupUiState(
     val url: String = "",
     val token: String = "",
+    val username: String = "",
+    val password: String = "",
     val testResult: String? = null,
     val saved: Boolean = false,
 )
@@ -23,23 +28,35 @@ data class SetupUiState(
 class SetupViewModel @Inject constructor(
     private val store: CredentialStore,
     private val rest: HermesRestApi,
+    private val gatedAuth: GatedAuth,
 ) : ViewModel() {
     private val _state = MutableStateFlow(
-        store.load()?.let { SetupUiState(url = it.baseUrl, token = it.token) } ?: SetupUiState()
+        store.load()?.let {
+            SetupUiState(url = it.baseUrl, token = it.token, username = it.username, password = it.password)
+        } ?: SetupUiState(),
     )
     val state: StateFlow<SetupUiState> = _state.asStateFlow()
 
     fun onUrlChange(v: String) { _state.value = _state.value.copy(url = v.trim()) }
     fun onTokenChange(v: String) { _state.value = _state.value.copy(token = v.trim()) }
+    fun onUsernameChange(v: String) { _state.value = _state.value.copy(username = v.trim()) }
+    fun onPasswordChange(v: String) { _state.value = _state.value.copy(password = v) }
 
-    // T10b: test() must NOT persist unverified credentials — use statusFor() with transient values
+    // T10b: test() must NOT persist unverified credentials — probe with transient values.
     fun test() = viewModelScope.launch {
-        val ok = rest.statusFor(_state.value.url, _state.value.token)
+        val s = _state.value
+        val ok = if (s.username.isNotBlank()) {
+            withContext(Dispatchers.IO) { gatedAuth.probeLogin(s.url, s.username, s.password) }
+        } else {
+            rest.statusFor(s.url, s.token)
+        }
         _state.value = _state.value.copy(testResult = if (ok) "Connected" else "Unreachable")
     }
 
     fun save() {
-        store.save(GatewayConfig(_state.value.url, _state.value.token))
+        val s = _state.value
+        store.save(GatewayConfig(s.url, s.token, s.username.trim(), s.password))
+        gatedAuth.cookieJar.clear()
         _state.value = _state.value.copy(saved = true)
     }
 }

--- a/app/src/test/java/com/hermes/client/data/network/GatedAuthTest.kt
+++ b/app/src/test/java/com/hermes/client/data/network/GatedAuthTest.kt
@@ -1,0 +1,61 @@
+package com.hermes.client.data.network
+
+import com.hermes.client.data.auth.GatewayConfig
+import kotlinx.serialization.json.Json
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GatedAuthTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun authFor(base: String) =
+        GatedAuth(json) { GatewayConfig(baseUrl = base, token = "", username = "admin", password = "pw") }
+
+    @Test fun login_posts_basic_credentials_and_succeeds() {
+        MockWebServer().use { server ->
+            server.enqueue(
+                MockResponse.Builder()
+                    .body("{\"ok\":true}")
+                    .addHeader("Set-Cookie", "hermes_session_at=abc; Path=/")
+                    .build(),
+            )
+            server.start()
+            val base = server.url("/").toString().trimEnd('/')
+
+            assertTrue(authFor(base).login())
+
+            val req = server.takeRequest()
+            assertEquals("POST", req.method)
+            assertEquals("/auth/password-login", req.target)
+            val body = req.body?.utf8().orEmpty()
+            assertTrue(body.contains("\"provider\":\"basic\""))
+            assertTrue(body.contains("\"username\":\"admin\""))
+            assertTrue(body.contains("\"password\":\"pw\""))
+        }
+    }
+
+    @Test fun login_returns_false_on_401() {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse.Builder().code(401).body("{\"detail\":\"Invalid credentials\"}").build())
+            server.start()
+            assertFalse(authFor(server.url("/").toString().trimEnd('/')).login())
+        }
+    }
+
+    @Test fun wsTicket_parses_ticket_field() {
+        MockWebServer().use { server ->
+            server.enqueue(MockResponse.Builder().body("{\"ticket\":\"TICK123\",\"ttl_seconds\":30}").build())
+            server.start()
+            val auth = authFor(server.url("/").toString().trimEnd('/'))
+            val client = OkHttpClient.Builder().cookieJar(auth.cookieJar).build()
+
+            assertEquals("TICK123", auth.wsTicket(client))
+            assertEquals("/api/auth/ws-ticket", server.takeRequest().target)
+        }
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
@@ -1,0 +1,67 @@
+package com.hermes.client.ui.sessions
+
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.domain.Session
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArchivedSessionsViewModelTest {
+    private val sessionRepo = mockk<SessionRepository>(relaxed = true)
+    private val profileManager = mockk<ProfileManager>(relaxed = true)
+
+    @Before fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        every { profileManager.active } returns MutableStateFlow<String?>("personal")
+    }
+
+    private fun session(id: String) = Session(
+        id = id, title = id, model = null, provider = null,
+        messageCount = 1, profile = "personal", workspace = "No workspace", source = null,
+    )
+
+    private fun buildVm() = ArchivedSessionsViewModel(sessionRepo, profileManager)
+
+    @Test fun loads_archived_sessions_on_init() = runTest {
+        coEvery { sessionRepo.archived(any()) } returns listOf(session("a1"), session("a2"))
+        val vm = buildVm()
+        advanceUntilIdle()
+        assertEquals(listOf("a1", "a2"), vm.state.value.sessions.map { it.id })
+    }
+
+    @Test fun unarchive_restores_then_reloads() = runTest {
+        coEvery { sessionRepo.archived(any()) } returns listOf(session("a1"))
+        val vm = buildVm()
+        advanceUntilIdle()
+        // After restoring, the session is no longer archived, so the reloaded list is empty.
+        coEvery { sessionRepo.archived(any()) } returns emptyList()
+        vm.unarchive("a1")
+        advanceUntilIdle()
+        coVerify { sessionRepo.archive("a1", archived = false) }
+        assertEquals(emptyList<String>(), vm.state.value.sessions.map { it.id })
+    }
+
+    @Test fun delete_removes_then_reloads() = runTest {
+        coEvery { sessionRepo.archived(any()) } returns listOf(session("a1"))
+        val vm = buildVm()
+        advanceUntilIdle()
+        coEvery { sessionRepo.archived(any()) } returns emptyList()
+        vm.delete("a1")
+        advanceUntilIdle()
+        coVerify { sessionRepo.delete("a1") }
+        assertEquals(emptyList<String>(), vm.state.value.sessions.map { it.id })
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -45,6 +45,27 @@ class SessionsViewModelTest {
     // ViewModel is not recreated when navigating back, so init runs only once). This proves
     // refresh() re-queries the repository and surfaces the newly-added session — the mechanism
     // the resume hook relies on. Without that hook, the user's just-run session never shows.
+    // Typing a query is an instant client-side concern; only the explicit Search action hits
+    // the gateway. searchMessages must populate messageResults from the repo, and clearing the
+    // query must clear results.
+    @Test fun searchMessages_populates_results_and_clear_resets() = runTest {
+        coEvery { sessionRepo.list(any()) } returns emptyList()
+        coEvery { sessionRepo.search(any(), any()) } returns listOf(
+            com.hermes.client.data.network.SearchResultDto(sessionId = "s9", snippet = "found it"),
+        )
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.onQueryChange("invoice")
+        vm.searchMessages()
+        advanceUntilIdle()
+        assertEquals(listOf("s9"), vm.messageResults.value.map { it.sessionId })
+
+        vm.onQueryChange("")
+        advanceUntilIdle()
+        assertTrue("clearing the query clears message results", vm.messageResults.value.isEmpty())
+    }
+
     @Test fun refresh_resurfaces_newly_added_session() = runTest {
         coEvery { sessionRepo.list(any()) } returns listOf(session("s1", "old"))
         val vm = buildVm()

--- a/app/src/test/java/com/hermes/client/ui/settings/ConnectionSettingsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/settings/ConnectionSettingsViewModelTest.kt
@@ -24,10 +24,11 @@ class ConnectionSettingsViewModelTest {
     private val store = mockk<CredentialStore>(relaxed = true)
     private val rest = mockk<HermesRestApi>(relaxed = true)
     private val chat = mockk<ChatRepository>(relaxed = true)
+    private val gatedAuth = mockk<com.hermes.client.data.network.GatedAuth>(relaxed = true)
 
     @Before fun setUp() { Dispatchers.setMain(StandardTestDispatcher()) }
 
-    private fun buildVm() = ConnectionSettingsViewModel(store, rest, chat)
+    private fun buildVm() = ConnectionSettingsViewModel(store, rest, chat, gatedAuth)
 
     @Test fun prefills_fields_from_stored_config() {
         every { store.load() } returns GatewayConfig("https://host.ts.net", "tok123")

--- a/app/src/test/java/com/hermes/client/ui/settings/ConnectionSettingsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/settings/ConnectionSettingsViewModelTest.kt
@@ -1,0 +1,62 @@
+package com.hermes.client.ui.settings
+
+import com.hermes.client.data.auth.CredentialStore
+import com.hermes.client.data.auth.GatewayConfig
+import com.hermes.client.data.network.HermesRestApi
+import com.hermes.client.data.repository.ChatRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectionSettingsViewModelTest {
+    private val store = mockk<CredentialStore>(relaxed = true)
+    private val rest = mockk<HermesRestApi>(relaxed = true)
+    private val chat = mockk<ChatRepository>(relaxed = true)
+
+    @Before fun setUp() { Dispatchers.setMain(StandardTestDispatcher()) }
+
+    private fun buildVm() = ConnectionSettingsViewModel(store, rest, chat)
+
+    @Test fun prefills_fields_from_stored_config() {
+        every { store.load() } returns GatewayConfig("https://host.ts.net", "tok123")
+        val vm = buildVm()
+        assertEquals("https://host.ts.net", vm.state.value.url)
+        assertEquals("tok123", vm.state.value.token)
+    }
+
+    @Test fun save_persists_new_config_and_reconnects() {
+        every { store.load() } returns GatewayConfig("https://old", "")
+        val vm = buildVm()
+        vm.onUrlChange("https://new.ts.net")
+        vm.onTokenChange("newtok")
+        vm.save()
+        verify { store.save(GatewayConfig("https://new.ts.net", "newtok")) }
+        verify { chat.reconnect() }
+        assertEquals(true, vm.state.value.saved)
+    }
+
+    @Test fun test_probes_with_entered_values_without_saving() = runTest {
+        every { store.load() } returns null
+        coEvery { rest.statusFor("https://h", "t") } returns true
+        val vm = buildVm()
+        vm.onUrlChange("https://h")
+        vm.onTokenChange("t")
+        vm.test()
+        advanceUntilIdle()
+        coVerify { rest.statusFor("https://h", "t") }
+        verify(exactly = 0) { store.save(any()) }
+        assertEquals("Connected ✓", vm.state.value.testResult)
+    }
+}

--- a/docs/superpowers/specs/2026-06-22-archived-sessions-design.md
+++ b/docs/superpowers/specs/2026-06-22-archived-sessions-design.md
@@ -1,0 +1,59 @@
+# Archived Sessions — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (key decision confirmed with user)
+
+## Problem
+
+A session can be archived today (long-press → Archive), and archived sessions are listed in
+the buried "Session admin" screen — but there is **no way to un-archive** one, and the
+archived list is hard to find. Users want a clear way to view archived sessions and restore
+or delete them.
+
+## What already exists (reused, not rebuilt)
+
+- `SessionRepository.archived(profile)` → `GET /api/sessions?archived=only` — list archived.
+- `SessionRepository.archive(id, archived)` — set the flag (pass `false` to restore).
+- `SessionRepository.delete(id)` — permanent delete.
+- `SessionRow` long-press menu pattern (Open / Pin / Rename / Archive / Delete) in
+  `SessionsScreen` — the interaction model to mirror.
+
+## Decision
+
+A **dedicated Archived Sessions screen**, reachable from an **action on the Sessions screen
+top bar**. Each archived row supports **Open**, **Unarchive (restore)**, and **Delete**.
+
+## Design
+
+### Navigation
+- `SessionsScreen` gains an `onOpenArchived` callback, wired in `HermesNav` to
+  `nav.navigate("archived")`, surfaced as a top-bar action (label/glyph "Archived").
+- New route `composable("archived")` → `ArchivedSessionsScreen(onOpen = { nav.navigate("chat/$id") }, onBack = { nav.popBackStack() })`.
+
+### `ArchivedSessionsViewModel` (new)
+- State: `sessions: List<Session>`, `loading`, `error`, `unauthorized` (mirrors
+  `SessionsViewModel`).
+- `init` + ON_RESUME `refresh()`; reloads on active-profile change.
+- `refresh()` → `sessions.archived(profileManager.active.value)`.
+- `unarchive(id)` → `sessions.archive(id, archived = false)` then `refresh()`.
+- `delete(id)` → `sessions.delete(id)` then `refresh()`.
+
+### `ArchivedSessionsScreen` (new)
+- `TopAppBar("Archived")` with a back navigation icon.
+- `LazyColumn` of archived sessions; empty state "No archived sessions."
+- Each row: tap = Open; long-press menu = **Unarchive**, **Delete** (Delete behind a confirm
+  dialog, matching the active-list pattern).
+- ON_RESUME refresh so a session archived from the active list appears here on return, and a
+  restore disappears from here.
+
+### Active list
+- Unchanged except the new top-bar "Archived" action. The existing long-press **Archive**
+  stays as-is.
+
+## Testing
+- `ArchivedSessionsViewModelTest` (unit): `refresh` loads archived list; `unarchive` calls
+  `archive(id, false)` then reloads; `delete` calls `delete(id)` then reloads.
+
+## Non-goals
+- No bulk select / multi-archive. No new REST endpoints (all exist). No change to how
+  archiving is triggered from the active list.

--- a/docs/superpowers/specs/2026-06-22-sessions-search-design.md
+++ b/docs/superpowers/specs/2026-06-22-sessions-search-design.md
@@ -1,0 +1,45 @@
+# Sessions Search — Design
+
+**Date:** 2026-06-22
+**Status:** Approved (confirmed with user)
+
+## Problem
+
+The main Sessions screen has no search. Finding a conversation means scrolling, and the only
+search (message full-text) is buried in the Session admin screen. Users want to search from
+the Sessions list — both a quick title filter and a deeper message-content search.
+
+## Decision
+
+A search bar at the top of the Sessions screen that does **both**:
+- **Title filter (instant, client-side):** as you type, the loaded session list is filtered
+  by title/workspace — no round-trip.
+- **Message-content search (gateway):** pressing the keyboard Search action runs the existing
+  `/api/sessions/search` and shows matching sessions in a "Message matches" section above the
+  list.
+
+Reuses existing plumbing: `SessionRepository.search(query, profile)` and `SearchResultDto`.
+
+## Design
+
+### `SessionsViewModel`
+- `query: StateFlow<String>` + `onQueryChange(q)` (clearing the query clears message results).
+- `messageResults: StateFlow<List<SearchResultDto>>` + `searchMessages()` → calls
+  `sessions.search(query, activeProfile)`; failures clear results.
+
+### `SessionsScreen`
+- An `OutlinedTextField` (placeholder "Search sessions…", clear button, IME action = Search)
+  pinned above the list.
+- The grouped/pinned list is filtered by `title`/`workspace` containing the query.
+- When `messageResults` is non-empty, a "Message matches (N)" section renders first; each row
+  opens its session.
+- A hint when the title filter yields nothing: "No titles match — press search to search
+  message text."
+
+## Testing
+- `SessionsViewModelTest`: `onQueryChange` updates query; `searchMessages` populates
+  `messageResults` from the repo; a blank query clears results.
+
+## Non-goals
+- No search history, no debounced auto message-search (explicit Search action only), no
+  changes to the Session admin screen.


### PR DESCRIPTION
Promotes develop to the next stable release.

## Since v0.1.8
- **Archived sessions** view (Sessions top bar) with unarchive/delete.
- **Session search** on the Sessions screen: instant title filter + gateway message-content search.
- **Settings → Server & token** — view/edit the gateway URL, token, or username/password and reconnect, after first-run setup.
- **Basic-auth (gated dashboard) support** — login (POST /auth/password-login), cookie session with 401 re-login, and per-socket WS tickets. Required now that Hermes refuses to expose the dashboard on a network address without an auth provider.
- Open-at-newest-message scroll fix; session model switch (/model --session); README updated.

## Notes
- Unit + instrumented tests across the new code; full suite green.
- Open HIGH Dependabot alerts are all build-classpath (AGP/Gradle) transitive deps; none ship in the APK.