### PR TITLE
ci/docs: rename default branch master -> main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -32,14 +32,14 @@ fi
 
 # 2) Dependency vulnerability check (master/main only)
 if [ "$pushing_master" = "1" ]; then
-  echo "${grn}▶ dependency vulnerability check (master)…${rst}"
+  echo "${grn}▶ dependency vulnerability check (main)…${rst}"
   if command -v gh >/dev/null 2>&1; then
     n=$(gh api "repos/${repo_slug}/dependabot/alerts" --jq \
       '[.[] | select(.state=="open" and (.security_advisory.severity=="high" or .security_advisory.severity=="critical"))] | length' 2>/dev/null || echo "skip")
     if [ "$n" = "skip" ]; then
       echo "${ylw}⚠ could not query Dependabot alerts — verify manually before release.${rst}" >&2
     elif [ "${n:-0}" -gt 0 ] 2>/dev/null; then
-      fail "${n} open HIGH/CRITICAL Dependabot alert(s). Resolve before releasing to master."
+      fail "${n} open HIGH/CRITICAL Dependabot alert(s). Resolve before releasing to main."
     else
       echo "${grn}✓ no open high/critical Dependabot alerts${rst}"
     fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: CI
 # Uses an unsigned debug build, so it needs no secrets.
 on:
   push:
-    branches: [master, develop]
+    branches: [main, develop]
   pull_request:
-    branches: [master, develop]
+    branches: [main, develop]
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,9 @@ name: CodeQL
 # Static code-scanning for security vulnerabilities in the Kotlin/Java sources.
 on:
   push:
-    branches: [master, develop]
+    branches: [main, develop]
   pull_request:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"   # weekly, Monday 06:00 UTC
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,9 +4,9 @@ name: Security
 # (release runtime) dependencies.
 on:
   push:
-    branches: [master, develop]
+    branches: [main, develop]
   pull_request:
-    branches: [master, develop]
+    branches: [main, develop]
 
 jobs:
   secret-scan:
@@ -21,9 +21,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   dependency-graph:
-    # Submit the Gradle dependency graph to GitHub on master so Dependabot evaluates the
+    # Submit the Gradle dependency graph to GitHub on main so Dependabot evaluates the
     # SHIPPED dependency tree for advisories.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Branches & pull requests
 
-New work lands on `develop` first; `master` is the protected, always-releasable branch (see
+New work lands on `develop` first; `main` is the protected, always-releasable branch (see
 [Development & release workflow](README.md#development--release-workflow)).
 
 1. Branch from `develop`: `git switch develop && git switch -c feature/my-change`.

--- a/README.md
+++ b/README.md
@@ -242,14 +242,14 @@ the same Wi-Fi.
 
 | Branch | Role | Distribution |
 |--------|------|--------------|
-| `master` | Production / stable. Always releasable. | Stable releases (`v1.2.3`) |
+| `main` | Production / stable. Always releasable. | Stable releases (`v1.2.3`) |
 | `develop` | Beta / integration. New features land here first. | Beta pre-releases (`v1.2.3-beta.1`) |
 | `feature/*` | Short-lived work branches. | — (open a PR into `develop`) |
 
 Day-to-day flow:
 
 ```
-feature/x ──PR──▶ develop ──(stabilize)──▶ master
+feature/x ──PR──▶ develop ──(stabilize)──▶ main
                     │                         │
               beta pre-release          stable release
               v0.2.0-beta.1               v0.2.0
@@ -258,7 +258,7 @@ feature/x ──PR──▶ develop ──(stabilize)──▶ master
 1. Branch from `develop`: `git switch develop && git switch -c feature/my-change`.
 2. Open a PR into `develop`. CI (`.github/workflows/ci.yml`) builds and unit-tests every push/PR.
 3. Cut a **beta** for testers: tag a commit on `develop`, e.g. `git tag v0.2.0-beta.1 && git push --tags`.
-4. When stable, merge `develop` → `master` and tag the release: `git tag v0.2.0 && git push --tags`.
+4. When stable, merge `develop` → `main` and tag the release: `git tag v0.2.0 && git push --tags`.
 
 **Automated releases** (`.github/workflows/release.yml`) — pushing a `v*` tag builds a
 signed APK and publishes a GitHub Release:


### PR DESCRIPTION
Updates all master->main references (workflow triggers, dependency-graph push condition, README/CONTRIBUTING, pre-push wording) so CI/security/release keep working after the default branch is renamed. The GitHub branch rename (default + protection + open-PR retarget) is done immediately after this merges.