### PR TITLE
Fix launch crash: self-heal corrupted EncryptedSharedPreferences keyset

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.1.14"
+        versionCode = 16
+        versionName = "0.1.15"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/HermesApp.kt
+++ b/app/src/main/java/com/hermes/client/HermesApp.kt
@@ -1,6 +1,7 @@
 package com.hermes.client
 
 import android.app.Application
+import com.hermes.client.data.diagnostics.CrashReporter
 import com.hermes.client.data.diagnostics.DebugLog
 import com.hermes.client.data.repository.SettingsStore
 import dagger.hilt.android.HiltAndroidApp
@@ -20,6 +21,8 @@ class HermesApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // Capture uncaught exceptions to a file so the next launch can surface the trace (no adb).
+        CrashReporter.install(this)
         // Restore the diagnostic-logging toggle at launch so capture is active before the
         // Diagnostics screen is ever opened (e.g. to catch a failure on the first session open).
         settingsStore.debugLogging

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.hermes.client
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,10 +8,15 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.hermes.client.data.auth.CredentialStore
+import com.hermes.client.data.diagnostics.CrashReporter
 import com.hermes.client.data.repository.SettingsStore
 import com.hermes.client.data.repository.ThemeMode
+import com.hermes.client.ui.diagnostics.CrashReportScreen
 import com.hermes.client.ui.nav.HermesNav
 import com.hermes.client.ui.theme.HermesTheme
 import com.hermes.client.ui.theme.LocalToolCallTechnical
@@ -25,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val hasConfig = credentialStore.load() != null
+        val crashReport = CrashReporter.read(this)
         setContent {
             val mode by settingsStore.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
             val technical by settingsStore.toolCallTechnical.collectAsState(initial = true)
@@ -36,10 +43,32 @@ class MainActivity : ComponentActivity() {
             HermesTheme(darkTheme = dark) {
                 CompositionLocalProvider(LocalToolCallTechnical provides technical) {
                     Surface {
-                        HermesNav(hasConfig = hasConfig)
+                        // If the previous run crashed, show the saved trace first so it can be
+                        // shared, then continue into the app once dismissed.
+                        var report by remember { mutableStateOf(crashReport) }
+                        val current = report
+                        if (current != null) {
+                            CrashReportScreen(
+                                report = current,
+                                onShare = { shareCrash(current) },
+                                onDismiss = { CrashReporter.clear(this@MainActivity); report = null },
+                            )
+                        } else {
+                            HermesNav(hasConfig = hasConfig)
+                        }
                     }
                 }
             }
         }
+    }
+
+    /** Share the saved crash trace via the system share sheet. */
+    private fun shareCrash(report: String) {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, "Hermes Beta crash report")
+            putExtra(Intent.EXTRA_TEXT, report)
+        }
+        startActivity(Intent.createChooser(intent, "Share crash report"))
     }
 }

--- a/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
+++ b/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
@@ -1,25 +1,44 @@
 package com.hermes.client.data.auth
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import com.hermes.client.data.diagnostics.DebugLog
 
 /**
  * Concrete secure storage backed by EncryptedSharedPreferences (security-crypto 1.0.0).
  * If migrating to a newer backend later, only this file changes — callers depend on
  * the CredentialStore interface.
  */
