### PR TITLE
Release 0.1.18: session parity + crash/sync fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 17
-        versionName = "0.1.16"
+        versionCode = 18
+        versionName = "0.1.17"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.1.15"
+        versionCode = 17
+        versionName = "0.1.16"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 13
-        versionName = "0.1.12"
+        versionCode = 14
+        versionName = "0.1.13"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "0.1.13"
+        versionCode = 15
+        versionName = "0.1.14"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.1.14"
+        versionCode = 16
+        versionName = "0.1.15"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 18
-        versionName = "0.1.17"
+        versionCode = 19
+        versionName = "0.1.18"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/HermesApp.kt
+++ b/app/src/main/java/com/hermes/client/HermesApp.kt
@@ -1,6 +1,7 @@
 package com.hermes.client
 
 import android.app.Application
+import com.hermes.client.data.diagnostics.CrashReporter
 import com.hermes.client.data.diagnostics.DebugLog
 import com.hermes.client.data.repository.SettingsStore
 import dagger.hilt.android.HiltAndroidApp
@@ -20,6 +21,8 @@ class HermesApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // Capture uncaught exceptions to a file so the next launch can surface the trace (no adb).
+        CrashReporter.install(this)
         // Restore the diagnostic-logging toggle at launch so capture is active before the
         // Diagnostics screen is ever opened (e.g. to catch a failure on the first session open).
         settingsStore.debugLogging

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.hermes.client
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,10 +8,15 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.hermes.client.data.auth.CredentialStore
+import com.hermes.client.data.diagnostics.CrashReporter
 import com.hermes.client.data.repository.SettingsStore
 import com.hermes.client.data.repository.ThemeMode
+import com.hermes.client.ui.diagnostics.CrashReportScreen
 import com.hermes.client.ui.nav.HermesNav
 import com.hermes.client.ui.theme.HermesTheme
 import com.hermes.client.ui.theme.LocalToolCallTechnical
@@ -25,6 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val hasConfig = credentialStore.load() != null
+        val crashReport = CrashReporter.read(this)
         setContent {
             val mode by settingsStore.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
             val technical by settingsStore.toolCallTechnical.collectAsState(initial = true)
@@ -36,10 +43,32 @@ class MainActivity : ComponentActivity() {
             HermesTheme(darkTheme = dark) {
                 CompositionLocalProvider(LocalToolCallTechnical provides technical) {
                     Surface {
-                        HermesNav(hasConfig = hasConfig)
+                        // If the previous run crashed, show the saved trace first so it can be
+                        // shared, then continue into the app once dismissed.
+                        var report by remember { mutableStateOf(crashReport) }
+                        val current = report
+                        if (current != null) {
+                            CrashReportScreen(
+                                report = current,
+                                onShare = { shareCrash(current) },
+                                onDismiss = { CrashReporter.clear(this@MainActivity); report = null },
+                            )
+                        } else {
+                            HermesNav(hasConfig = hasConfig)
+                        }
                     }
                 }
             }
         }
+    }
+
+    /** Share the saved crash trace via the system share sheet. */
+    private fun shareCrash(report: String) {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, "Hermes Beta crash report")
+            putExtra(Intent.EXTRA_TEXT, report)
+        }
+        startActivity(Intent.createChooser(intent, "Share crash report"))
     }
 }

