### PR TITLE
chore: close 17 HIGH Dependabot advisories (build-classpath deps) + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ vector in `app/src/main/res/drawable/`.
 
 Toolchain is pinned in `gradle/libs.versions.toml`: AGP 8.13.2, Kotlin 2.2.21,
 Gradle 8.14.5. `minSdk` 26, `targetSdk` 36. These are the newest mutually-compatible
-versions — AGP 9.x drops the `kotlin-android` plugin and Hilt 2.59 requires it, so the set
-is held here on purpose.
+versions — AGP 9.x's built-in Kotlin integration is incompatible with applying the standalone
+`kotlin-android` Kotlin Gradle plugin this project uses, and Hilt 2.59 requires AGP 9.x, so the
+set is held here on purpose.
 
 The root `build.gradle.kts` **forces patched versions of a few transitive build-classpath
 dependencies** (gRPC/Google-Cloud tooling the Android Gradle Plugin bundles — netty,

--- a/README.md
+++ b/README.md
@@ -106,7 +106,14 @@ vector in `app/src/main/res/drawable/`.
   password-protected dashboard)
 
 Toolchain is pinned in `gradle/libs.versions.toml`: AGP 8.13.2, Kotlin 2.2.21,
-Gradle 8.14.5. `minSdk` 26, `targetSdk` 36.
+Gradle 8.14.5. `minSdk` 26, `targetSdk` 36. These are the newest mutually-compatible
+versions — AGP 9.x drops the `kotlin-android` plugin and Hilt 2.59 requires it, so the set
+is held here on purpose.
+
+The root `build.gradle.kts` **forces patched versions of a few transitive build-classpath
+dependencies** (gRPC/Google-Cloud tooling the Android Gradle Plugin bundles — netty,
+protobuf, jose4j, jdom2, bouncycastle) to close known advisories. These are build-time only
+and **never shipped in the APK**; the forces touch no app runtime dependency.
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,22 @@
+// Force patched versions of the Android Gradle Plugin's transitive BUILD-CLASSPATH deps
+// (gRPC / Google-Cloud tooling AGP bundles — never shipped in the APK). All minor/patch bumps
+// that close the open HIGH Dependabot advisories without touching app runtime deps.
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.force(
+            "io.netty:netty-handler:4.1.135.Final",
+            "io.netty:netty-codec:4.1.135.Final",
+            "io.netty:netty-codec-http:4.1.135.Final",
+            "io.netty:netty-codec-http2:4.1.135.Final",
+            "com.google.protobuf:protobuf-java:3.25.5",
+            "com.google.protobuf:protobuf-kotlin:3.25.5",
+            "org.bouncycastle:bcpg-jdk18on:1.84",
+            "org.bitbucket.b_c:jose4j:0.9.6",
+            "org.jdom:jdom2:2.0.6.1",
+        )
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,17 +3,21 @@
 // that close the open HIGH Dependabot advisories without touching app runtime deps.
 buildscript {
     configurations.classpath {
-        resolutionStrategy.force(
-            "io.netty:netty-handler:4.1.135.Final",
-            "io.netty:netty-codec:4.1.135.Final",
-            "io.netty:netty-codec-http:4.1.135.Final",
-            "io.netty:netty-codec-http2:4.1.135.Final",
-            "com.google.protobuf:protobuf-java:3.25.5",
-            "com.google.protobuf:protobuf-kotlin:3.25.5",
-            "org.bouncycastle:bcpg-jdk18on:1.84",
-            "org.bitbucket.b_c:jose4j:0.9.6",
-            "org.jdom:jdom2:2.0.6.1",
-        )
+        resolutionStrategy {
+            // Pin EVERY netty module to one patched version. Forcing only a subset (codec,
+            // handler, …) would leave netty-common/buffer/transport/resolver on the old version
+            // and skew the set, risking linkage errors — so bump the whole io.netty group.
+            eachDependency {
+                if (requested.group == "io.netty") useVersion("4.1.135.Final")
+            }
+            force(
+                "com.google.protobuf:protobuf-java:3.25.5",
+                "com.google.protobuf:protobuf-kotlin:3.25.5",
+                "org.bouncycastle:bcpg-jdk18on:1.84",
+                "org.bitbucket.b_c:jose4j:0.9.6",
+                "org.jdom:jdom2:2.0.6.1",
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Closes the 17 open HIGH Dependabot advisories and refreshes the docs.

## Security
All 17 HIGH alerts are transitive deps of the Android Gradle Plugin's bundled build tooling (gRPC / Google-Cloud client libs) — **build-time only, never shipped in the APK**. The root `build.gradle.kts` now forces patched versions on the build classpath:
- io.netty:* 4.1.110 → 4.1.135.Final
- com.google.protobuf:* → 3.25.5
- jose4j 0.9.5 → 0.9.6, jdom2 2.0.6 → 2.0.6.1, bcpg-jdk18on → 1.84

All minor/patch (binary-compatible); no app runtime dependency changed. Build + full unit suite green. The dependency-graph submission runs on the `master` push, so Dependabot re-evaluates and auto-closes these once merged.

## Docs
README updated: toolchain-pin rationale and a note that the build-classpath forces are build-time only.

## Notes
The same advisories show as 'open' until the post-merge graph submission re-runs.