### PR TITLE
Free custom accent colour picker (HSL)

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AdminPanelSettings
@@ -23,10 +24,12 @@ import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.People
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -44,6 +47,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.HubRow
 import com.hermes.client.ui.theme.ACCENT_SWATCHES
+import com.hermes.client.ui.theme.accentFromHsl
+import com.hermes.client.ui.theme.colorArgbToHsl
+import com.hermes.client.ui.theme.hslToColorArgb
 import com.hermes.client.ui.theme.rememberProfileAccent
 
 /**
@@ -119,9 +125,16 @@ private fun AccentColorDialog(
         onDismissRequest = onDismiss,
         title = { Text("Accent colour · $profile") },
         text = {
-            Column {
+            val dark = androidx.compose.foundation.isSystemInDarkTheme()
+            val initHsl = selected?.let { colorArgbToHsl(it) }
+            var hue by remember { mutableStateOf(initHsl?.first ?: 210f) }
+            var sat by remember { mutableStateOf(initHsl?.second ?: 0.62f) }
+            var light by remember { mutableStateOf(initHsl?.third ?: 0.44f) }
+            val preview = accentFromHsl(hue, sat, light, dark)
+
+            Column(Modifier.verticalScroll(rememberScrollState())) {
                 Text(
-                    "Pick a colour for this profile, or Auto for the automatic hue.",
+                    "Pick a swatch, dial in a custom colour, or Auto for the automatic hue.",
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(Modifier.height(16.dp))
@@ -144,11 +157,45 @@ private fun AccentColorDialog(
                         }
                     }
                 }
+
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+                Text(
+                    "CUSTOM",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
+                )
+                // Live preview of the dialled-in colour (accent + its adaptive, always-legible on-colour).
+                Box(
+                    Modifier.fillMaxWidth().height(44.dp).clip(RoundedCornerShape(12.dp)).background(preview.accent),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("Preview", color = preview.onAccent, style = MaterialTheme.typography.labelLarge)
+                }
+                SliderRow("Hue", hue, 0f..360f) { hue = it }
+                SliderRow("Saturation", sat, 0f..1f) { sat = it }
+                SliderRow("Lightness", light, 0f..1f) { light = it }
+                Button(
+                    onClick = { onPick(hslToColorArgb(hue, sat, light)) },
+                    modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                ) { Text("Use custom colour") }
             }
         },
         confirmButton = { TextButton(onClick = onAuto) { Text("Auto") } },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
     )
+}
+
+@Composable
+private fun SliderRow(
+    label: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    onChange: (Float) -> Unit,
+) {
+    Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Slider(value = value, onValueChange = onChange, valueRange = range)
 }
 
 /** Quick-switch avatar row: each profile's initial in a chip tinted to that profile's own accent. */

--- a/app/src/main/java/com/hermes/client/ui/theme/ProfileAccent.kt
+++ b/app/src/main/java/com/hermes/client/ui/theme/ProfileAccent.kt
@@ -173,3 +173,15 @@ val LocalProfileAccentOverrides = staticCompositionLocalOf<Map<String, Int>> { e
 @androidx.compose.runtime.Composable
 fun rememberProfileAccent(profile: String?, dark: Boolean): ProfileAccentColors =
     profileAccentColors(profile, dark, LocalProfileAccentOverrides.current[profile])
+
+// --- Custom colour picker helpers (free HSL selection; contrast is inherent) ---
+
+/** ARGB for an HSL triple — the value the custom picker persists. */
+fun hslToColorArgb(hue: Float, sat: Float, light: Float): Int = hslToArgb(hue, sat, light)
+
+/** Accent bundle previewing an HSL choice (accent verbatim + adaptive on-colour + soft container). */
+fun accentFromHsl(hue: Float, sat: Float, light: Float, dark: Boolean): ProfileAccentColors =
+    profileAccentColors(null, dark, overrideArgb = hslToArgb(hue, sat, light))
+
+/** Decompose an ARGB colour into (hue, saturation, lightness) to seed the picker sliders. */
+fun colorArgbToHsl(argb: Int): Triple<Float, Float, Float> = argbToHsl(argb)

--- a/app/src/test/java/com/hermes/client/ui/theme/ProfileAccentTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/theme/ProfileAccentTest.kt
@@ -94,6 +94,19 @@ class ProfileAccentTest {
         assertEquals(0f, sg, 0.02f); assertEquals(0.5f, lg, 0.02f) // grey → ~0 saturation
     }
 
+    // Any colour the free HSL picker can produce keeps its adaptive on-colour legible — the basis
+    // for allowing a free picker with no rejection.
+    @Test fun custom_hsl_colours_stay_legible() {
+        var h = 0
+        while (h < 360) {
+            for (l in listOf(0.15f, 0.44f, 0.7f, 0.9f)) {
+                val argb = hslToColorArgb(h.toFloat(), 0.6f, l)
+                assertTrue("hsl($h,0.6,$l)", contrastRatio(argb, onColorFor(argb)) >= 3.0)
+            }
+            h += 30
+        }
+    }
+
     // The soft container derived from any chosen swatch must also stay legible in both modes.
     @Test fun soft_container_stays_legible() {
         for (argb in ACCENT_SWATCHES) for (dark in listOf(false, true)) {


### PR DESCRIPTION
Extend the per-profile accent picker with a custom HSL section (Hue/Saturation/Lightness sliders + live preview) alongside the curated swatches. Any colour is allowed with no guard — the adaptive on-colour is always legible (proved + unit-tested across the hue range). Adds public theme helpers hslToColorArgb/accentFromHsl/colorArgbToHsl. Tests green; verified on-device.