### PR TITLE
Fix archive/delete/rename silently failing (missing profile → 404)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 18
-        versionName = "0.1.17"
+        versionCode = 19
+        versionName = "0.1.18"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
@@ -123,15 +123,22 @@ class HermesRestApi(
         }
     }
 
-    /** Rename and/or archive a session via PATCH /api/sessions/{id}. */
+    /**
+     * Rename and/or archive a session via PATCH /api/sessions/{id}. [profile] MUST identify the
+     * session's profile (sent in the body): the gateway resolves the session against a per-profile
+     * DB, and without it a session in a non-default profile returns 404 — so the archive/rename
+     * silently no-ops and the session never leaves the list.
+     */
     suspend fun patchSession(
         sessionId: String,
         title: String? = null,
         archived: Boolean? = null,
+        profile: String? = null,
     ) = withContext(Dispatchers.IO) {
         val obj: JsonObject = buildJsonObject {
             if (title != null) put("title", title)
             if (archived != null) put("archived", archived)
+            if (!profile.isNullOrBlank()) put("profile", profile)
         }
         val payload = json.encodeToString(JsonObject.serializer(), obj)
             .toRequestBody("application/json".toMediaType())
@@ -140,8 +147,10 @@ class HermesRestApi(
         }
     }
 
-    suspend fun deleteSession(sessionId: String) = withContext(Dispatchers.IO) {
-        okHttp.newCall(builder("/api/sessions/$sessionId").delete().build()).execute().use { resp ->
+    /** Delete a session. [profile] (query param) scopes it to the right per-profile DB. */
+    suspend fun deleteSession(sessionId: String, profile: String? = null) = withContext(Dispatchers.IO) {
+        val path = "/api/sessions/$sessionId${profileParam(profile, first = true)}"
+        okHttp.newCall(builder(path).delete().build()).execute().use { resp ->
             if (!resp.isSuccessful) throw HermesApiException(resp.code, "delete session failed")
         }
     }

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -46,8 +46,11 @@ class SessionRepository(private val rest: HermesRestApi) {
             m.copy(id = "h-$i-${m.id}")
         }
 
-    suspend fun rename(sessionId: String, title: String) = rest.patchSession(sessionId, title = title)
-    suspend fun archive(sessionId: String, archived: Boolean) =
-        rest.patchSession(sessionId, archived = archived)
-    suspend fun delete(sessionId: String) = rest.deleteSession(sessionId)
+    // All mutations carry the session's profile so the gateway hits the right per-profile DB
+    // (otherwise the call 404s and the change silently no-ops).
+    suspend fun rename(sessionId: String, title: String, profile: String?) =
+        rest.patchSession(sessionId, title = title, profile = profile)
+    suspend fun archive(sessionId: String, archived: Boolean, profile: String?) =
+        rest.patchSession(sessionId, archived = archived, profile = profile)
+    suspend fun delete(sessionId: String, profile: String?) = rest.deleteSession(sessionId, profile)
 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
@@ -73,8 +73,8 @@ fun ArchivedSessionsScreen(
                         ArchivedRow(
                             session = s,
                             onOpen = { onOpen(s.id) },
-                            onUnarchive = { vm.unarchive(s.id) },
-                            onDelete = { vm.delete(s.id) },
+                            onUnarchive = { vm.unarchive(s) },
+                            onDelete = { vm.delete(s) },
                         )
                     }
                 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
@@ -51,11 +51,11 @@ class ArchivedSessionsViewModel @Inject constructor(
     }
 
     /** Restore an archived session to the active list, then refresh so it leaves this view. */
-    fun unarchive(sessionId: String) = viewModelScope.launch {
-        runCatching { sessions.archive(sessionId, archived = false) }.onSuccess { refresh() }
+    fun unarchive(session: Session) = viewModelScope.launch {
+        runCatching { sessions.archive(session.id, archived = false, session.profile) }.onSuccess { refresh() }
     }
 
-    fun delete(sessionId: String) = viewModelScope.launch {
-        runCatching { sessions.delete(sessionId) }.onSuccess { refresh() }
+    fun delete(session: Session) = viewModelScope.launch {
+        runCatching { sessions.delete(session.id, session.profile) }.onSuccess { refresh() }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -182,9 +182,9 @@ fun SessionsScreen(
                                     // so the chat resumes against the right per-profile DB.
                                     onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                     onTogglePin = { vm.togglePin(s) },
-                                    onRename = { vm.rename(s.id, it) },
-                                    onArchive = { vm.archive(s.id) },
-                                    onDelete = { vm.delete(s.id) },
+                                    onRename = { vm.rename(s, it) },
+                                    onArchive = { vm.archive(s) },
+                                    onDelete = { vm.delete(s) },
                                 )
                             }
                         }
@@ -224,9 +224,9 @@ fun SessionsScreen(
                                         isPinned = false,
                                         onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                         onTogglePin = { vm.togglePin(s) },
-                                        onRename = { vm.rename(s.id, it) },
-                                        onArchive = { vm.archive(s.id) },
-                                        onDelete = { vm.delete(s.id) },
+                                        onRename = { vm.rename(s, it) },
+                                        onArchive = { vm.archive(s) },
+                                        onDelete = { vm.delete(s) },
                                     )
                                 }
                             }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -132,17 +132,18 @@ class SessionsViewModel @Inject constructor(
     /** Returns the new session id, or null if creation failed (so the UI doesn't crash). */
     suspend fun createSession(): String? = runCatching { chat.createSession() }.getOrNull()
 
-    fun rename(sessionId: String, title: String) = viewModelScope.launch {
-        runCatching { sessions.rename(sessionId, title) }.onSuccess { refresh() }
+    fun rename(session: Session, title: String) = viewModelScope.launch {
+        runCatching { sessions.rename(session.id, title, session.profile) }.onSuccess { refresh() }
     }
 
-    fun archive(sessionId: String) = viewModelScope.launch {
-        // Archiving removes it from the default (archived=exclude) list.
-        runCatching { sessions.archive(sessionId, archived = true) }.onSuccess { refresh() }
+    fun archive(session: Session) = viewModelScope.launch {
+        // Archiving removes it from the active list — must carry the session's profile or the
+        // gateway 404s (wrong per-profile DB) and the session never disappears.
+        runCatching { sessions.archive(session.id, archived = true, session.profile) }.onSuccess { refresh() }
     }
 
-    fun delete(sessionId: String) = viewModelScope.launch {
-        runCatching { sessions.delete(sessionId) }.onSuccess { refresh() }
+    fun delete(session: Session) = viewModelScope.launch {
+        runCatching { sessions.delete(session.id, session.profile) }.onSuccess { refresh() }
     }
 
     /** Pin/unpin keyed by the session's OWN profile, so it works regardless of the active one. */

--- a/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
@@ -48,9 +48,9 @@ class ArchivedSessionsViewModelTest {
         advanceUntilIdle()
         // After restoring, the session is no longer archived, so the reloaded list is empty.
         coEvery { sessionRepo.archivedAllProfiles() } returns emptyList()
-        vm.unarchive("a1")
+        vm.unarchive(session("a1"))
         advanceUntilIdle()
-        coVerify { sessionRepo.archive("a1", archived = false) }
+        coVerify { sessionRepo.archive("a1", archived = false, "personal") }
         assertEquals(emptyList<String>(), vm.state.value.sessions.map { it.id })
     }
 
@@ -59,9 +59,9 @@ class ArchivedSessionsViewModelTest {
         val vm = buildVm()
         advanceUntilIdle()
         coEvery { sessionRepo.archivedAllProfiles() } returns emptyList()
-        vm.delete("a1")
+        vm.delete(session("a1"))
         advanceUntilIdle()
-        coVerify { sessionRepo.delete("a1") }
+        coVerify { sessionRepo.delete("a1", "personal") }
         assertEquals(emptyList<String>(), vm.state.value.sessions.map { it.id })
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -123,6 +123,18 @@ class SessionsViewModelTest {
         io.mockk.coVerify { pinStore.toggle("odos/s2") }
     }
 
+    // Archiving must carry the session's profile, or the gateway PATCH 404s against the wrong
+    // per-profile DB and the session never leaves the list (looks like "refresh doesn't work").
+    @Test fun archive_passes_session_profile() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.archive(session("s1", "mine", profile = "personal"))
+        advanceUntilIdle()
+        io.mockk.coVerify { sessionRepo.archive("s1", archived = true, "personal") }
+    }
+
     // T3: opening a session from another profile must switch the active profile first, so the
     // chat resumes against the correct per-profile DB.
     @Test fun prepareOpen_switches_to_session_profile_when_different() = runTest {


### PR DESCRIPTION
## Problem
Archiving a session did nothing — it stayed in the list ("page doesn't refresh"). `PATCH /api/sessions/{id}` was sent **without a profile**, so the gateway resolved it against the wrong per-profile DB and returned **404**; the change silently no-op'd.

Verified on the live gateway:
- `PATCH {archived:true}` (no profile) → **404**, archived unchanged
- `PATCH {archived:true, profile:"personal"}` → **200**, archived=1

## Fix
All session mutations now carry the session's profile — PATCH in the body (`profile`), DELETE as `?profile=`:
- `archive`, `rename`, `delete` (main list) and `unarchive`, `delete` (archived view)

Bumps to 0.1.18 / 0.1.18-beta. +1 regression test.
