### PR TITLE
Scope session list to the active profile

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 17
-        versionName = "0.1.16"
+        versionCode = 18
+        versionName = "0.1.17"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
@@ -31,15 +31,17 @@ class ArchivedSessionsViewModel @Inject constructor(
     val activeProfile: StateFlow<String?> = profileManager.active
 
     init {
-        // The archived view now spans all profiles (desktop mirror), so it loads once rather than
-        // reloading per profile switch. The screen refreshes on ON_RESUME.
-        refresh()
+        // Scoped to the active profile, matching the main list — reload when the profile changes.
+        viewModelScope.launch { profileManager.active.collect { refresh() } }
     }
 
     fun refresh() = viewModelScope.launch {
         _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
         try {
-            _state.value = ArchivedUiState(sessions = sessions.archivedAllProfiles())
+            val active = profileManager.active.value
+            val all = sessions.archivedAllProfiles()
+            val list = if (active.isNullOrBlank()) all else all.filter { it.profile == active }
+            _state.value = ArchivedUiState(sessions = list)
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = ArchivedUiState(unauthorized = true)
             else _state.value = ArchivedUiState(error = e.message ?: "Failed to load")

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -63,18 +63,20 @@ class SessionsViewModel @Inject constructor(
     init {
         chat.connect()
         viewModelScope.launch { profileManager.refresh() }
-        // The list now spans all profiles (desktop mirror), so it no longer reloads on a profile
-        // switch — the contents are identical regardless of which profile is active. Load once;
-        // the screen's ON_RESUME effect refreshes after creating/updating a session in a chat.
-        refresh()
+        // The list is scoped to the active profile (like the desktop, one tenant at a time), so it
+        // reloads whenever the selected profile changes — including the first value once it loads.
+        viewModelScope.launch { profileManager.active.collect { refresh() } }
     }
 
     fun refresh() = viewModelScope.launch {
         _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
         try {
-            // Cross-profile: every session carries its true profile, so the app no longer guesses
-            // the profile from the active selection (the root cause of "wrong profile shown").
-            val list = sessions.listAllProfiles()
+            // Fetch the cross-profile list (true per-session profile + cron/empty already filtered),
+            // then scope to the active profile so only that tenant's sessions show. Until the active
+            // profile is known, fall back to showing everything rather than a blank list.
+            val active = profileManager.active.value
+            val all = sessions.listAllProfiles()
+            val list = if (active.isNullOrBlank()) all else all.filter { it.profile == active }
             _state.value = SessionsUiState(sessions = list)
         } catch (e: HermesApiException) {
             if (e.code == 401) {

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -85,10 +85,9 @@ class SessionsViewModelTest {
         assertEquals(2, ids.size)
     }
 
-    // T1: the list spans every profile (desktop mirror), and each session keeps its OWN profile
-    // — not the active one. This is the fix for "wrong profile shown": the app no longer guesses
-    // the profile from the active selection.
-    @Test fun list_spans_all_profiles_each_with_its_own_profile() = runTest {
+    // The list is scoped to the active profile (one tenant at a time, like the desktop): a session
+    // from another profile is filtered out, and each shown session keeps its own true profile.
+    @Test fun list_is_scoped_to_active_profile() = runTest {
         coEvery { sessionRepo.listAllProfiles() } returns listOf(
             session("s1", "mine", profile = "personal"),
             session("s2", "client", profile = "odos"),
@@ -96,10 +95,8 @@ class SessionsViewModelTest {
         val vm = buildVm() // active profile is "personal"
         advanceUntilIdle()
 
-        val byId = vm.state.value.sessions.associateBy { it.id }
-        assertEquals(setOf("s1", "s2"), byId.keys)
-        assertEquals("personal", byId["s1"]?.profile)
-        assertEquals("odos", byId["s2"]?.profile) // not coerced to the active "personal"
+        assertEquals(listOf("s1"), vm.state.value.sessions.map { it.id })
+        assertEquals("personal", vm.state.value.sessions.single().profile)
     }
 
     // T5: in the cross-profile list, a session is pinned by its OWN profile token — so a pin made

--- a/docs/ideas/mobile-desktop-parity.md
+++ b/docs/ideas/mobile-desktop-parity.md
@@ -71,8 +71,12 @@ profile when opening a session from another profile; archive refresh verified;
   current "wrong profile" bug; use the server's `profile` field instead.
 
 ## Resolved Decisions
-- Default view: **all-profiles** (true desktop mirror), not single-active-profile.
-- Opening a session from another profile: **auto-switch** the active profile to it.
+- View scope: **active profile only** (one tenant at a time, switched via the drawer —
+  how the desktop actually behaves). *Superseded the initial all-profiles choice after
+  hands-on use (0.1.17).*
+- Opening a session from another profile: **auto-switch** the active profile to it
+  (now effectively a no-op since the list is single-profile, but retained for safety).
+- List contents match desktop: **cron** and **empty (0-message)** sessions are hidden (0.1.16).
 
 ## Status — implemented in 0.1.14-beta (branch `feature/session-parity`)
 - T1 ✅ list sources from `/api/profiles/sessions` (all profiles, true per-session profile)


### PR DESCRIPTION
After hands-on use, the all-profiles "desktop mirror" list is reverted to show **only the active profile's** sessions — one tenant at a time, switched via the drawer, matching how the desktop dashboard behaves.

- Main + archived lists filter to the active profile and reload on profile change.
- Each session still carries its true profile, so counts/grouping stay correct.
- Combined with the 0.1.16 cron/empty filter, a profile shows exactly the desktop's set.

Bumps to 0.1.17 / 0.1.17-beta.
