### PR TITLE
Match desktop: hide cron + empty sessions from the list

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.1.15"
+        versionCode = 17
+        versionName = "0.1.16"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -7,6 +7,13 @@ import com.hermes.client.domain.ChatMessage
 import com.hermes.client.domain.Session
 import com.hermes.client.domain.toDomain
 
+/**
+ * Mirror the desktop session list: show interactive, used sessions only. Cron-created sessions
+ * live in the Cron view, and empty (0-message) sessions are scratch — both are hidden from the
+ * session list so the mobile counts match the desktop dashboard.
+ */
+private fun Session.isInteractive(): Boolean = source != "cron" && messageCount > 0
+
 class SessionRepository(private val rest: HermesRestApi) {
     suspend fun list(profile: String? = null): List<Session> =
         rest.sessions(limit = 50, offset = 0, profile = profile).map { it.toDomain() }
@@ -15,13 +22,16 @@ class SessionRepository(private val rest: HermesRestApi) {
      * All non-archived sessions across every profile, each tagged with its true profile.
      * This is the desktop-mirror list source — it replaces the single-profile [list] for the
      * sessions screen. The endpoint already excludes archived; the filter is defensive.
+     * [isInteractive] hides cron + empty sessions so the counts match the desktop dashboard.
      */
     suspend fun listAllProfiles(): List<Session> =
-        rest.profileSessions().sessions.map { it.toDomain() }.filter { !it.archived }
+        rest.profileSessions().sessions.map { it.toDomain() }
+            .filter { !it.archived && it.isInteractive() }
 
     /** All archived sessions across every profile (the cross-profile archived view). */
     suspend fun archivedAllProfiles(): List<Session> =
-        rest.profileSessions(archivedOnly = true).sessions.map { it.toDomain() }.filter { it.archived }
+        rest.profileSessions(archivedOnly = true).sessions.map { it.toDomain() }
+            .filter { it.archived && it.isInteractive() }
     suspend fun stats(profile: String? = null): SessionStatsDto = rest.sessionStats(profile)
     suspend fun search(query: String, profile: String? = null): List<SearchResultDto> =
         rest.searchSessions(query, profile)

--- a/app/src/test/java/com/hermes/client/data/repository/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/SessionRepositoryTest.kt
@@ -1,0 +1,44 @@
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesRestApi
+import com.hermes.client.data.network.ProfileSessionsDto
+import com.hermes.client.data.network.SessionDto
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionRepositoryTest {
+    private val rest = mockk<HermesRestApi>()
+    private val repo = SessionRepository(rest)
+
+    private fun dto(id: String, source: String?, msgs: Int, archived: Boolean = false) =
+        SessionDto(sessionId = id, source = source, messageCount = msgs, archived = archived, profile = "personal")
+
+    // Parity with desktop: the list hides cron-created and empty (0-message) sessions, so a
+    // profile shows the same count the desktop dashboard shows.
+    @Test fun listAllProfiles_hides_cron_and_empty_sessions() = runTest {
+        coEvery { rest.profileSessions(any(), false) } returns ProfileSessionsDto(
+            sessions = listOf(
+                dto("keep-tui", "tui", 5),
+                dto("hide-cron", "cron", 12),     // cron → hidden
+                dto("hide-empty", "tui", 0),       // 0 messages → hidden
+                dto("keep-dispatch", "hermes-dispatch", 2),
+                dto("hide-empty-cron", "cron", 0),
+            ),
+        )
+        assertEquals(listOf("keep-tui", "keep-dispatch"), repo.listAllProfiles().map { it.id })
+    }
+
+    @Test fun archivedAllProfiles_also_hides_cron_and_empty() = runTest {
+        coEvery { rest.profileSessions(any(), true) } returns ProfileSessionsDto(
+            sessions = listOf(
+                dto("a-keep", "cli", 3, archived = true),
+                dto("a-cron", "cron", 9, archived = true),
+                dto("a-empty", "tui", 0, archived = true),
+            ),
+        )
+        assertEquals(listOf("a-keep"), repo.archivedAllProfiles().map { it.id })
+    }
+}


### PR DESCRIPTION
## Problem
Mobile session counts didn't match the desktop dashboard (e.g. Personal **70** on mobile vs **27** on desktop), and real sessions were buried among cron entries. Diagnosed against the live gateway: the mobile list showed **every** source, while the desktop hides **cron**-created sessions (Cron view) and **empty** 0-message scratch sessions.

## Fix
`SessionRepository` filters the cross-profile active + archived lists to interactive, used sessions: `source != "cron" && messageCount > 0`.

Verified against the live gateway data:
- Personal: 70 → **27** (matches desktop exactly)
- Personal → No workspace: 48 → **13** (matches desktop exactly)
- The user's "missing" session (tui, 213 msgs) is retained and no longer buried.

Bumps to 0.1.16 / 0.1.16-beta. +2 unit tests.