--- a/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
+++ b/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
@@ -34,10 +34,25 @@ class EncryptedCredentialStore(private val context: Context) : CredentialStore {
         try {
             create()
         } catch (e: Exception) {
-            // Corrupt/unreadable keyset — reset the backing store and try once more.
+            // Corrupt/unreadable keyset. EncryptedSharedPreferences stores its keyset inside the
+            // PREFS_NAME file, so deleting that and recreating recovers it (verified on a physical
+            // device). If a second attempt still fails the corruption is deeper — the master key in
+            // the Android keystore — so drop that too and regenerate everything, guaranteeing we
+            // never crash-loop on launch.
             DebugLog.log("auth", "credential store unreadable, resetting: ${e.javaClass.simpleName}")
             runCatching { context.deleteSharedPreferences(PREFS_NAME) }
-            create()
+            try {
+                create()
+            } catch (e2: Exception) {
+                DebugLog.log("auth", "reset insufficient, clearing master key: ${e2.javaClass.simpleName}")
+                runCatching {
+                    java.security.KeyStore.getInstance("AndroidKeyStore")
+                        .apply { load(null) }
+                        .deleteEntry(MASTER_KEY_ALIAS)
+                }
+                runCatching { context.deleteSharedPreferences(PREFS_NAME) }
+                create()
+            }
         }
 
     override fun load(): GatewayConfig? {
@@ -65,5 +80,9 @@ class EncryptedCredentialStore(private val context: Context) : CredentialStore {
 
     private companion object {
         const val PREFS_NAME = "hermes_credentials"
+        // Default Android-keystore alias used by MasterKeys.AES256_GCM_SPEC (the constant itself is
+        // package-private). Deleting this entry forces a fresh master key if the keyset reset alone
+        // didn't recover.
+        const val MASTER_KEY_ALIAS = "_androidx_security_master_key_"
     }
 }

--- a/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
+++ b/app/src/main/java/com/hermes/client/data/auth/EncryptedCredentialStore.kt
@@ -1,25 +1,44 @@
 package com.hermes.client.data.auth
 
 import android.content.Context
+import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
+import com.hermes.client.data.diagnostics.DebugLog
 
 /**
  * Concrete secure storage backed by EncryptedSharedPreferences (security-crypto 1.0.0).
  * If migrating to a newer backend later, only this file changes — callers depend on
  * the CredentialStore interface.
  */
-class EncryptedCredentialStore(context: Context) : CredentialStore {
-    private val prefs by lazy {
+class EncryptedCredentialStore(private val context: Context) : CredentialStore {
+    // EncryptedSharedPreferences keeps its Tink keyset inside this same prefs file. If that keyset
+    // is corrupted (e.g. an interrupted write or an app upgrade), create() throws
+    // InvalidProtocolBufferException and the app crashes on EVERY launch — before any UI. Recover
+    // by wiping the backing file once and regenerating a fresh keyset: the saved credentials are
+    // lost (the user re-enters them on the Setup screen), which is far better than a crash loop.
+    private val prefs by lazy { openOrReset() }
+
+    private fun create(): SharedPreferences {
         val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-        EncryptedSharedPreferences.create(
-            "hermes_credentials",
+        return EncryptedSharedPreferences.create(
+            PREFS_NAME,
             masterKeyAlias,
             context,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
         )
     }
+
+    private fun openOrReset(): SharedPreferences =
+        try {
+            create()
+        } catch (e: Exception) {
+            // Corrupt/unreadable keyset — reset the backing store and try once more.
+            DebugLog.log("auth", "credential store unreadable, resetting: ${e.javaClass.simpleName}")
+            runCatching { context.deleteSharedPreferences(PREFS_NAME) }
+            create()
+        }
 
     override fun load(): GatewayConfig? {
         val url = prefs.getString("base_url", null) ?: return null
@@ -42,5 +61,9 @@ class EncryptedCredentialStore(context: Context) : CredentialStore {
 
     override fun clear() {
         prefs.edit().clear().apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "hermes_credentials"
     }
 }

--- a/app/src/main/java/com/hermes/client/data/diagnostics/CrashReporter.kt
+++ b/app/src/main/java/com/hermes/client/data/diagnostics/CrashReporter.kt
@@ -1,0 +1,55 @@
+package com.hermes.client.data.diagnostics
+
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/**
+ * Captures otherwise-invisible crashes. On an uncaught exception the full stack trace (plus device
+ * + OS info) is written to a file; on the next launch [MainActivity] reads it and shows it on a
+ * screen the user can share. This turns a silent "app keeps crashing" into a copyable trace without
+ * needing adb/logcat. The token is redacted so a shared trace can't leak credentials.
+ */
+object CrashReporter {
+    private const val FILE = "last_crash.txt"
+
+    fun install(app: Application) {
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, error ->
+            runCatching {
+                val sw = StringWriter()
+                error.printStackTrace(PrintWriter(sw))
+                val trace = DebugLog.redact(sw.toString())
+                val version = runCatching {
+                    val pi = app.packageManager.getPackageInfo(app.packageName, 0)
+                    "${pi.versionName} (${pi.longVersionCode})"
+                }.getOrDefault("?")
+                val report = buildString {
+                    appendLine("Hermes Beta — crash report")
+                    appendLine("app: ${app.packageName} $version")
+                    appendLine("android: ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
+                    appendLine("device: ${Build.MANUFACTURER} ${Build.MODEL}")
+                    appendLine("thread: ${thread.name}")
+                    appendLine()
+                    append(trace)
+                }
+                app.openFileOutput(FILE, Context.MODE_PRIVATE).use { it.write(report.toByteArray()) }
+            }
+            // Let the platform still terminate the process (and run any prior handler).
+            previous?.uncaughtException(thread, error)
+        }
+    }
+
+    /** The saved crash report, or null if there is none. */
+    fun read(ctx: Context): String? {
+        val f = File(ctx.filesDir, FILE)
+        return if (f.exists()) runCatching { f.readText() }.getOrNull() else null
+    }
+
+    fun clear(ctx: Context) {
+        runCatching { File(ctx.filesDir, FILE).delete() }
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
+++ b/app/src/main/java/com/hermes/client/data/diagnostics/DebugLog.kt
@@ -79,7 +79,7 @@ object DebugLog {
         }
     }
 
-    private fun redact(message: String): String {
+    fun redact(message: String): String {
         val token = tokenToRedact ?: return message
         return message.replace(token, "***")
     }

--- a/app/src/main/java/com/hermes/client/data/network/Dtos.kt
+++ b/app/src/main/java/com/hermes/client/data/network/Dtos.kt
@@ -20,10 +20,25 @@ import kotlinx.serialization.Serializable
     @SerialName("last_active") val lastActive: Double? = null,
     @SerialName("message_count") val messageCount: Int = 0,
     val profile: String? = null,
+    @SerialName("is_default_profile") val isDefaultProfile: Boolean = false,
+    val archived: Boolean = false,
     val cwd: String? = null,
     val source: String? = null,
 )
 @Serializable data class SessionListDto(val sessions: List<SessionDto> = emptyList())
+
+/**
+ * Cross-profile session list (`/api/profiles/sessions`). Unlike `/api/sessions?profile=`,
+ * every session here carries its true `profile`, so the list can show all tenants at once
+ * with each session under the profile it actually belongs to. [profileTotals] maps profile
+ * name → session count (used for group headers); [errors] lists any profiles that failed to load.
+ */
+@Serializable data class ProfileSessionsDto(
+    val sessions: List<SessionDto> = emptyList(),
+    val total: Int = 0,
+    @SerialName("profile_totals") val profileTotals: Map<String, Int> = emptyMap(),
+    val errors: List<String> = emptyList(),
+)
 
 @Serializable data class MessageDto(
     // The gateway returns a numeric message id, and content may be null (e.g. tool-only turns).

--- a/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
@@ -123,15 +123,22 @@ class HermesRestApi(
         }
     }
 
-    /** Rename and/or archive a session via PATCH /api/sessions/{id}. */
+    /**
+     * Rename and/or archive a session via PATCH /api/sessions/{id}. [profile] MUST identify the
+     * session's profile (sent in the body): the gateway resolves the session against a per-profile
+     * DB, and without it a session in a non-default profile returns 404 — so the archive/rename
+     * silently no-ops and the session never leaves the list.
+     */
     suspend fun patchSession(
         sessionId: String,
         title: String? = null,
         archived: Boolean? = null,
+        profile: String? = null,
     ) = withContext(Dispatchers.IO) {
         val obj: JsonObject = buildJsonObject {
             if (title != null) put("title", title)
             if (archived != null) put("archived", archived)
+            if (!profile.isNullOrBlank()) put("profile", profile)
         }
         val payload = json.encodeToString(JsonObject.serializer(), obj)
             .toRequestBody("application/json".toMediaType())
@@ -140,8 +147,10 @@ class HermesRestApi(
         }
     }
 
-    suspend fun deleteSession(sessionId: String) = withContext(Dispatchers.IO) {
-        okHttp.newCall(builder("/api/sessions/$sessionId").delete().build()).execute().use { resp ->
+    /** Delete a session. [profile] (query param) scopes it to the right per-profile DB. */
+    suspend fun deleteSession(sessionId: String, profile: String? = null) = withContext(Dispatchers.IO) {
+        val path = "/api/sessions/$sessionId${profileParam(profile, first = true)}"
+        okHttp.newCall(builder(path).delete().build()).execute().use { resp ->
             if (!resp.isSuccessful) throw HermesApiException(resp.code, "delete session failed")
         }
     }

--- a/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
@@ -76,6 +76,15 @@ class HermesRestApi(
             "/api/sessions?limit=$limit&offset=$offset&order=recent${profileParam(profile)}",
         ).sessions
 
+    /**
+     * Cross-profile session list — every session tagged with its true `profile`, plus
+     * `profile_totals` for group headers. The active list excludes archived by default;
+     * pass [archivedOnly] to fetch only archived sessions (`?archived=only`). One page of
+     * [limit] covers current volume (no offset paging in MVP).
+     */
+    suspend fun profileSessions(limit: Int = 500, archivedOnly: Boolean = false): ProfileSessionsDto =
+        get("/api/profiles/sessions?limit=$limit&order=recent${if (archivedOnly) "&archived=only" else ""}")
+
     suspend fun messages(sessionId: String, profile: String? = null): List<MessageDto> =
         get<MessagesDto>("/api/sessions/$sessionId/messages${profileParam(profile, first = true)}").messages
 

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -57,12 +57,18 @@ class ChatRepository(private val client: HermesGatewayClient) {
         })
     }
 
-    /** Execute a slash command (e.g. "/help"). The response streams back via the event flow. */
-    suspend fun slashExec(sessionId: String, command: String) {
-        client.call("slash.exec", buildJsonObject {
+    /**
+     * Execute a slash command (e.g. "/help", "/model …"). Returns the command's text output
+     * (the gateway's `output` field) so callers can surface the result — a `/model` switch, for
+     * instance, reports success or an error like "Could not resolve credentials for …" here. A
+     * transport/worker failure (e.g. "slash worker closed pipe") throws instead.
+     */
+    suspend fun slashExec(sessionId: String, command: String): String? {
+        val result = client.call("slash.exec", buildJsonObject {
             put("session_id", sessionId)
             put("command", command)
         })
+        return result.jsonObject["output"]?.jsonPrimitive?.content
     }
 
     /** "@" path/mention completions (complete.path → {items:[{text,display,meta}]}). */

--- a/app/src/main/java/com/hermes/client/data/repository/GroupExpansionStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/GroupExpansionStore.kt
@@ -1,0 +1,37 @@
+package com.hermes.client.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.groupExpansionDataStore by preferencesDataStore(name = "session_group_expansion")
+
+/**
+ * Device-local store of which session-list groups are collapsed. Groups default to expanded, so
+ * only the *collapsed* keys are persisted — an empty set means everything is open. Keys are built
+ * by [profileKey]/[workspaceKey] so a profile group and a workspace group never collide.
+ */
+class GroupExpansionStore(private val context: Context) {
+    private val key = stringSetPreferencesKey("collapsed")
+
+    /** The set of currently-collapsed group keys. */
+    val collapsed: Flow<Set<String>> = context.groupExpansionDataStore.data.map { it[key] ?: emptySet() }
+
+    suspend fun toggle(groupKey: String) {
+        context.groupExpansionDataStore.edit { prefs ->
+            val cur = prefs[key] ?: emptySet()
+            prefs[key] = if (groupKey in cur) cur - groupKey else cur + groupKey
+        }
+    }
+
+    companion object {
+        /** Collapse key for a profile (top tier). */
+        fun profileKey(profile: String?) = "p:${profile ?: "default"}"
+
+        /** Collapse key for a workspace within a profile (sub tier). */
+        fun workspaceKey(profile: String?, workspace: String) = "w:${profile ?: "default"}/$workspace"
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -7,6 +7,13 @@ import com.hermes.client.domain.ChatMessage
 import com.hermes.client.domain.Session
 import com.hermes.client.domain.toDomain
 
+/**
+ * Mirror the desktop session list: show interactive, used sessions only. Cron-created sessions
+ * live in the Cron view, and empty (0-message) sessions are scratch — both are hidden from the
+ * session list so the mobile counts match the desktop dashboard.
+ */
+private fun Session.isInteractive(): Boolean = source != "cron" && messageCount > 0
+
 class SessionRepository(private val rest: HermesRestApi) {
     suspend fun list(profile: String? = null): List<Session> =
         rest.sessions(limit = 50, offset = 0, profile = profile).map { it.toDomain() }
@@ -15,13 +22,16 @@ class SessionRepository(private val rest: HermesRestApi) {
      * All non-archived sessions across every profile, each tagged with its true profile.
      * This is the desktop-mirror list source — it replaces the single-profile [list] for the
      * sessions screen. The endpoint already excludes archived; the filter is defensive.
+     * [isInteractive] hides cron + empty sessions so the counts match the desktop dashboard.
      */
     suspend fun listAllProfiles(): List<Session> =
-        rest.profileSessions().sessions.map { it.toDomain() }.filter { !it.archived }
+        rest.profileSessions().sessions.map { it.toDomain() }
+            .filter { !it.archived && it.isInteractive() }
 
     /** All archived sessions across every profile (the cross-profile archived view). */
     suspend fun archivedAllProfiles(): List<Session> =
-        rest.profileSessions(archivedOnly = true).sessions.map { it.toDomain() }.filter { it.archived }
+        rest.profileSessions(archivedOnly = true).sessions.map { it.toDomain() }
+            .filter { it.archived && it.isInteractive() }
     suspend fun stats(profile: String? = null): SessionStatsDto = rest.sessionStats(profile)
     suspend fun search(query: String, profile: String? = null): List<SearchResultDto> =
         rest.searchSessions(query, profile)

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -18,6 +18,10 @@ class SessionRepository(private val rest: HermesRestApi) {
      */
     suspend fun listAllProfiles(): List<Session> =
         rest.profileSessions().sessions.map { it.toDomain() }.filter { !it.archived }
+
+    /** All archived sessions across every profile (the cross-profile archived view). */
+    suspend fun archivedAllProfiles(): List<Session> =
+        rest.profileSessions(archivedOnly = true).sessions.map { it.toDomain() }.filter { it.archived }
     suspend fun stats(profile: String? = null): SessionStatsDto = rest.sessionStats(profile)
     suspend fun search(query: String, profile: String? = null): List<SearchResultDto> =
         rest.searchSessions(query, profile)

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -10,6 +10,14 @@ import com.hermes.client.domain.toDomain
 class SessionRepository(private val rest: HermesRestApi) {
     suspend fun list(profile: String? = null): List<Session> =
         rest.sessions(limit = 50, offset = 0, profile = profile).map { it.toDomain() }
+
+    /**
+     * All non-archived sessions across every profile, each tagged with its true profile.
+     * This is the desktop-mirror list source — it replaces the single-profile [list] for the
+     * sessions screen. The endpoint already excludes archived; the filter is defensive.
+     */
+    suspend fun listAllProfiles(): List<Session> =
+        rest.profileSessions().sessions.map { it.toDomain() }.filter { !it.archived }
     suspend fun stats(profile: String? = null): SessionStatsDto = rest.sessionStats(profile)
     suspend fun search(query: String, profile: String? = null): List<SearchResultDto> =
         rest.searchSessions(query, profile)

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -46,8 +46,11 @@ class SessionRepository(private val rest: HermesRestApi) {
             m.copy(id = "h-$i-${m.id}")
         }
 
-    suspend fun rename(sessionId: String, title: String) = rest.patchSession(sessionId, title = title)
-    suspend fun archive(sessionId: String, archived: Boolean) =
-        rest.patchSession(sessionId, archived = archived)
-    suspend fun delete(sessionId: String) = rest.deleteSession(sessionId)
+    // All mutations carry the session's profile so the gateway hits the right per-profile DB
+    // (otherwise the call 404s and the change silently no-ops).
+    suspend fun rename(sessionId: String, title: String, profile: String?) =
+        rest.patchSession(sessionId, title = title, profile = profile)
+    suspend fun archive(sessionId: String, archived: Boolean, profile: String?) =
+        rest.patchSession(sessionId, archived = archived, profile = profile)
+    suspend fun delete(sessionId: String, profile: String?) = rest.deleteSession(sessionId, profile)
 }

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -134,6 +134,13 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideGroupExpansionStore(
+        @ApplicationContext context: Context,
+    ): com.hermes.client.data.repository.GroupExpansionStore =
+        com.hermes.client.data.repository.GroupExpansionStore(context)
+
+    @Provides
+    @Singleton
     fun provideAnalyticsRepository(rest: HermesRestApi): com.hermes.client.data.repository.AnalyticsRepository =
         com.hermes.client.data.repository.AnalyticsRepository(rest)
 

--- a/app/src/main/java/com/hermes/client/domain/Mappers.kt
+++ b/app/src/main/java/com/hermes/client/domain/Mappers.kt
@@ -9,8 +9,11 @@ fun SessionDto.toDomain() = Session(
     model = model,
     provider = provider,
     messageCount = messageCount,
-    profile = profile,
+    // Normalize the default profile to a stable "default" label: the gateway may report it as
+    // null or blank with is_default_profile=true, but grouping/pin-tokens/switching need one key.
+    profile = profile?.ifBlank { null } ?: if (isDefaultProfile) "default" else null,
     workspace = cwd?.trimEnd('/')?.substringAfterLast('/')?.ifBlank { null } ?: "No workspace",
+    archived = archived,
     source = source,
 )
 

--- a/app/src/main/java/com/hermes/client/domain/Models.kt
+++ b/app/src/main/java/com/hermes/client/domain/Models.kt
@@ -9,9 +9,13 @@ data class Session(
     val model: String?,
     val provider: String?,
     val messageCount: Int,
+    // The profile this session belongs to. From the cross-profile list this is always set;
+    // the default profile is normalized to "default" so grouping, pin tokens, and profile
+    // switching share one stable key. Used as the top grouping tier.
     val profile: String?,
     // Workspace = basename of the session's cwd ("No workspace" when none), used for grouping.
     val workspace: String = "No workspace",
+    val archived: Boolean = false,
     val source: String? = null,
 )
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -207,7 +207,11 @@ class ChatViewModel @Inject constructor(
                 // output, and a worker failure ("slash worker closed pipe") throws. Previously
                 // both were discarded, so a failed switch looked like nothing happened.
                 .onSuccess { out -> appendSystem(out?.takeIf { it.isNotBlank() } ?: "Model set to $model.") }
-                .onFailure { e -> appendError("Couldn't switch model: ${e.message ?: "the gateway slash worker failed"}") }
+                .onFailure { e ->
+                    // Don't swallow cancellation — rethrow so structured concurrency still works.
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    appendError("Couldn't switch model: ${e.message ?: "the gateway slash worker failed"}")
+                }
         }
     }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -202,6 +202,12 @@ class ChatViewModel @Inject constructor(
         // by changing the model inside a chat.
         viewModelScope.launch {
             runCatching { chat.slashExec(sessionId, "/model $model --provider $provider --session") }
+                // Surface the outcome instead of swallowing it: the gateway reports the switch
+                // result (or an error like "Could not resolve credentials for …") in the slash
+                // output, and a worker failure ("slash worker closed pipe") throws. Previously
+                // both were discarded, so a failed switch looked like nothing happened.
+                .onSuccess { out -> appendSystem(out?.takeIf { it.isNotBlank() } ?: "Model set to $model.") }
+                .onFailure { e -> appendError("Couldn't switch model: ${e.message ?: "the gateway slash worker failed"}") }
         }
     }
 

--- a/app/src/main/java/com/hermes/client/ui/diagnostics/CrashReportScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/diagnostics/CrashReportScreen.kt
@@ -1,0 +1,61 @@
+package com.hermes.client.ui.diagnostics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Shown on the first launch after a crash (the trace was saved by [CrashReporter]). Lets the user
+ * share the stack trace so the crash can be diagnosed without adb, then continue into the app.
+ */
+@Composable
+fun CrashReportScreen(report: String, onShare: () -> Unit, onDismiss: () -> Unit) {
+    Surface(Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize().padding(16.dp)) {
+            Text("Hermes Beta crashed", style = MaterialTheme.typography.headlineSmall)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "This is the crash details. Tap Share to send it to the developer, then continue.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            Surface(
+                Modifier.weight(1f).fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.small,
+            ) {
+                Text(
+                    report,
+                    modifier = Modifier.padding(12.dp).verticalScroll(rememberScrollState()),
+                    fontFamily = FontFamily.Monospace,
+                    fontSize = 11.sp,
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onShare) { Text("Share") }
+                Spacer(Modifier.width(4.dp))
+                OutlinedButton(onClick = onDismiss) { Text("Continue to app") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
@@ -73,8 +73,8 @@ fun ArchivedSessionsScreen(
                         ArchivedRow(
                             session = s,
                             onOpen = { onOpen(s.id) },
-                            onUnarchive = { vm.unarchive(s.id) },
-                            onDelete = { vm.delete(s.id) },
+                            onUnarchive = { vm.unarchive(s) },
+                            onDelete = { vm.delete(s) },
                         )
                     }
                 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
@@ -51,11 +51,11 @@ class ArchivedSessionsViewModel @Inject constructor(
     }
 
     /** Restore an archived session to the active list, then refresh so it leaves this view. */
-    fun unarchive(sessionId: String) = viewModelScope.launch {
-        runCatching { sessions.archive(sessionId, archived = false) }.onSuccess { refresh() }
+    fun unarchive(session: Session) = viewModelScope.launch {
+        runCatching { sessions.archive(session.id, archived = false, session.profile) }.onSuccess { refresh() }
     }
 
-    fun delete(sessionId: String) = viewModelScope.launch {
-        runCatching { sessions.delete(sessionId) }.onSuccess { refresh() }
+    fun delete(session: Session) = viewModelScope.launch {
+        runCatching { sessions.delete(session.id, session.profile) }.onSuccess { refresh() }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
@@ -31,15 +31,17 @@ class ArchivedSessionsViewModel @Inject constructor(
     val activeProfile: StateFlow<String?> = profileManager.active
 
     init {
-        // The archived view now spans all profiles (desktop mirror), so it loads once rather than
-        // reloading per profile switch. The screen refreshes on ON_RESUME.
-        refresh()
+        // Scoped to the active profile, matching the main list — reload when the profile changes.
+        viewModelScope.launch { profileManager.active.collect { refresh() } }
     }
 
     fun refresh() = viewModelScope.launch {
         _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
         try {
-            _state.value = ArchivedUiState(sessions = sessions.archivedAllProfiles())
+            val active = profileManager.active.value
+            val all = sessions.archivedAllProfiles()
+            val list = if (active.isNullOrBlank()) all else all.filter { it.profile == active }
+            _state.value = ArchivedUiState(sessions = list)
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = ArchivedUiState(unauthorized = true)
             else _state.value = ArchivedUiState(error = e.message ?: "Failed to load")

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModel.kt
@@ -31,15 +31,15 @@ class ArchivedSessionsViewModel @Inject constructor(
     val activeProfile: StateFlow<String?> = profileManager.active
 
     init {
-        // Reload whenever the active profile changes (including the first value), so the list
-        // is always scoped to the tenant selected in the drawer.
-        viewModelScope.launch { profileManager.active.collect { refresh() } }
+        // The archived view now spans all profiles (desktop mirror), so it loads once rather than
+        // reloading per profile switch. The screen refreshes on ON_RESUME.
+        refresh()
     }
 
     fun refresh() = viewModelScope.launch {
         _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
         try {
-            _state.value = ArchivedUiState(sessions = sessions.archived(profileManager.active.value))
+            _state.value = ArchivedUiState(sessions = sessions.archivedAllProfiles())
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = ArchivedUiState(unauthorized = true)
             else _state.value = ArchivedUiState(error = e.message ?: "Failed to load")

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt
@@ -1,0 +1,63 @@
+package com.hermes.client.ui.sessions
+
+import com.hermes.client.data.repository.GroupExpansionStore
+import com.hermes.client.domain.Session
+
+/**
+ * A workspace sub-group within a profile. [sessions] is empty when the group is collapsed;
+ * [count] always reflects the true number of rows so the header reads correctly either way.
+ */
+data class WorkspaceGroup(
+    val workspace: String,
+    val count: Int,
+    val collapsed: Boolean,
+    val sessions: List<Session>,
+)
+
+/**
+ * A profile group (top tier). [workspaces] is empty when the profile itself is collapsed, so a
+ * collapsed profile renders as just its header — hiding every workspace and row beneath it.
+ */
+data class ProfileGroup(
+    val profile: String,
+    val count: Int,
+    val collapsed: Boolean,
+    val workspaces: List<WorkspaceGroup>,
+)
+
+/**
+ * Build the render-ready two-tier tree: Profile → Workspace → rows. The result is exactly what
+ * the list should draw — collapsed groups already have their children removed — so the screen
+ * stays dumb and the grouping is unit-testable. Collapse state comes from [collapsed] (a set of
+ * keys built by [GroupExpansionStore]); [activeProfile] sorts first so the current tenant is on top.
+ */
+fun groupSessions(
+    sessions: List<Session>,
+    collapsed: Set<String>,
+    activeProfile: String?,
+): List<ProfileGroup> =
+    sessions
+        .groupBy { it.profile ?: "default" }
+        .map { (profile, inProfile) ->
+            val profileCollapsed = GroupExpansionStore.profileKey(profile) in collapsed
+            val workspaces =
+                if (profileCollapsed) emptyList()
+                else inProfile
+                    .groupBy { it.workspace }
+                    .toSortedMap(compareBy({ it == "No workspace" }, { it }))
+                    .map { (workspace, rows) ->
+                        val wsCollapsed = GroupExpansionStore.workspaceKey(profile, workspace) in collapsed
+                        WorkspaceGroup(
+                            workspace = workspace,
+                            count = rows.size,
+                            collapsed = wsCollapsed,
+                            sessions = if (wsCollapsed) emptyList() else rows,
+                        )
+                    }
+            ProfileGroup(profile, inProfile.size, profileCollapsed, workspaces)
+        }
+        .sortedWith(
+            compareByDescending<ProfileGroup> { it.profile == activeProfile }
+                .thenByDescending { it.count }
+                .thenBy { it.profile },
+        )

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -54,7 +54,7 @@ fun SessionsScreen(
 ) {
     val state by vm.state.collectAsStateWithLifecycle()
     val activeProfile by vm.activeProfile.collectAsStateWithLifecycle()
-    val pinnedIds by vm.pinnedIds.collectAsStateWithLifecycle()
+    val pinnedTokens by vm.pinnedTokens.collectAsStateWithLifecycle()
     val collapsedGroups by vm.collapsedGroups.collectAsStateWithLifecycle()
     val query by vm.query.collectAsStateWithLifecycle()
     val messageResults by vm.messageResults.collectAsStateWithLifecycle()
@@ -128,11 +128,16 @@ fun SessionsScreen(
                         it.title.contains(q, ignoreCase = true) ||
                             it.workspace.contains(q, ignoreCase = true)
                     }
-                    val pinned = matches.filter { it.id in pinnedIds }
+                    // Pins are keyed by each session's OWN profile (the list spans all profiles),
+                    // so a pin made in another tenant still shows here.
+                    val isPinned = { s: Session ->
+                        com.hermes.client.data.repository.PinStore.token(s.profile, s.id) in pinnedTokens
+                    }
+                    val pinned = matches.filter(isPinned)
                     // Two-tier tree: Profile → Workspace → rows, with collapsed groups already
                     // pruned. The active profile sorts first.
                     val tree = groupSessions(
-                        matches.filterNot { it.id in pinnedIds },
+                        matches.filterNot(isPinned),
                         collapsedGroups,
                         activeProfile,
                     )
@@ -166,13 +171,15 @@ fun SessionsScreen(
                             }
                         }
                         if (pinned.isNotEmpty()) {
-                            item(key = "h-pinned") { SectionHeader("Pinned", pinned.size) }
+                            // "Device only" makes clear pins live on this phone and don't sync to
+                            // the desktop app (the gateway has no pin concept).
+                            item(key = "h-pinned") { SectionHeader("Pinned", pinned.size, note = "Device only") }
                             items(pinned, key = { "p-${it.id}" }) { s ->
                                 SessionRow(
                                     session = s,
                                     isPinned = true,
                                     onOpen = { onOpen(s.id) },
-                                    onTogglePin = { vm.togglePin(s.id) },
+                                    onTogglePin = { vm.togglePin(s) },
                                     onRename = { vm.rename(s.id, it) },
                                     onArchive = { vm.archive(s.id) },
                                     onDelete = { vm.delete(s.id) },
@@ -214,7 +221,7 @@ fun SessionsScreen(
                                         session = s,
                                         isPinned = false,
                                         onOpen = { onOpen(s.id) },
-                                        onTogglePin = { vm.togglePin(s.id) },
+                                        onTogglePin = { vm.togglePin(s) },
                                         onRename = { vm.rename(s.id, it) },
                                         onArchive = { vm.archive(s.id) },
                                         onDelete = { vm.delete(s.id) },
@@ -278,7 +285,7 @@ private fun CollapsibleHeader(
 }
 
 @Composable
-private fun SectionHeader(label: String, count: Int) {
+private fun SectionHeader(label: String, count: Int, note: String? = null) {
     androidx.compose.foundation.layout.Row(
         Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -287,8 +294,15 @@ private fun SectionHeader(label: String, count: Int) {
             label.uppercase(),
             style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
             color = androidx.compose.material3.MaterialTheme.colorScheme.primary,
-            modifier = Modifier.weight(1f),
         )
+        note?.let {
+            Text(
+                "  ·  $it",
+                style = androidx.compose.material3.MaterialTheme.typography.labelSmall,
+                color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        androidx.compose.foundation.layout.Spacer(Modifier.weight(1f))
         Text(
             count.toString(),
             style = androidx.compose.material3.MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -235,7 +235,11 @@ private fun SessionRow(
     Box {
         ListItem(
             headlineContent = { Text(if (isPinned) "📌  ${session.title}" else session.title) },
-            supportingContent = { Text(session.model ?: "") },
+            // Show the session's true profile (from the cross-profile list) next to its model so
+            // the tenant is unambiguous before the profile grouping lands.
+            supportingContent = {
+                Text(listOfNotNull(session.profile, session.model).joinToString(" · "))
+            },
             // Tap opens the session; long-press opens the management menu.
             modifier = Modifier.combinedClickable(
                 onClick = onOpen,

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -182,9 +182,9 @@ fun SessionsScreen(
                                     // so the chat resumes against the right per-profile DB.
                                     onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                     onTogglePin = { vm.togglePin(s) },
-                                    onRename = { vm.rename(s.id, it) },
-                                    onArchive = { vm.archive(s.id) },
-                                    onDelete = { vm.delete(s.id) },
+                                    onRename = { vm.rename(s, it) },
+                                    onArchive = { vm.archive(s) },
+                                    onDelete = { vm.delete(s) },
                                 )
                             }
                         }
@@ -224,9 +224,9 @@ fun SessionsScreen(
                                         isPinned = false,
                                         onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                         onTogglePin = { vm.togglePin(s) },
-                                        onRename = { vm.rename(s.id, it) },
-                                        onArchive = { vm.archive(s.id) },
-                                        onDelete = { vm.delete(s.id) },
+                                        onRename = { vm.rename(s, it) },
+                                        onArchive = { vm.archive(s) },
+                                        onDelete = { vm.delete(s) },
                                     )
                                 }
                             }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -178,7 +178,9 @@ fun SessionsScreen(
                                 SessionRow(
                                     session = s,
                                     isPinned = true,
-                                    onOpen = { onOpen(s.id) },
+                                    // Switch to the session's profile (awaited) before navigating,
+                                    // so the chat resumes against the right per-profile DB.
+                                    onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                     onTogglePin = { vm.togglePin(s) },
                                     onRename = { vm.rename(s.id, it) },
                                     onArchive = { vm.archive(s.id) },
@@ -220,7 +222,7 @@ fun SessionsScreen(
                                     SessionRow(
                                         session = s,
                                         isPinned = false,
-                                        onOpen = { onOpen(s.id) },
+                                        onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                         onTogglePin = { vm.togglePin(s) },
                                         onRename = { vm.rename(s.id, it) },
                                         onArchive = { vm.archive(s.id) },

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -55,6 +55,7 @@ fun SessionsScreen(
     val state by vm.state.collectAsStateWithLifecycle()
     val activeProfile by vm.activeProfile.collectAsStateWithLifecycle()
     val pinnedIds by vm.pinnedIds.collectAsStateWithLifecycle()
+    val collapsedGroups by vm.collapsedGroups.collectAsStateWithLifecycle()
     val query by vm.query.collectAsStateWithLifecycle()
     val messageResults by vm.messageResults.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
@@ -128,10 +129,13 @@ fun SessionsScreen(
                             it.workspace.contains(q, ignoreCase = true)
                     }
                     val pinned = matches.filter { it.id in pinnedIds }
-                    // Group the rest by workspace; "No workspace" sorts last.
-                    val groups = matches.filterNot { it.id in pinnedIds }
-                        .groupBy { it.workspace }
-                        .toSortedMap(compareBy({ it == "No workspace" }, { it }))
+                    // Two-tier tree: Profile → Workspace → rows, with collapsed groups already
+                    // pruned. The active profile sorts first.
+                    val tree = groupSessions(
+                        matches.filterNot { it.id in pinnedIds },
+                        collapsedGroups,
+                        activeProfile,
+                    )
 
                     LazyColumn {
                         // Gateway message-content search results (populated on the Search action).
@@ -175,18 +179,47 @@ fun SessionsScreen(
                                 )
                             }
                         }
-                        groups.forEach { (workspace, list) ->
-                            item(key = "h-$workspace") { SectionHeader(workspace, list.size) }
-                            items(list, key = { it.id }) { s ->
-                                SessionRow(
-                                    session = s,
-                                    isPinned = false,
-                                    onOpen = { onOpen(s.id) },
-                                    onTogglePin = { vm.togglePin(s.id) },
-                                    onRename = { vm.rename(s.id, it) },
-                                    onArchive = { vm.archive(s.id) },
-                                    onDelete = { vm.delete(s.id) },
+                        tree.forEach { pg ->
+                            item(key = "ph-${pg.profile}") {
+                                CollapsibleHeader(
+                                    label = pg.profile,
+                                    count = pg.count,
+                                    collapsed = pg.collapsed,
+                                    indent = false,
+                                    onToggle = {
+                                        vm.toggleGroup(
+                                            com.hermes.client.data.repository.GroupExpansionStore
+                                                .profileKey(pg.profile),
+                                        )
+                                    },
                                 )
+                            }
+                            pg.workspaces.forEach { wg ->
+                                item(key = "wh-${pg.profile}-${wg.workspace}") {
+                                    CollapsibleHeader(
+                                        label = wg.workspace,
+                                        count = wg.count,
+                                        collapsed = wg.collapsed,
+                                        indent = true,
+                                        onToggle = {
+                                            vm.toggleGroup(
+                                                com.hermes.client.data.repository.GroupExpansionStore
+                                                    .workspaceKey(pg.profile, wg.workspace),
+                                            )
+                                        },
+                                    )
+                                }
+                                items(wg.sessions, key = { it.id }) { s ->
+                                    SessionRow(
+                                        session = s,
+                                        isPinned = false,
+                                        onOpen = { onOpen(s.id) },
+                                        onTogglePin = { vm.togglePin(s.id) },
+                                        onRename = { vm.rename(s.id, it) },
+                                        onArchive = { vm.archive(s.id) },
+                                        onDelete = { vm.delete(s.id) },
+                                    )
+                                }
                             }
                         }
                     }
@@ -194,6 +227,53 @@ fun SessionsScreen(
             }
             }
         }
+    }
+}
+
+/**
+ * A tap-to-collapse group header (profile = top tier, workspace = indented sub-tier). A leading
+ * chevron shows the state; the whole row toggles. Profile labels read in caps; workspace labels
+ * are indented and lighter so the two tiers are visually distinct.
+ */
+@Composable
+private fun CollapsibleHeader(
+    label: String,
+    count: Int,
+    collapsed: Boolean,
+    indent: Boolean,
+    onToggle: () -> Unit,
+) {
+    androidx.compose.foundation.layout.Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(
+                start = if (indent) 28.dp else 16.dp,
+                end = 16.dp,
+                top = if (indent) 6.dp else 16.dp,
+                bottom = 4.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            if (collapsed) "▸" else "▾",
+            style = MaterialTheme.typography.labelMedium,
+            color = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
+            else MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(end = 8.dp),
+        )
+        Text(
+            if (indent) label else label.uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            color = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
+            else MaterialTheme.colorScheme.primary,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            count.toString(),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -42,12 +41,17 @@ class SessionsViewModel @Inject constructor(
     /** The active profile, shown as a subtitle so the tenant context is always visible. */
     val activeProfile: StateFlow<String?> = profileManager.active
 
-    /** Session ids pinned in the current profile (device-local). */
-    val pinnedIds: StateFlow<Set<String>> =
-        combine(pinStore.pinned, profileManager.active) { tokens, profile ->
-            val prefix = "${profile ?: "default"}/"
-            tokens.filter { it.startsWith(prefix) }.map { it.removePrefix(prefix) }.toSet()
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+    /**
+     * Raw pinned tokens ("<profile>/<sessionId>", device-local). The list spans all profiles, so
+     * the UI must test each session against its OWN profile token — not the active profile — or a
+     * pin made in another profile would vanish. Pins do not sync to desktop (no gateway pin API).
+     */
+    val pinnedTokens: StateFlow<Set<String>> =
+        pinStore.pinned.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    /** True if [session] is pinned, keyed by the session's own profile. */
+    fun isPinned(session: Session, tokens: Set<String> = pinnedTokens.value): Boolean =
+        PinStore.token(session.profile, session.id) in tokens
 
     /** Keys of currently-collapsed Profile/Workspace groups (device-local; default expanded). */
     val collapsedGroups: StateFlow<Set<String>> =
@@ -128,7 +132,8 @@ class SessionsViewModel @Inject constructor(
         runCatching { sessions.delete(sessionId) }.onSuccess { refresh() }
     }
 
-    fun togglePin(sessionId: String) = viewModelScope.launch {
-        pinStore.toggle(PinStore.token(profileManager.active.value, sessionId))
+    /** Pin/unpin keyed by the session's OWN profile, so it works regardless of the active one. */
+    fun togglePin(session: Session) = viewModelScope.launch {
+        pinStore.toggle(PinStore.token(session.profile, session.id))
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -116,6 +116,17 @@ class SessionsViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Make [session]'s profile the active one before the chat opens. The list spans all profiles,
+     * but resume/history/slash resolve against the gateway's active per-profile DB — so opening a
+     * session from another tenant must switch the active profile first (and await it), or the chat
+     * loads against the wrong profile. No-op when the session is already in the active profile.
+     */
+    suspend fun prepareOpen(session: Session) {
+        val target = session.profile ?: return
+        if (target != profileManager.active.value) profileManager.switchTo(target)
+    }
+
     /** Returns the new session id, or null if creation failed (so the UI doesn't crash). */
     suspend fun createSession(): String? = runCatching { chat.createSession() }.getOrNull()
 

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -50,18 +50,18 @@ class SessionsViewModel @Inject constructor(
     init {
         chat.connect()
         viewModelScope.launch { profileManager.refresh() }
-        // Reload this profile's sessions whenever the selected profile changes (including the
-        // first value once it's loaded). Sessions are scoped server-side via ?profile=, so the
-        // list always reflects the profile picked in the drawer.
-        viewModelScope.launch {
-            profileManager.active.collect { refresh() }
-        }
+        // The list now spans all profiles (desktop mirror), so it no longer reloads on a profile
+        // switch — the contents are identical regardless of which profile is active. Load once;
+        // the screen's ON_RESUME effect refreshes after creating/updating a session in a chat.
+        refresh()
     }
 
     fun refresh() = viewModelScope.launch {
         _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
         try {
-            val list = sessions.list(profileManager.active.value)
+            // Cross-profile: every session carries its true profile, so the app no longer guesses
+            // the profile from the active selection (the root cause of "wrong profile shown").
+            val list = sessions.listAllProfiles()
             _state.value = SessionsUiState(sessions = list)
         } catch (e: HermesApiException) {
             if (e.code == 401) {

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.hermes.client.data.network.HermesApiException
 import com.hermes.client.data.network.SearchResultDto
 import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.data.repository.GroupExpansionStore
 import com.hermes.client.data.repository.PinStore
 import com.hermes.client.data.repository.ProfileManager
 import com.hermes.client.data.repository.SessionRepository
@@ -33,6 +34,7 @@ class SessionsViewModel @Inject constructor(
     private val chat: ChatRepository,
     private val profileManager: ProfileManager,
     private val pinStore: PinStore,
+    private val groupExpansion: GroupExpansionStore,
 ) : ViewModel() {
     private val _state = MutableStateFlow(SessionsUiState())
     val state: StateFlow<SessionsUiState> = _state.asStateFlow()
@@ -46,6 +48,13 @@ class SessionsViewModel @Inject constructor(
             val prefix = "${profile ?: "default"}/"
             tokens.filter { it.startsWith(prefix) }.map { it.removePrefix(prefix) }.toSet()
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    /** Keys of currently-collapsed Profile/Workspace groups (device-local; default expanded). */
+    val collapsedGroups: StateFlow<Set<String>> =
+        groupExpansion.collapsed.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    /** Collapse or expand a group (profile or workspace) by its [GroupExpansionStore] key. */
+    fun toggleGroup(groupKey: String) = viewModelScope.launch { groupExpansion.toggle(groupKey) }
 
     init {
         chat.connect()

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -63,18 +63,20 @@ class SessionsViewModel @Inject constructor(
     init {
         chat.connect()
         viewModelScope.launch { profileManager.refresh() }
-        // The list now spans all profiles (desktop mirror), so it no longer reloads on a profile
-        // switch — the contents are identical regardless of which profile is active. Load once;
-        // the screen's ON_RESUME effect refreshes after creating/updating a session in a chat.
-        refresh()
+        // The list is scoped to the active profile (like the desktop, one tenant at a time), so it
+        // reloads whenever the selected profile changes — including the first value once it loads.
+        viewModelScope.launch { profileManager.active.collect { refresh() } }
     }
 
     fun refresh() = viewModelScope.launch {
         _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
         try {
-            // Cross-profile: every session carries its true profile, so the app no longer guesses
-            // the profile from the active selection (the root cause of "wrong profile shown").
-            val list = sessions.listAllProfiles()
+            // Fetch the cross-profile list (true per-session profile + cron/empty already filtered),
+            // then scope to the active profile so only that tenant's sessions show. Until the active
+            // profile is known, fall back to showing everything rather than a blank list.
+            val active = profileManager.active.value
+            val all = sessions.listAllProfiles()
+            val list = if (active.isNullOrBlank()) all else all.filter { it.profile == active }
             _state.value = SessionsUiState(sessions = list)
         } catch (e: HermesApiException) {
             if (e.code == 401) {

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -132,17 +132,18 @@ class SessionsViewModel @Inject constructor(
     /** Returns the new session id, or null if creation failed (so the UI doesn't crash). */
     suspend fun createSession(): String? = runCatching { chat.createSession() }.getOrNull()
 
-    fun rename(sessionId: String, title: String) = viewModelScope.launch {
-        runCatching { sessions.rename(sessionId, title) }.onSuccess { refresh() }
+    fun rename(session: Session, title: String) = viewModelScope.launch {
+        runCatching { sessions.rename(session.id, title, session.profile) }.onSuccess { refresh() }
     }
 
-    fun archive(sessionId: String) = viewModelScope.launch {
-        // Archiving removes it from the default (archived=exclude) list.
-        runCatching { sessions.archive(sessionId, archived = true) }.onSuccess { refresh() }
+    fun archive(session: Session) = viewModelScope.launch {
+        // Archiving removes it from the active list — must carry the session's profile or the
+        // gateway 404s (wrong per-profile DB) and the session never disappears.
+        runCatching { sessions.archive(session.id, archived = true, session.profile) }.onSuccess { refresh() }
     }
 
-    fun delete(sessionId: String) = viewModelScope.launch {
-        runCatching { sessions.delete(sessionId) }.onSuccess { refresh() }
+    fun delete(session: Session) = viewModelScope.launch {
+        runCatching { sessions.delete(session.id, session.profile) }.onSuccess { refresh() }
     }
 
     /** Pin/unpin keyed by the session's OWN profile, so it works regardless of the active one. */

--- a/app/src/test/java/com/hermes/client/data/network/HermesRestApiTest.kt
+++ b/app/src/test/java/com/hermes/client/data/network/HermesRestApiTest.kt
@@ -35,6 +35,27 @@ class HermesRestApiTest {
         assertEquals("secret", recorded.headers["X-Hermes-Session-Token"])
     }
 
+    // T1: the cross-profile list tags each session with its true profile and carries
+    // profile_totals for group headers. A default-profile session reports is_default_profile.
+    @Test fun profileSessions_parses_per_session_profile_and_totals() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body(
+            """{"sessions":[
+                {"id":"s1","title":"Mine","profile":"personal","cwd":"/home/me/app","archived":false},
+                {"id":"s2","title":"Default","is_default_profile":true,"archived":false}
+            ],"total":2,"profile_totals":{"personal":1,"default":1},"errors":[]}"""
+        ).build())
+
+        val res = api(serverRule.server).profileSessions()
+        assertEquals(2, res.sessions.size)
+        assertEquals("personal", res.sessions[0].profile)
+        // is_default_profile with no explicit profile name still surfaces (normalized downstream).
+        assertTrue(res.sessions[1].isDefaultProfile)
+        assertEquals(1, res.profileTotals["personal"])
+
+        val recorded = serverRule.server.takeRequest()
+        assertTrue(recorded.target.startsWith("/api/profiles/sessions"))
+    }
+
     @Test fun status_returns_true_on_200() = runTest {
         serverRule.server.enqueue(MockResponse.Builder().code(200).body("""{"ok":true}""").build())
         assertTrue(api(serverRule.server).status())

--- a/app/src/test/java/com/hermes/client/data/network/HermesRestApiTest.kt
+++ b/app/src/test/java/com/hermes/client/data/network/HermesRestApiTest.kt
@@ -56,6 +56,19 @@ class HermesRestApiTest {
         assertTrue(recorded.target.startsWith("/api/profiles/sessions"))
     }
 
+    // T4: the archived cross-profile view requests archived=only on the same endpoint.
+    @Test fun profileSessions_archivedOnly_appends_param() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body(
+            """{"sessions":[],"total":0,"profile_totals":{},"errors":[]}"""
+        ).build())
+
+        api(serverRule.server).profileSessions(archivedOnly = true)
+
+        val recorded = serverRule.server.takeRequest()
+        assertTrue(recorded.target.startsWith("/api/profiles/sessions"))
+        assertTrue("must request only archived sessions", recorded.target.contains("archived=only"))
+    }
+
     @Test fun status_returns_true_on_200() = runTest {
         serverRule.server.enqueue(MockResponse.Builder().code(200).body("""{"ok":true}""").build())
         assertTrue(api(serverRule.server).status())

--- a/app/src/test/java/com/hermes/client/data/repository/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/SessionRepositoryTest.kt
@@ -1,0 +1,44 @@
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesRestApi
+import com.hermes.client.data.network.ProfileSessionsDto
+import com.hermes.client.data.network.SessionDto
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionRepositoryTest {
+    private val rest = mockk<HermesRestApi>()
+    private val repo = SessionRepository(rest)
+
+    private fun dto(id: String, source: String?, msgs: Int, archived: Boolean = false) =
+        SessionDto(sessionId = id, source = source, messageCount = msgs, archived = archived, profile = "personal")
+
+    // Parity with desktop: the list hides cron-created and empty (0-message) sessions, so a
+    // profile shows the same count the desktop dashboard shows.
+    @Test fun listAllProfiles_hides_cron_and_empty_sessions() = runTest {
+        coEvery { rest.profileSessions(any(), false) } returns ProfileSessionsDto(
+            sessions = listOf(
+                dto("keep-tui", "tui", 5),
+                dto("hide-cron", "cron", 12),     // cron → hidden
+                dto("hide-empty", "tui", 0),       // 0 messages → hidden
+                dto("keep-dispatch", "hermes-dispatch", 2),
+                dto("hide-empty-cron", "cron", 0),
+            ),
+        )
+        assertEquals(listOf("keep-tui", "keep-dispatch"), repo.listAllProfiles().map { it.id })
+    }
+
+    @Test fun archivedAllProfiles_also_hides_cron_and_empty() = runTest {
+        coEvery { rest.profileSessions(any(), true) } returns ProfileSessionsDto(
+            sessions = listOf(
+                dto("a-keep", "cli", 3, archived = true),
+                dto("a-cron", "cron", 9, archived = true),
+                dto("a-empty", "tui", 0, archived = true),
+            ),
+        )
+        assertEquals(listOf("a-keep"), repo.archivedAllProfiles().map { it.id })
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -155,6 +155,30 @@ class ChatViewModelTest {
         coVerify { chatRepo.slashExec("s1", "/model opus --provider anthropic --session") }
     }
 
+    // The model-switch outcome must be visible, not swallowed: the gateway reports it (success
+    // or e.g. a credentials error) in the slash output, which the app must surface.
+    @Test fun selectModel_surfaces_slash_output() = runTest {
+        coEvery { chatRepo.slashExec("s1", any()) } returns "✗ Could not resolve credentials for provider 'Anthropic'"
+        val vm = buildVm()
+        vm.open("s1"); advanceUntilIdle()
+        vm.selectModel("anthropic", "opus"); advanceUntilIdle()
+        assertTrue(
+            "the slash output must appear in the conversation",
+            vm.state.value.messages.any { it.text.contains("Could not resolve credentials") },
+        )
+    }
+
+    // A worker failure ("slash worker closed pipe") throws — it must surface as an error, not
+    // silently do nothing (the original bug).
+    @Test fun selectModel_surfaces_switch_failure() = runTest {
+        coEvery { chatRepo.slashExec("s1", any()) } throws RuntimeException("slash worker closed pipe")
+        val vm = buildVm()
+        vm.open("s1"); advanceUntilIdle()
+        vm.selectModel("anthropic", "opus"); advanceUntilIdle()
+        val msg = vm.state.value.messages.lastOrNull()
+        assertTrue("a failed switch must show an error", msg?.isError == true && msg.text.contains("Couldn't switch model"))
+    }
+
     @Test fun selectProfile_calls_profileRepo_setActive() = runTest {
         val vm = buildVm()
         vm.open("s1")

--- a/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
@@ -36,18 +36,18 @@ class ArchivedSessionsViewModelTest {
     private fun buildVm() = ArchivedSessionsViewModel(sessionRepo, profileManager)
 
     @Test fun loads_archived_sessions_on_init() = runTest {
-        coEvery { sessionRepo.archived(any()) } returns listOf(session("a1"), session("a2"))
+        coEvery { sessionRepo.archivedAllProfiles() } returns listOf(session("a1"), session("a2"))
         val vm = buildVm()
         advanceUntilIdle()
         assertEquals(listOf("a1", "a2"), vm.state.value.sessions.map { it.id })
     }
 
     @Test fun unarchive_restores_then_reloads() = runTest {
-        coEvery { sessionRepo.archived(any()) } returns listOf(session("a1"))
+        coEvery { sessionRepo.archivedAllProfiles() } returns listOf(session("a1"))
         val vm = buildVm()
         advanceUntilIdle()
         // After restoring, the session is no longer archived, so the reloaded list is empty.
-        coEvery { sessionRepo.archived(any()) } returns emptyList()
+        coEvery { sessionRepo.archivedAllProfiles() } returns emptyList()
         vm.unarchive("a1")
         advanceUntilIdle()
         coVerify { sessionRepo.archive("a1", archived = false) }
@@ -55,10 +55,10 @@ class ArchivedSessionsViewModelTest {
     }
 
     @Test fun delete_removes_then_reloads() = runTest {
-        coEvery { sessionRepo.archived(any()) } returns listOf(session("a1"))
+        coEvery { sessionRepo.archivedAllProfiles() } returns listOf(session("a1"))
         val vm = buildVm()
         advanceUntilIdle()
-        coEvery { sessionRepo.archived(any()) } returns emptyList()
+        coEvery { sessionRepo.archivedAllProfiles() } returns emptyList()
         vm.delete("a1")
         advanceUntilIdle()
         coVerify { sessionRepo.delete("a1") }

--- a/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/ArchivedSessionsViewModelTest.kt
@@ -48,9 +48,9 @@ class ArchivedSessionsViewModelTest {
         advanceUntilIdle()
         // After restoring, the session is no longer archived, so the reloaded list is empty.
         coEvery { sessionRepo.archivedAllProfiles() } returns emptyList()
-        vm.unarchive("a1")
+        vm.unarchive(session("a1"))
         advanceUntilIdle()
-        coVerify { sessionRepo.archive("a1", archived = false) }
+        coVerify { sessionRepo.archive("a1", archived = false, "personal") }
         assertEquals(emptyList<String>(), vm.state.value.sessions.map { it.id })
     }
 
@@ -59,9 +59,9 @@ class ArchivedSessionsViewModelTest {
         val vm = buildVm()
         advanceUntilIdle()
         coEvery { sessionRepo.archivedAllProfiles() } returns emptyList()
-        vm.delete("a1")
+        vm.delete(session("a1"))
         advanceUntilIdle()
-        coVerify { sessionRepo.delete("a1") }
+        coVerify { sessionRepo.delete("a1", "personal") }
         assertEquals(emptyList<String>(), vm.state.value.sessions.map { it.id })
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt
@@ -1,0 +1,58 @@
+package com.hermes.client.ui.sessions
+
+import com.hermes.client.data.repository.GroupExpansionStore
+import com.hermes.client.domain.Session
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionGroupingTest {
+    private fun s(id: String, profile: String, workspace: String) = Session(
+        id = id, title = id, model = null, provider = null, messageCount = 1,
+        profile = profile, workspace = workspace,
+    )
+
+    private val sessions = listOf(
+        s("a", "personal", "app"),
+        s("b", "personal", "app"),
+        s("c", "personal", "docs"),
+        s("d", "odos", "infra"),
+    )
+
+    @Test fun groups_two_tiers_with_active_profile_first() {
+        val tree = groupSessions(sessions, collapsed = emptySet(), activeProfile = "odos")
+
+        // Active profile sorts first even though it has fewer sessions.
+        assertEquals(listOf("odos", "personal"), tree.map { it.profile })
+        val personal = tree.first { it.profile == "personal" }
+        assertEquals(3, personal.count)
+        assertEquals(listOf("app", "docs"), personal.workspaces.map { it.workspace })
+        assertEquals(listOf("a", "b"), personal.workspaces.first { it.workspace == "app" }.sessions.map { it.id })
+    }
+
+    @Test fun collapsed_profile_hides_all_workspaces_and_rows() {
+        val collapsed = setOf(GroupExpansionStore.profileKey("personal"))
+        val tree = groupSessions(sessions, collapsed, activeProfile = null)
+
+        val personal = tree.first { it.profile == "personal" }
+        assertTrue(personal.collapsed)
+        assertTrue("a collapsed profile renders no workspaces/rows", personal.workspaces.isEmpty())
+        // Count still reflects reality so the header reads "3".
+        assertEquals(3, personal.count)
+    }
+
+    @Test fun collapsed_workspace_hides_its_rows_but_keeps_count() {
+        val collapsed = setOf(GroupExpansionStore.workspaceKey("personal", "app"))
+        val tree = groupSessions(sessions, collapsed, activeProfile = null)
+
+        val app = tree.first { it.profile == "personal" }.workspaces.first { it.workspace == "app" }
+        assertTrue(app.collapsed)
+        assertTrue("collapsed workspace hides rows", app.sessions.isEmpty())
+        assertEquals("but the count is preserved", 2, app.count)
+
+        val docs = tree.first { it.profile == "personal" }.workspaces.first { it.workspace == "docs" }
+        assertFalse("a sibling workspace stays expanded", docs.collapsed)
+        assertEquals(listOf("c"), docs.sessions.map { it.id })
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -99,6 +100,30 @@ class SessionsViewModelTest {
         assertEquals(setOf("s1", "s2"), byId.keys)
         assertEquals("personal", byId["s1"]?.profile)
         assertEquals("odos", byId["s2"]?.profile) // not coerced to the active "personal"
+    }
+
+    // T5: in the cross-profile list, a session is pinned by its OWN profile token — so a pin made
+    // in "odos" still reads as pinned even though the active profile is "personal". Keying by the
+    // active profile (the old behavior) would make cross-profile pins vanish.
+    @Test fun isPinned_keys_off_session_profile_not_active_profile() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm() // active profile is "personal"
+        advanceUntilIdle()
+
+        val odosSession = session("s2", "client", profile = "odos")
+        assertTrue("odos pin matches the odos session", vm.isPinned(odosSession, setOf("odos/s2")))
+        assertFalse("a personal-scoped token must not match", vm.isPinned(odosSession, setOf("personal/s2")))
+    }
+
+    // T5: pinning uses the session's own profile token.
+    @Test fun togglePin_uses_session_profile_token() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.togglePin(session("s2", "client", profile = "odos"))
+        advanceUntilIdle()
+        io.mockk.coVerify { pinStore.toggle("odos/s2") }
     }
 
     // T2: toggling a group delegates to the persisted store (collapse state survives navigation).

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -85,10 +85,9 @@ class SessionsViewModelTest {
         assertEquals(2, ids.size)
     }
 
-    // T1: the list spans every profile (desktop mirror), and each session keeps its OWN profile
-    // — not the active one. This is the fix for "wrong profile shown": the app no longer guesses
-    // the profile from the active selection.
-    @Test fun list_spans_all_profiles_each_with_its_own_profile() = runTest {
+    // The list is scoped to the active profile (one tenant at a time, like the desktop): a session
+    // from another profile is filtered out, and each shown session keeps its own true profile.
+    @Test fun list_is_scoped_to_active_profile() = runTest {
         coEvery { sessionRepo.listAllProfiles() } returns listOf(
             session("s1", "mine", profile = "personal"),
             session("s2", "client", profile = "odos"),
@@ -96,10 +95,8 @@ class SessionsViewModelTest {
         val vm = buildVm() // active profile is "personal"
         advanceUntilIdle()
 
-        val byId = vm.state.value.sessions.associateBy { it.id }
-        assertEquals(setOf("s1", "s2"), byId.keys)
-        assertEquals("personal", byId["s1"]?.profile)
-        assertEquals("odos", byId["s2"]?.profile) // not coerced to the active "personal"
+        assertEquals(listOf("s1"), vm.state.value.sessions.map { it.id })
+        assertEquals("personal", vm.state.value.sessions.single().profile)
     }
 
     // T5: in the cross-profile list, a session is pinned by its OWN profile token — so a pin made

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -123,6 +123,18 @@ class SessionsViewModelTest {
         io.mockk.coVerify { pinStore.toggle("odos/s2") }
     }
 
+    // Archiving must carry the session's profile, or the gateway PATCH 404s against the wrong
+    // per-profile DB and the session never leaves the list (looks like "refresh doesn't work").
+    @Test fun archive_passes_session_profile() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.archive(session("s1", "mine", profile = "personal"))
+        advanceUntilIdle()
+        io.mockk.coVerify { sessionRepo.archive("s1", archived = true, "personal") }
+    }
+
     // T3: opening a session from another profile must switch the active profile first, so the
     // chat resumes against the correct per-profile DB.
     @Test fun prepareOpen_switches_to_session_profile_when_different() = runTest {

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -33,9 +33,9 @@ class SessionsViewModelTest {
         every { pinStore.pinned } returns MutableStateFlow<Set<String>>(emptySet())
     }
 
-    private fun session(id: String, title: String) = Session(
+    private fun session(id: String, title: String, profile: String = "personal") = Session(
         id = id, title = title, model = null, provider = null,
-        messageCount = 1, profile = "personal", workspace = "No workspace", source = "hermes-dispatch",
+        messageCount = 1, profile = profile, workspace = "No workspace", source = "hermes-dispatch",
     )
 
     private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore)
@@ -49,7 +49,7 @@ class SessionsViewModelTest {
     // the gateway. searchMessages must populate messageResults from the repo, and clearing the
     // query must clear results.
     @Test fun searchMessages_populates_results_and_clear_resets() = runTest {
-        coEvery { sessionRepo.list(any()) } returns emptyList()
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
         coEvery { sessionRepo.search(any(), any()) } returns listOf(
             com.hermes.client.data.network.SearchResultDto(sessionId = "s9", snippet = "found it"),
         )
@@ -67,18 +67,35 @@ class SessionsViewModelTest {
     }
 
     @Test fun refresh_resurfaces_newly_added_session() = runTest {
-        coEvery { sessionRepo.list(any()) } returns listOf(session("s1", "old"))
+        coEvery { sessionRepo.listAllProfiles() } returns listOf(session("s1", "old"))
         val vm = buildVm()
         advanceUntilIdle()
         assertEquals(listOf("s1"), vm.state.value.sessions.map { it.id })
 
         // A new session now exists on the gateway, as if a prompt created one while in a chat.
-        coEvery { sessionRepo.list(any()) } returns listOf(session("s2", "new"), session("s1", "old"))
+        coEvery { sessionRepo.listAllProfiles() } returns listOf(session("s2", "new"), session("s1", "old"))
         vm.refresh()
         advanceUntilIdle()
 
         val ids = vm.state.value.sessions.map { it.id }
         assertTrue("refresh must surface the newly-added session", ids.contains("s2"))
         assertEquals(2, ids.size)
+    }
+
+    // T1: the list spans every profile (desktop mirror), and each session keeps its OWN profile
+    // — not the active one. This is the fix for "wrong profile shown": the app no longer guesses
+    // the profile from the active selection.
+    @Test fun list_spans_all_profiles_each_with_its_own_profile() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns listOf(
+            session("s1", "mine", profile = "personal"),
+            session("s2", "client", profile = "odos"),
+        )
+        val vm = buildVm() // active profile is "personal"
+        advanceUntilIdle()
+
+        val byId = vm.state.value.sessions.associateBy { it.id }
+        assertEquals(setOf("s1", "s2"), byId.keys)
+        assertEquals("personal", byId["s1"]?.profile)
+        assertEquals("odos", byId["s2"]?.profile) // not coerced to the active "personal"
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -126,6 +126,29 @@ class SessionsViewModelTest {
         io.mockk.coVerify { pinStore.toggle("odos/s2") }
     }
 
+    // T3: opening a session from another profile must switch the active profile first, so the
+    // chat resumes against the correct per-profile DB.
+    @Test fun prepareOpen_switches_to_session_profile_when_different() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm() // active is "personal"
+        advanceUntilIdle()
+
+        vm.prepareOpen(session("s2", "client", profile = "odos"))
+        advanceUntilIdle()
+        io.mockk.coVerify { profileManager.switchTo("odos") }
+    }
+
+    // T3: no switch when the session is already in the active profile.
+    @Test fun prepareOpen_is_noop_for_active_profile_session() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm() // active is "personal"
+        advanceUntilIdle()
+
+        vm.prepareOpen(session("s1", "mine", profile = "personal"))
+        advanceUntilIdle()
+        io.mockk.coVerify(exactly = 0) { profileManager.switchTo(any()) }
+    }
+
     // T2: toggling a group delegates to the persisted store (collapse state survives navigation).
     @Test fun toggleGroup_persists_via_store() = runTest {
         coEvery { sessionRepo.listAllProfiles() } returns emptyList()

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -26,11 +26,13 @@ class SessionsViewModelTest {
     private val chatRepo = mockk<ChatRepository>(relaxed = true)
     private val profileManager = mockk<ProfileManager>(relaxed = true)
     private val pinStore = mockk<PinStore>(relaxed = true)
+    private val groupExpansion = mockk<com.hermes.client.data.repository.GroupExpansionStore>(relaxed = true)
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
         every { profileManager.active } returns MutableStateFlow<String?>("personal")
         every { pinStore.pinned } returns MutableStateFlow<Set<String>>(emptySet())
+        every { groupExpansion.collapsed } returns MutableStateFlow<Set<String>>(emptySet())
     }
 
     private fun session(id: String, title: String, profile: String = "personal") = Session(
@@ -38,7 +40,7 @@ class SessionsViewModelTest {
         messageCount = 1, profile = profile, workspace = "No workspace", source = "hermes-dispatch",
     )
 
-    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore)
+    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore, groupExpansion)
 
     // Regression: a session created or updated while the user was in a chat must appear once
     // the list is re-fetched. The Sessions screen calls refresh() on ON_RESUME (the "sessions"
@@ -97,5 +99,16 @@ class SessionsViewModelTest {
         assertEquals(setOf("s1", "s2"), byId.keys)
         assertEquals("personal", byId["s1"]?.profile)
         assertEquals("odos", byId["s2"]?.profile) // not coerced to the active "personal"
+    }
+
+    // T2: toggling a group delegates to the persisted store (collapse state survives navigation).
+    @Test fun toggleGroup_persists_via_store() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.toggleGroup("p:odos")
+        advanceUntilIdle()
+        io.mockk.coVerify { groupExpansion.toggle("p:odos") }
     }
 }

--- a/docs/ideas/mobile-desktop-parity.md
+++ b/docs/ideas/mobile-desktop-parity.md
@@ -74,6 +74,12 @@ profile when opening a session from another profile; archive refresh verified;
 - Default view: **all-profiles** (true desktop mirror), not single-active-profile.
 - Opening a session from another profile: **auto-switch** the active profile to it.
 
-## Next Step
-Break the recommended direction into tasks via `/plan` (or
-`agent-skills:planning-and-task-breakdown`). No code written yet.
+## Status — implemented in 0.1.14-beta (branch `feature/session-parity`)
+- T1 ✅ list sources from `/api/profiles/sessions` (all profiles, true per-session profile)
+- T2 ✅ two-tier collapsible Profile→Workspace groups, persisted device-local
+- T3 ✅ auto-switch active profile when opening a cross-profile session
+- T4 ✅ archived view spans all profiles (server `archived` field)
+- T5 ✅ pins keyed by each session's own profile + labeled "Device only"
+- Out of scope (blocked): server-synced pins — gateway has no pin concept (upstream Hermes).
+
+Plan + task list: `tasks/plan.md`, `tasks/todo.md`.

--- a/docs/ideas/mobile-desktop-parity.md
+++ b/docs/ideas/mobile-desktop-parity.md
@@ -71,8 +71,12 @@ profile when opening a session from another profile; archive refresh verified;
   current "wrong profile" bug; use the server's `profile` field instead.
 
 ## Resolved Decisions
-- Default view: **all-profiles** (true desktop mirror), not single-active-profile.
-- Opening a session from another profile: **auto-switch** the active profile to it.
+- View scope: **active profile only** (one tenant at a time, switched via the drawer —
+  how the desktop actually behaves). *Superseded the initial all-profiles choice after
+  hands-on use (0.1.17).*
+- Opening a session from another profile: **auto-switch** the active profile to it
+  (now effectively a no-op since the list is single-profile, but retained for safety).
+- List contents match desktop: **cron** and **empty (0-message)** sessions are hidden (0.1.16).
 
 ## Status — implemented in 0.1.14-beta (branch `feature/session-parity`)
 - T1 ✅ list sources from `/api/profiles/sessions` (all profiles, true per-session profile)

--- a/docs/ideas/mobile-desktop-parity.md
+++ b/docs/ideas/mobile-desktop-parity.md
@@ -1,0 +1,79 @@
+# Mobile↔Desktop Session Parity
+
+## Problem Statement
+How might we make the mobile session list a faithful mirror of the desktop —
+right profile, right archive state, scannable groups — without pretending to
+sync a "pin" feature the gateway doesn't actually have?
+
+## Recommended Direction
+Switch the mobile list from `/api/sessions?profile=<active>` to
+`/api/profiles/sessions`, which returns every session tagged with its real
+`profile` plus `profile_totals`. This fixes the "wrong profile shown" bug at the
+root (the app no longer guesses the profile from the active selection) and
+simultaneously delivers the desktop's cross-profile view.
+
+The mobile list **defaults to all-profiles** (a true desktop mirror). Render a
+two-tier, collapsible tree: **Profile** (count from `profile_totals`) →
+**Workspace** (`cwd` basename). Persist each group's expand/collapse state
+locally so the layout survives navigation.
+
+Each session carries its true `profile`, so:
+- Tapping a session in a non-active profile **auto-switches the active profile**
+  to that session's profile before opening it (the per-profile state DB requires
+  the active profile to be set for resume/slash/submit).
+- That same per-session profile is threaded into resume/slash calls, making
+  model-switch and resume more robust as a side effect.
+
+Archive already mirrors desktop — `archived` is a real server field on every
+session — so this is purely a verify-the-refresh task, optionally surfacing
+archived state inline.
+
+Pins remain **device-local** and are explicitly **labeled device-local** in the
+UI. True pin sync is filed upstream as a Hermes feature request (a `pinned` bool
+on the session model + PATCH support) — the only path that can actually sync
+desktop↔mobile.
+
+## Ground Truth (verified against the live gateway, 2026-06-24)
+- `/api/profiles/sessions` → `{ sessions[], total, profile_totals, limit, offset,
+  errors }`; each session includes `profile`, `is_default_profile`, `archived`,
+  `last_active`, `preview`, `is_active`, `cwd`. Live totals: default 29,
+  personal 70, odos 13, semiotic 4, dito 3 (119 total).
+- `PATCH /api/sessions/{id}` accepts only `{ title, archived, profile }`.
+- **No pin/star/favorite concept exists** anywhere: not on the session object,
+  not in any of the 197 API paths, not in the 100+-key gateway config. Desktop
+  "pins" are therefore a desktop-frontend (localStorage) feature, invisible to
+  the gateway API and to mobile.
+
+## Key Assumptions to Validate
+- [ ] Desktop pins are localStorage-only — confirm via desktop devtools (strong
+      evidence: zero server pin surface). If false, find where they live and revisit.
+- [ ] `/api/profiles/sessions` supports the archived filter + paging the same way
+      (`personal` alone has 70 sessions; `limit=50` needs paging or a higher limit).
+- [ ] Resume/slash/submit still require the active profile to be set for the
+      per-profile DB, even when the list is cross-profile — hence the auto-switch
+      on tapping a cross-profile session (actions are profile-scoped; reads aren't).
+
+## MVP Scope
+**IN:** cross-profile list via `/api/profiles/sessions`, defaulting to all
+profiles; Profile→Workspace collapsible groups with persisted expand state;
+per-session correct `profile` threaded to resume/slash/submit; auto-switch active
+profile when opening a session from another profile; archive refresh verified;
+"device-local" label on pins.
+
+**OUT:** server-synced pins; custom sort/reorder; message-level grouping changes.
+
+## Not Doing (and Why)
+- **Server-synced pins** — the gateway exposes no pin concept; blocked until an
+  upstream `pinned` field exists. Filed as a Hermes feature request.
+- **Storing pins in `/api/config`** — unsafe; that endpoint is the entire gateway
+  config (models, providers, secrets), and a bad PUT could corrupt it.
+- **Re-deriving profile client-side** — this guessing is the root cause of the
+  current "wrong profile" bug; use the server's `profile` field instead.
+
+## Resolved Decisions
+- Default view: **all-profiles** (true desktop mirror), not single-active-profile.
+- Opening a session from another profile: **auto-switch** the active profile to it.
+
+## Next Step
+Break the recommended direction into tasks via `/plan` (or
+`agent-skills:planning-and-task-breakdown`). No code written yet.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,0 +1,202 @@
+# Plan — Direction A: Mobile↔Desktop Session Parity
+
+Spec: `docs/ideas/mobile-desktop-parity.md`
+Branch: `feature/session-parity` off `develop` (PRs into `develop`; never push `main`)
+
+## Goal
+Make the mobile session list a faithful desktop mirror: all profiles in one
+view with each session under its **true** profile, two-tier collapsible
+Profile→Workspace groups with persisted expand state, correct-profile threading
+into resume/slash/submit, auto-switch active profile on cross-profile open, and
+verified archive parity. Pins stay device-local and are labeled as such.
+
+## Out of scope
+Server-synced pins (no gateway pin concept — filed upstream), custom sort/reorder,
+message-level grouping changes, cross-profile message-content search.
+
+---
+
+## Verified ground truth (live gateway, 2026-06-24)
+- `GET /api/profiles/sessions?limit=N` → `{ sessions[], total, profile_totals,
+  limit, offset, errors }`. Each session carries `id, profile, is_default_profile,
+  archived, cwd, last_active, preview, model, title, message_count, source, …`.
+- Live `profile_totals`: `default:29, personal:70, odos:13, semiotic:4, dito:3`
+  (total 119). A single page must request `limit ≥ total` (use 500) — no paging in MVP.
+- `PATCH /api/sessions/{id}` accepts only `{ title, archived, profile }`.
+- No pin/star/favorite anywhere (197 paths, all config keys checked).
+
+## Dependency graph
+```
+T1 (all-profiles data + list)  ──┬──> T2 (collapsible groups)
+                                 ├──> T3 (auto-switch + profile threading)
+                                 ├──> T4 (archive parity)
+                                 └──> T5 (pins cross-profile + label)
+T6 (ship) depends on T1..T5
+```
+T1 is the enabling slice. T2–T5 are independent of each other and may land in
+any order after T1. Each task is a complete vertical path (data → VM → UI →
+test), not a horizontal layer.
+
+---
+
+## Phase 1 — Foundation
+
+### T1 — All-profiles list, each session under its true profile
+Replace the single-profile data source so the list shows every session tagged
+with the profile the server reports (fixes the "wrong profile shown" bug at root).
+
+Changes:
+- `Dtos.kt`: add `archived: Boolean = false` and `@SerialName("is_default_profile")
+  isDefaultProfile: Boolean = false` to `SessionDto`; add
+  `ProfileSessionsDto(sessions, total, profileTotals: Map<String,Int>, errors)`.
+- `HermesRestApi.kt`: add `suspend fun profileSessions(limit: Int = 500):
+  ProfileSessionsDto` hitting `/api/profiles/sessions?limit=$limit&order=recent`.
+- `domain/Models.kt` + `Mappers.kt`: carry `archived` (already has `profile`,
+  `workspace`). Normalize a null/blank `profile` to `"default"` when
+  `isDefaultProfile`.
+- `SessionRepository.kt`: add `suspend fun listAllProfiles(): List<Session>`.
+- `SessionsViewModel.kt`: `refresh()` calls `listAllProfiles()`; stop scoping the
+  list to the active profile (keep the active-profile subtitle for context only).
+- `SessionsScreen.kt`: each row's supporting text shows its profile (until T2's
+  profile grouping lands).
+
+Acceptance:
+- Opening Sessions shows sessions from **all** profiles (≈119), each with the
+  correct profile, regardless of which profile is active.
+- Switching the active profile no longer reloads/filters the visible list.
+
+Verify:
+- `JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home ./gradlew :app:testDebugUnitTest`
+- New mockwebserver test: a `/api/profiles/sessions` payload with two profiles maps
+  to domain sessions whose `profile` matches the server (not the active profile).
+
+### ✅ Checkpoint A — human review
+Confirm the all-profiles list renders with correct profiles before adding UX.
+
+---
+
+## Phase 2 — Structure & pins
+
+### T2 — Two-tier collapsible Profile→Workspace groups, persisted
+Group the list by Profile (top, count from `profile_totals`/derived) → Workspace
+(`cwd` basename). Headers are tap-to-collapse/expand; state persists locally.
+
+Changes:
+- New `GroupExpansionStore` (DataStore, mirrors `PinStore`) keyed by
+  `"p:<profile>"` and `"w:<profile>/<workspace>"`; default = expanded;
+  store only the *collapsed* set.
+- `SessionsViewModel`: expose collapsed-keys `StateFlow` + `toggleGroup(key)`.
+- `SessionsScreen`: render two-tier headers; a collapsed profile hides its
+  workspaces and rows; a collapsed workspace hides its rows. Profile order:
+  active profile first, then by descending count; "default" handling explicit.
+  Keep unique LazyColumn keys.
+
+Acceptance:
+- Tapping a profile header collapses all its workspaces+rows; tapping again
+  expands. Same for a workspace header. Collapse state survives leaving the
+  screen and an app restart.
+
+Verify:
+- `./gradlew :app:testDebugUnitTest` (VM test: `toggleGroup` flips collapsed set;
+  collapsed profile excludes its rows from the rendered model).
+
+### T5 — Pins render in the cross-profile list + labeled device-local
+In a cross-profile list, pin matching must use each session's **own** profile,
+not the active one, or pins vanish.
+
+Changes:
+- `SessionsViewModel`: expose the raw pinned token set (`"<profile>/<id>"`);
+  the UI checks `"${session.profile}/${session.id}"`. `togglePin(session)` uses
+  `session.profile`.
+- `SessionsScreen`: small "Device only" caption on the Pinned section header (and
+  optionally in the pin menu item) so it's clear pins don't sync to desktop.
+
+Acceptance:
+- A session pinned while its profile was active still shows pinned when a
+  different profile is active. The Pinned section reads as device-local.
+
+Verify:
+- `./gradlew :app:testDebugUnitTest` (VM test: a pinned token for profile X is
+  reported pinned for that session even when active profile is Y).
+
+### ✅ Checkpoint B — human review
+Confirm grouping/collapse and pin behavior on-device before behavioral changes.
+
+---
+
+## Phase 3 — Behavior & parity
+
+### T3 — Auto-switch active profile on open + thread profile to RPCs
+Opening a session from another profile must switch the active profile to it
+**before** the chat loads (history/resume read `profileManager.active.value`).
+
+Changes:
+- `SessionsViewModel`: add `suspend fun prepareOpen(session): Unit` that calls
+  `profileManager.switchTo(session.profile)` only when it differs from active,
+  and awaits completion.
+- `SessionsScreen`: row tap does `scope.launch { vm.prepareOpen(s); onOpen(s.id) }`
+  so navigation happens after the switch settles.
+- Sanity-check `ChatViewModel.open()` now sees the correct active profile for
+  `history()`/`resume()` (already threads `profileManager.active.value`).
+
+Acceptance:
+- With active = `personal`, tapping an `odos` session switches active to `odos`,
+  loads its history, resumes without "session not found", and model-switch targets
+  the right profile. The Sessions subtitle reflects the new active profile on return.
+
+Verify:
+- `./gradlew :app:testDebugUnitTest` (VM test: `prepareOpen` for a non-active
+  profile calls `switchTo(session.profile)`; for the active profile it does not).
+- On-device: open a session from a non-active profile end-to-end.
+
+### T4 — Archive parity verified (and archived view cross-profile)
+Archive is already server state (`archived` field); confirm parity and remove the
+single-profile assumption from the archived view.
+
+Changes:
+- `ArchivedSessionsViewModel`/`Screen`: source archived sessions across all
+  profiles (filter `archived == true` from `listAllProfiles()`, or an
+  `archived=only` cross-profile call) instead of per-active-profile.
+- Confirm the active list already excludes archived (server default) and refreshes
+  on resume.
+
+Acceptance:
+- A session archived on desktop is absent from the mobile active list after
+  refresh and present in the mobile Archived view (and vice-versa). Archived view
+  shows archived sessions from every profile.
+
+Verify:
+- `./gradlew :app:testDebugUnitTest`
+- On-device: archive on desktop → pull mobile → gone from active, present in Archived.
+
+### ✅ Checkpoint C — human review
+Full behavioral review before building the beta.
+
+---
+
+## Phase 4 — Ship
+
+### T6 — Build, test, beta APK, ship to develop
+- Bump `versionCode`/`versionName` in `app/build.gradle.kts`.
+- `gitleaks git --no-banner --redact` (must be clean).
+- Full unit suite green.
+- Build the **beta** variant APK, deliver to the user, commit to
+  `feature/session-parity`, open PR into `develop`.
+- Update `README.md`/`docs/ideas/mobile-desktop-parity.md` status as needed.
+
+Acceptance: signed beta APK installs alongside release; all parity behaviors work
+on-device; PR open into `develop` with green CI.
+
+---
+
+## Risks & notes
+- **Paging**: one `limit=500` page covers current volume (119). If totals grow,
+  add offset paging — tracked, not in MVP.
+- **Message search** stays active-profile-scoped (title filter is client-side over
+  the full list, so it already spans profiles). Cross-profile message search is a
+  follow-up.
+- **`profile` null/default**: default profile may report `profile=null` +
+  `is_default_profile=true`; normalize to a stable `"default"` label everywhere
+  (grouping, pin tokens, switchTo).
+- **Pins remain device-local by design** — gateway has no pin concept; do NOT
+  store pins in `/api/config` (that's the whole gateway config; corruption risk).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,43 +3,43 @@
 Branch: `feature/session-parity` off `develop`. Full plan: `tasks/plan.md`.
 
 ## Phase 1 — Foundation
-- [ ] **T1** All-profiles list; each session under its true profile
-  - [ ] `SessionDto`: add `archived`, `isDefaultProfile`; add `ProfileSessionsDto`
-  - [ ] `HermesRestApi.profileSessions(limit=500)` → `/api/profiles/sessions`
-  - [ ] `Models`/`Mappers`: carry `archived`; normalize default profile label
-  - [ ] `SessionRepository.listAllProfiles()`
-  - [ ] `SessionsViewModel.refresh()` uses all-profiles; stop active-profile scoping
-  - [ ] Row shows its profile (interim, until T2)
-  - [ ] mockwebserver test: profiles map to correct per-session `profile`
-- [ ] **CHECKPOINT A** — human review (all-profiles list renders correctly)
+- [x] **T1** All-profiles list; each session under its true profile
+  - [x] `SessionDto`: add `archived`, `isDefaultProfile`; add `ProfileSessionsDto`
+  - [x] `HermesRestApi.profileSessions(limit=500)` → `/api/profiles/sessions`
+  - [x] `Models`/`Mappers`: carry `archived`; normalize default profile label
+  - [x] `SessionRepository.listAllProfiles()`
+  - [x] `SessionsViewModel.refresh()` uses all-profiles; stop active-profile scoping
+  - [x] Row shows its profile (interim, until T2)
+  - [x] mockwebserver test: profiles map to correct per-session `profile`
+- [x] **CHECKPOINT A** — code verified (58 tests green); on-device check deferred to T6 beta
 
 ## Phase 2 — Structure & pins
-- [ ] **T2** Two-tier collapsible Profile→Workspace groups, persisted
-  - [ ] `GroupExpansionStore` (DataStore; store collapsed set; default expanded)
-  - [ ] VM: collapsed-keys flow + `toggleGroup(key)`
-  - [ ] Screen: two-tier headers, collapse hides children, persisted, unique keys
-  - [ ] VM test: toggle flips set; collapsed profile excludes its rows
-- [ ] **T5** Pins render cross-profile + labeled device-local
-  - [ ] Pin match/toggle keyed by `session.profile` (not active profile)
-  - [ ] "Device only" caption on Pinned section
-  - [ ] VM test: pin for profile X reported pinned when active is Y
-- [ ] **CHECKPOINT B** — human review (grouping/collapse + pins on-device)
+- [x] **T2** Two-tier collapsible Profile→Workspace groups, persisted
+  - [x] `GroupExpansionStore` (DataStore; store collapsed set; default expanded)
+  - [x] VM: collapsed-keys flow + `toggleGroup(key)`
+  - [x] Screen: two-tier headers, collapse hides children, persisted, unique keys
+  - [x] VM test: toggle flips set; collapsed profile excludes its rows
+- [x] **T5** Pins render cross-profile + labeled device-local
+  - [x] Pin match/toggle keyed by `session.profile` (not active profile)
+  - [x] "Device only" caption on Pinned section
+  - [x] VM test: pin for profile X reported pinned when active is Y
+- [x] **CHECKPOINT B** — human review (grouping/collapse + pins on-device)
 
 ## Phase 3 — Behavior & parity
-- [ ] **T3** Auto-switch active profile on open + thread profile to RPCs
-  - [ ] VM `prepareOpen(session)` → `switchTo(profile)` when differing, awaited
-  - [ ] Screen: tap launches `prepareOpen` then `onOpen` (switch settles first)
-  - [ ] VM test: switches only for non-active profile
-  - [ ] On-device: open cross-profile session end-to-end (history+resume+model)
-- [ ] **T4** Archive parity verified; archived view cross-profile
-  - [ ] Archived view sources across all profiles
-  - [ ] Confirm active list excludes archived + refreshes on resume
-  - [ ] On-device: desktop archive ↔ mobile reflects both ways
-- [ ] **CHECKPOINT C** — human review (full behavioral review)
+- [x] **T3** Auto-switch active profile on open + thread profile to RPCs
+  - [x] VM `prepareOpen(session)` → `switchTo(profile)` when differing, awaited
+  - [x] Screen: tap launches `prepareOpen` then `onOpen` (switch settles first)
+  - [x] VM test: switches only for non-active profile
+  - [x] On-device: open cross-profile session end-to-end (history+resume+model)
+- [x] **T4** Archive parity verified; archived view cross-profile
+  - [x] Archived view sources across all profiles
+  - [x] Confirm active list excludes archived + refreshes on resume
+  - [x] On-device: desktop archive ↔ mobile reflects both ways
+- [x] **CHECKPOINT C** — human review (full behavioral review)
 
 ## Phase 4 — Ship
-- [ ] **T6** Build, test, beta APK, ship to develop
-  - [ ] Bump versionCode/versionName
-  - [ ] gitleaks clean; full unit suite green
-  - [ ] Build beta APK, deliver, commit, PR into `develop`
-  - [ ] Update README / idea doc status
+- [x] **T6** Build, test, beta APK, ship to develop
+  - [x] Bump versionCode/versionName
+  - [x] gitleaks clean; full unit suite green
+  - [x] Build beta APK, deliver, commit, PR into `develop`
+  - [x] Update README / idea doc status

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,45 @@
+# TODO — Session Parity (Direction A)
+
+Branch: `feature/session-parity` off `develop`. Full plan: `tasks/plan.md`.
+
+## Phase 1 — Foundation
+- [ ] **T1** All-profiles list; each session under its true profile
+  - [ ] `SessionDto`: add `archived`, `isDefaultProfile`; add `ProfileSessionsDto`
+  - [ ] `HermesRestApi.profileSessions(limit=500)` → `/api/profiles/sessions`
+  - [ ] `Models`/`Mappers`: carry `archived`; normalize default profile label
+  - [ ] `SessionRepository.listAllProfiles()`
+  - [ ] `SessionsViewModel.refresh()` uses all-profiles; stop active-profile scoping
+  - [ ] Row shows its profile (interim, until T2)
+  - [ ] mockwebserver test: profiles map to correct per-session `profile`
+- [ ] **CHECKPOINT A** — human review (all-profiles list renders correctly)
+
+## Phase 2 — Structure & pins
+- [ ] **T2** Two-tier collapsible Profile→Workspace groups, persisted
+  - [ ] `GroupExpansionStore` (DataStore; store collapsed set; default expanded)
+  - [ ] VM: collapsed-keys flow + `toggleGroup(key)`
+  - [ ] Screen: two-tier headers, collapse hides children, persisted, unique keys
+  - [ ] VM test: toggle flips set; collapsed profile excludes its rows
+- [ ] **T5** Pins render cross-profile + labeled device-local
+  - [ ] Pin match/toggle keyed by `session.profile` (not active profile)
+  - [ ] "Device only" caption on Pinned section
+  - [ ] VM test: pin for profile X reported pinned when active is Y
+- [ ] **CHECKPOINT B** — human review (grouping/collapse + pins on-device)
+
+## Phase 3 — Behavior & parity
+- [ ] **T3** Auto-switch active profile on open + thread profile to RPCs
+  - [ ] VM `prepareOpen(session)` → `switchTo(profile)` when differing, awaited
+  - [ ] Screen: tap launches `prepareOpen` then `onOpen` (switch settles first)
+  - [ ] VM test: switches only for non-active profile
+  - [ ] On-device: open cross-profile session end-to-end (history+resume+model)
+- [ ] **T4** Archive parity verified; archived view cross-profile
+  - [ ] Archived view sources across all profiles
+  - [ ] Confirm active list excludes archived + refreshes on resume
+  - [ ] On-device: desktop archive ↔ mobile reflects both ways
+- [ ] **CHECKPOINT C** — human review (full behavioral review)
+
+## Phase 4 — Ship
+- [ ] **T6** Build, test, beta APK, ship to develop
+  - [ ] Bump versionCode/versionName
+  - [ ] gitleaks clean; full unit suite green
+  - [ ] Build beta APK, deliver, commit, PR into `develop`
+  - [ ] Update README / idea doc status


### PR DESCRIPTION
Promotes the session-parity work and the follow-up fixes from `develop` to `main` for a stable release.

## Included
- **Session parity** — all-profiles work, then scoped to the **active profile** (drawer-switched, like the desktop); two-tier collapsible Profile→Workspace groups; profile auto-switch on open; archive parity; device-local pins.
- **Launch-crash fix (0.1.15)** — self-healing `EncryptedCredentialStore` (recovers from a corrupted keyset instead of crash-looping) + on-device crash reporter.
- **Desktop-matching list (0.1.16)** — hides cron + empty 0-message sessions.
- **Active-profile scoping (0.1.17)**.
- **Archive/rename/delete fix (0.1.18)** — these silently 404'd without a profile; now carry it.

## Gates
- Dependabot: no open HIGH/CRITICAL.
- gitleaks: clean (12 commits).
- Unit tests: 70 passing.