-class EncryptedCredentialStore(context: Context) : CredentialStore {
-    private val prefs by lazy {
+class EncryptedCredentialStore(private val context: Context) : CredentialStore {
+    // EncryptedSharedPreferences keeps its Tink keyset inside this same prefs file. If that keyset
+    // is corrupted (e.g. an interrupted write or an app upgrade), create() throws
+    // InvalidProtocolBufferException and the app crashes on EVERY launch — before any UI. Recover
+    // by wiping the backing file once and regenerating a fresh keyset: the saved credentials are
+    // lost (the user re-enters them on the Setup screen), which is far better than a crash loop.
+    private val prefs by lazy { openOrReset() }
+
+    private fun create(): SharedPreferences {
         val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-        EncryptedSharedPreferences.create(
-            "hermes_credentials",
+        return EncryptedSharedPreferences.create(
+            PREFS_NAME,
             masterKeyAlias,
             context,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
         )
     }
+
+    private fun openOrReset(): SharedPreferences =
+        try {
+            create()
+        } catch (e: Exception) {
+            // Corrupt/unreadable keyset — reset the backing store and try once more.
+            DebugLog.log("auth", "credential store unreadable, resetting: ${e.javaClass.simpleName}")
+            runCatching { context.deleteSharedPreferences(PREFS_NAME) }
+            create()
+        }
 
     override fun load(): GatewayConfig? {
         val url = prefs.getString("base_url", null) ?: return null
@@ -42,5 +61,9 @@ class EncryptedCredentialStore(context: Context) : CredentialStore {
 
     override fun clear() {
         prefs.edit().clear().apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "hermes_credentials"
     }
 }

--- a/app/src/main/java/com/hermes/client/data/diagnostics/CrashReporter.kt
+++ b/app/src/main/java/com/hermes/client/data/diagnostics/CrashReporter.kt
@@ -1,0 +1,55 @@
+package com.hermes.client.data.diagnostics
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/**
+ * Captures otherwise-invisible crashes. On an uncaught exception the full stack trace (plus device
+ * + OS info) is written to a file; on the next launch [MainActivity] reads it and shows it on a
+ * screen the user can share. This turns a silent "app keeps crashing" into a copyable trace without
+ * needing adb/logcat. The token is redacted so a shared trace can't leak credentials.
+ */
+object CrashReporter {
+    private const val FILE = "last_crash.txt"
+
+    fun install(app: Application) {
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, error ->
+            runCatching {
+                val sw = StringWriter()
+                error.printStackTrace(PrintWriter(sw))
+                val trace = DebugLog.redact(sw.toString())
+                val version = runCatching {
+                    val pi = app.packageManager.getPackageInfo(app.packageName, 0)
+                    "${pi.versionName} (${pi.longVersionCode})"
+                }.getOrDefault("?")
+                val report = buildString {
+                    appendLine("Hermes Beta — crash report")
+                    appendLine("app: ${app.packageName} $version")
+                    appendLine("android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+                    appendLine("device: ${Build.MANUFACTURER} ${Build.MODEL}")
+                    appendLine("thread: ${thread.name}")
+                    appendLine()
+                    append(trace)
+                }
+                app.openFileOutput(FILE, Context.MODE_PRIVATE).use { it.write(report.toByteArray()) }
+            }
+            // Let the platform still terminate the process (and run any prior handler).
+            previous?.uncaughtException(thread, error)
+        }
+    }
+
+    /** The saved crash report, or null if there is none. */
+    fun read(ctx: Context): String? {
+        val f = File(ctx.filesDir, FILE)
+        return if (f.exists()) runCatching { f.readText() }.getOrNull() else null
+    }
+
+    fun clear(ctx: Context) {
+        runCatching { File(ctx.filesDir, FILE).delete() }
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
+++ b/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
@@ -79,7 +79,7 @@ object DebugLog {
         }
     }
 
-    private fun redact(message: String): String {
+    fun redact(message: String): String {
         val token = tokenToRedact ?: return message
         return message.replace(token, "***")
     }

--- a/app/src/main/java/com/hermes/client/ui/diagnostics/CrashReportScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/diagnostics/CrashReportScreen.kt
@@ -1,0 +1,61 @@
+package com.hermes.client.ui.diagnostics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Shown on the first launch after a crash (the trace was saved by [CrashReporter]). Lets the user
+ * share the stack trace so the crash can be diagnosed without adb, then continue into the app.
+ */
+@Composable
+fun CrashReportScreen(report: String, onShare: () -> Unit, onDismiss: () -> Unit) {
+    Surface(Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize().padding(16.dp)) {
+            Text("Hermes Beta crashed", style = MaterialTheme.typography.headlineSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "This is the crash details. Tap Share to send it to the developer, then continue.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            Surface(
+                Modifier.weight(1f).fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.small,
+            ) {
+                Text(
+                    report,
+                    modifier = Modifier.padding(12.dp).verticalScroll(rememberScrollState()),
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 11.sp,
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onShare) { Text("Share") }
+                Spacer(Modifier.width(4.dp))
+                OutlinedButton(onClick = onDismiss) { Text("Continue to app") }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Hermes Beta crashed on **every launch** (crash loop) for a user on a Pixel 10 Pro. Captured the real trace over USB:

```
Caused by: InvalidProtocolBufferException: Protocol message contained an invalid tag (zero).
  at androidx.security.crypto.EncryptedSharedPreferences.create(...)
  at EncryptedCredentialStore.load(EncryptedCredentialStore.kt:25)
  at MainActivity.onCreate(MainActivity.kt:27)
```

The Tink keyset backing `EncryptedSharedPreferences` corrupted (interrupted write / in-place upgrade). `create()` then throws on every launch in `onCreate`, before any UI — no recovery. **Pre-existing fragility**, unrelated to the session-parity work; that build merely surfaced it.

## Fix
`EncryptedCredentialStore` now catches an unreadable keyset, deletes the backing prefs file, and regenerates a fresh one. Saved credentials are lost (re-entered on the Setup screen) — far better than a permanent crash loop. **Verified on the affected device against the real corrupted keyset**: app recovered to the Setup screen, no crash.

## Also
Adds a global `CrashReporter` (uncaught-exception handler) that saves the trace and shows it on the next launch with a Share button — so future crashes are diagnosable without adb.

Bumps to 0.1.15 / 0.1.15-beta.
