### PR TITLE
docs: add Code of Conduct, Contributing, Security policy + README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+v2.1. Be respectful, assume good faith, and keep discussion constructive.
+
+Report unacceptable behavior to the maintainer through a private channel — the GitHub
+profile contact, or **Security → Advisories → Report a vulnerability** on this repository for
+anything sensitive. Maintainers may remove, edit, or reject contributions and comments that
+violate this code.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,6 @@
 This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
 v2.1. Be respectful, assume good faith, and keep discussion constructive.
 
-Report unacceptable behavior to the maintainer through a private channel — the GitHub
-profile contact, or **Security → Advisories → Report a vulnerability** on this repository for
-anything sensitive. Maintainers may remove, edit, or reject contributions and comments that
-violate this code.
+Report unacceptable behavior privately to the maintainer via their GitHub profile contact.
+(GitHub's *Report a vulnerability* flow is for security issues, not conduct reports.)
+Maintainers may remove, edit, or reject contributions and comments that violate this code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to Hermes for Android
+
+Thanks for your interest! This is an early-stage open-source project. By participating you
+agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting started
+
+1. Install **Android Studio** (it bundles the JBR / JDK 21 the build expects) and the Android
+   SDK (`compileSdk` 36 / build-tools 36.x).
+2. Clone and open the project; let Gradle sync.
+3. Run the checks:
+   ```bash
+   ./gradlew :app:testDebugUnitTest      # JVM unit tests
+   ./gradlew :app:assembleDebug          # build
+   # Optional, needs a device/emulator:
+   ./gradlew :app:connectedDebugAndroidTest
+   ```
+
+## Ground rules
+
+- **Architecture:** MVVM + Hilt + Jetpack Compose + Repository. Keep transport
+  (`data/network`), storage (`data/auth`, DataStore), and UI (`ui/<screen>`) separate.
+  Business logic that can be a pure function (e.g. the chat `reduce()` reducer, DTO mappers)
+  should live in a testable, I/O-free unit.
+- **Tests:** add JVM unit tests for logic you can test without a device (see
+  `ChatReducerTest`, the `*ViewModelTest`s). PRs that change reducers, parsing, mapping, or
+  auth flow must include tests.
+- **Security:** never commit secrets — `keystore.properties`, `*.jks`/`*.keystore`,
+  `local.properties`, tokens, or anything under `~/.secrets`. Store credentials only via
+  `EncryptedCredentialStore`, and don't loosen the network/cleartext config beyond what
+  self-hosted private-network use requires. See [SECURITY.md](SECURITY.md). A `gitleaks`
+  secret scan runs on every push (pre-push hook + CI).
+- **Commits:** [Conventional Commits](https://www.conventionalcommits.org)
+  (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:`). No
+  AI/assistant attribution in commits or PRs.
+- **Style:** idiomatic Kotlin; match the surrounding code's conventions and comment density.
+
+## Branches & pull requests
+
+New work lands on `develop` first; `master` is the protected, always-releasable branch (see
+[Development & release workflow](README.md#development--release-workflow)).
+
+1. Branch from `develop`: `git switch develop && git switch -c feature/my-change`.
+2. Open a PR **into `develop`**. Keep it focused and incremental; describe what changed and
+   how you verified it.
+3. CI (build + unit tests + CodeQL + secret scan) must pass, and review conversations must be
+   resolved, before merge.
+
+By contributing you agree your contributions are licensed under [GPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-Support%20the%20project-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/andrew65386)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg?style=for-the-badge)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/adebnar/hermes-android?style=for-the-badge&label=latest)](https://github.com/adebnar/hermes-android/releases/latest)
 
 A native Android client for the **Hermes agent gateway** — a phone-friendly companion to
 the Hermes Desktop app. It connects to a remote Hermes gateway over Tailscale, another
@@ -64,8 +65,8 @@ on your phone:
   verbosity), memory, MCP servers, API keys/environment variables, and **Diagnostics** (a
   toggleable, token-redacted, shareable debug log). Configuration edits are written to the
   live gateway config.
-- **Reliability** — automatic reconnect with offline banner and manual retry; expired
-  tokens route back to the setup screen.
+- **Reliability** — automatic reconnect with offline banner and manual retry; an expired
+  session re-authenticates automatically (password mode) or routes back to Setup (token mode).
 
 ---
 
@@ -285,6 +286,20 @@ everyone else gets the stable [latest release](https://github.com/adebnar/hermes
 Until those are set, tag-triggered builds will fail to sign — build/release locally with
 `./gradlew :app:assembleRelease` (or `:app:assembleBeta`) instead, which reads the
 gitignored `keystore.properties`.
+
+---
+
+## Contributing
+
+Contributions are welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)** for setup, the
+architecture/test conventions, and the branch workflow (new work lands on `develop` via PR).
+All participation is governed by the **[Code of Conduct](CODE_OF_CONDUCT.md)**.
+
+## Security
+
+Found a vulnerability? Please report it privately — see **[SECURITY.md](SECURITY.md)** for how
+to report and the app's security posture (encrypted credential storage, the token/basic-auth
+modes, the private-network/cleartext design, and supply-chain hygiene).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately** via GitHub's **"Report a vulnerability"**
+(Security → Advisories) on this repository, or by email to the maintainer. Do not open public
+issues for vulnerabilities. We aim to acknowledge within 72 hours.
+
+## Security posture
+
+Hermes for Android connects a phone to a **self-hosted** Hermes dashboard/gateway, so it
+handles sensitive credentials and an authenticated channel to systems that can read mail,
+files, and more. Practices in this codebase:
+
+- **Credentials at rest** are stored in `EncryptedSharedPreferences` (AES-256, Android
+  Keystore-backed) via `EncryptedCredentialStore`. The gateway URL, session token, and
+  username/password never hit plaintext storage.
+- **Two auth modes.** A loopback-bound dashboard authenticates with a session token
+  (`X-Hermes-Session-Token`). A network-bound (gated) dashboard requires a password provider —
+  the app logs in (`POST /auth/password-login`), holds a rotating session cookie, and mints a
+  single-use WebSocket ticket per connection. The token/cookies are sent over the configured
+  transport only.
+- **Cleartext is permitted by design** (`usesCleartextTraffic="true"`) for self-hosted
+  dashboards on a **private network** — Tailscale is WireGuard-encrypted and a LAN is trusted,
+  so confidentiality/integrity come from the network layer. For public-internet exposure,
+  front the dashboard with HTTPS (Tailscale Serve / a reverse proxy) and use an `https://` URL.
+- **No secrets in the repo.** `keystore.properties`, `keystore/`, `*.jks`/`*.keystore`,
+  `local.properties`, and `.env` are git-ignored. Release signing reads the gitignored
+  `keystore.properties`; signing material never enters git.
+- **Diagnostics redaction.** The optional in-app diagnostic log (Settings → Diagnostics) is
+  off by default and masks the session token before anything is recorded or shared.
+- **Dependency & supply-chain hygiene.** Toolchain and libraries are pinned via the Gradle
+  version catalog. CI runs `gitleaks` secret scanning (pre-push hook + workflow), CodeQL code
+  scanning, and a Dependabot dependency-graph submission scoped to the app's **shipped**
+  (release runtime) dependencies — so advisories focus on what actually reaches the APK rather
+  than the build toolchain.
+- **Least privilege** — only the permissions the feature set needs.
+
+## Scope
+
+The app trusts the dashboard/gateway the user configures. Securing the dashboard and the
+Hermes agent (authentication, TLS, network exposure) is the operator's responsibility — see
+the [README setup guide](README.md#first-run-setup) and the upstream Hermes docs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,8 +3,8 @@
 ## Reporting a vulnerability
 
 Please report security issues **privately** via GitHub's **"Report a vulnerability"**
-(Security → Advisories) on this repository, or by email to the maintainer. Do not open public
-issues for vulnerabilities. We aim to acknowledge within 72 hours.
+(Security → Advisories) on this repository. Do not open public issues for vulnerabilities.
+We aim to acknowledge within 72 hours.
 
 ## Security posture
 


### PR DESCRIPTION
Adds the community-health files (Code of Conduct, Contributing, Security policy) tailored to this app, and refreshes the README (Contributing + Security sections, latest-release badge, accurate reconnect/auth wording). GPL-3 licensing unchanged. Community files need to be on the default branch to register in GitHub's Community/Security tabs.