### PR TITLE
Release 0.1.20: accent customization + feed/chat polish

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 20
-        versionName = "0.1.19"
+        versionCode = 21
+        versionName = "0.1.20"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -29,6 +29,7 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var credentialStore: CredentialStore
     @Inject lateinit var settingsStore: SettingsStore
     @Inject lateinit var profileManager: ProfileManager
+    @Inject lateinit var profileAccentStore: com.hermes.client.data.repository.ProfileAccentStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,26 +39,33 @@ class MainActivity : ComponentActivity() {
             val mode by settingsStore.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
             val technical by settingsStore.toolCallTechnical.collectAsState(initial = true)
             val activeProfile by profileManager.active.collectAsState()
+            val accentOverrides by profileAccentStore.overrides.collectAsState(initial = emptyMap())
             val dark = when (mode) {
                 ThemeMode.SYSTEM -> isSystemInDarkTheme()
                 ThemeMode.LIGHT -> false
                 ThemeMode.DARK -> true
             }
-            HermesTheme(darkTheme = dark, profile = activeProfile) {
-                CompositionLocalProvider(LocalToolCallTechnical provides technical) {
-                    Surface {
-                        // If the previous run crashed, show the saved trace first so it can be
-                        // shared, then continue into the app once dismissed.
-                        var report by remember { mutableStateOf(crashReport) }
-                        val current = report
-                        if (current != null) {
-                            CrashReportScreen(
-                                report = current,
-                                onShare = { shareCrash(current) },
-                                onDismiss = { CrashReporter.clear(this@MainActivity); report = null },
-                            )
-                        } else {
-                            HermesNav(hasConfig = hasConfig)
+            // Provide the user's per-profile colour overrides above the theme so HermesTheme and
+            // every accent call site (Mission Control pages, You-tab avatars) can honour them.
+            CompositionLocalProvider(
+                com.hermes.client.ui.theme.LocalProfileAccentOverrides provides accentOverrides,
+            ) {
+                HermesTheme(darkTheme = dark, profile = activeProfile) {
+                    CompositionLocalProvider(LocalToolCallTechnical provides technical) {
+                        Surface {
+                            // If the previous run crashed, show the saved trace first so it can be
+                            // shared, then continue into the app once dismissed.
+                            var report by remember { mutableStateOf(crashReport) }
+                            val current = report
+                            if (current != null) {
+                                CrashReportScreen(
+                                    report = current,
+                                    onShare = { shareCrash(current) },
+                                    onDismiss = { CrashReporter.clear(this@MainActivity); report = null },
+                                )
+                            } else {
+                                HermesNav(hasConfig = hasConfig)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/hermes/client/data/repository/ProfileAccentStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ProfileAccentStore.kt
@@ -30,14 +30,14 @@ class ProfileAccentStore(private val context: Context) {
     suspend fun setColor(profile: String, argb: Int) {
         context.profileAccentDataStore.edit { prefs ->
             val cur = prefs[key] ?: emptySet()
-            prefs[key] = cur.filterNot { it.startsWith("$profile=") }.toSet() + "$profile=$argb"
+            prefs[key] = cur.filterNot { it.substringBeforeLast('=') == profile }.toSet() + "$profile=$argb"
         }
     }
 
     suspend fun clear(profile: String) {
         context.profileAccentDataStore.edit { prefs ->
             val cur = prefs[key] ?: emptySet()
-            prefs[key] = cur.filterNot { it.startsWith("$profile=") }.toSet()
+            prefs[key] = cur.filterNot { it.substringBeforeLast('=') == profile }.toSet()
         }
     }
 }

--- a/app/src/main/java/com/hermes/client/data/repository/ProfileAccentStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ProfileAccentStore.kt
@@ -1,0 +1,43 @@
+package com.hermes.client.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.profileAccentDataStore by preferencesDataStore(name = "profile_accent")
+
+/**
+ * Device-local per-profile accent-colour overrides. When a profile has an entry, its accent uses
+ * that chosen colour instead of the auto-hashed hue; with no entry it falls back to the hash.
+ * Stored as a set of "<profile>=<argb>" entries so the whole map reads back in one flow.
+ */
+class ProfileAccentStore(private val context: Context) {
+    private val key = stringSetPreferencesKey("colors")
+
+    /** profile name → chosen ARGB colour. */
+    val overrides: Flow<Map<String, Int>> = context.profileAccentDataStore.data.map { prefs ->
+        (prefs[key] ?: emptySet()).mapNotNull { entry ->
+            val i = entry.lastIndexOf('=')
+            if (i <= 0) return@mapNotNull null
+            val argb = entry.substring(i + 1).toIntOrNull() ?: return@mapNotNull null
+            entry.substring(0, i) to argb
+        }.toMap()
+    }
+
+    suspend fun setColor(profile: String, argb: Int) {
+        context.profileAccentDataStore.edit { prefs ->
+            val cur = prefs[key] ?: emptySet()
+            prefs[key] = cur.filterNot { it.startsWith("$profile=") }.toSet() + "$profile=$argb"
+        }
+    }
+
+    suspend fun clear(profile: String) {
+        context.profileAccentDataStore.edit { prefs ->
+            val cur = prefs[key] ?: emptySet()
+            prefs[key] = cur.filterNot { it.startsWith("$profile=") }.toSet()
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -141,6 +141,13 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideProfileAccentStore(
+        @ApplicationContext context: Context,
+    ): com.hermes.client.data.repository.ProfileAccentStore =
+        com.hermes.client.data.repository.ProfileAccentStore(context)
+
+    @Provides
+    @Singleton
     fun provideAnalyticsRepository(rest: HermesRestApi): com.hermes.client.data.repository.AnalyticsRepository =
         com.hermes.client.data.repository.AnalyticsRepository(rest)
 

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -51,7 +51,7 @@ import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.LoadingState
 import com.hermes.client.ui.nav.ShellViewModel
 import com.hermes.client.ui.theme.LocalProfileAccent
-import com.hermes.client.ui.theme.profileAccentColors
+import com.hermes.client.ui.theme.rememberProfileAccent
 import com.hermes.client.ui.util.relativeTime
 import kotlinx.coroutines.launch
 
@@ -104,7 +104,7 @@ fun MissionControlScreen(
 
     val currentProfile = names.getOrNull(pagerState.currentPage)
     // Top bar + tabs paint in the *current page's* accent, so the chrome shifts colour as you swipe.
-    CompositionLocalProvider(LocalProfileAccent provides profileAccentColors(currentProfile, dark)) {
+    CompositionLocalProvider(LocalProfileAccent provides rememberProfileAccent(currentProfile, dark)) {
         Scaffold(
             topBar = {
                 Column {
@@ -149,7 +149,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     val onOpen: (String) -> Unit = { route -> scope.launch { vm.switchTo(profile); onNavigate(route) } }
 
     // Each page paints in its own tenant accent so peeking pages during a swipe read correctly.
-    CompositionLocalProvider(LocalProfileAccent provides profileAccentColors(profile, dark)) {
+    CompositionLocalProvider(LocalProfileAccent provides rememberProfileAccent(profile, dark)) {
         MissionControlContent(state = state, nowMs = now, onRetry = { vm.refresh() }, onOpen = onOpen)
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -133,6 +133,7 @@ fun MissionControlScreen(
     }
 }
 
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
 @Composable
 private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (String) -> Unit) {
     // One VM instance per tenant page, keyed by profile name.
@@ -148,9 +149,19 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     // the chat/cron screen acts against the right per-profile DB.
     val onOpen: (String) -> Unit = { route -> scope.launch { vm.switchTo(profile); onNavigate(route) } }
 
+    // Pull-to-refresh: the indicator shows only for an explicit pull (not the ON_RESUME reload),
+    // and clears when the load finishes.
+    var refreshing by remember { mutableStateOf(false) }
+    LaunchedEffect(state.loading) { if (!state.loading) refreshing = false }
+
     // Each page paints in its own tenant accent so peeking pages during a swipe read correctly.
     CompositionLocalProvider(LocalProfileAccent provides rememberProfileAccent(profile, dark)) {
-        MissionControlContent(state = state, nowMs = now, onRetry = { vm.refresh() }, onOpen = onOpen)
+        androidx.compose.material3.pulltorefresh.PullToRefreshBox(
+            isRefreshing = refreshing,
+            onRefresh = { refreshing = true; vm.refresh() },
+        ) {
+            MissionControlContent(state = state, nowMs = now, onRetry = { vm.refresh() }, onOpen = onOpen)
+        }
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -3,6 +3,8 @@ package com.hermes.client.ui.chat
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -56,6 +58,13 @@ import com.hermes.client.domain.ChatMessage
 import com.hermes.client.domain.Role
 import com.hermes.client.domain.ToolCall
 import com.hermes.client.domain.ToolStatus
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material3.IconButton
+import androidx.compose.ui.text.TextStyle
+import com.mikepenz.markdown.compose.components.MarkdownComponents
+import com.mikepenz.markdown.compose.components.markdownComponents
+import com.mikepenz.markdown.compose.elements.MarkdownCodeBlock
+import com.mikepenz.markdown.compose.elements.MarkdownCodeFence
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
@@ -210,7 +219,13 @@ private fun AssistantTurn(msg: ChatMessage) {
                     )
                 }
             } else {
-                Markdown(content = msg.text, colors = markdownColor(), typography = markdownTypography())
+                val mdComponents = remember { chatMarkdownComponents() }
+                Markdown(
+                    content = msg.text,
+                    colors = markdownColor(),
+                    typography = markdownTypography(),
+                    components = mdComponents,
+                )
             }
         }
         if (msg.isStreaming && msg.text.isBlank() && msg.tools.isEmpty()) {
@@ -227,6 +242,60 @@ private fun copyToClipboard(
     if (text.isNotBlank()) {
         clipboard.setText(AnnotatedString(text))
         Toast.makeText(context, "Copied", Toast.LENGTH_SHORT).show()
+    }
+}
+
+/**
+ * Markdown component set that renders code blocks/fences with a copy button. The library's fence
+ * renderer already extracts the clean code text and hands it to this block, so we just overlay a
+ * copy affordance on the default code rendering.
+ */
+private fun chatMarkdownComponents(): MarkdownComponents =
+    markdownComponents(
+        codeFence = { m ->
+            MarkdownCodeFence(m.content, m.node, style = m.typography.code) { code, language, style ->
+                CodeWithCopy(code, language, style)
+            }
+        },
+        codeBlock = { m ->
+            MarkdownCodeBlock(m.content, m.node, style = m.typography.code) { code, language, style ->
+                CodeWithCopy(code, language, style)
+            }
+        },
+    )
+
+@Composable
+private fun CodeWithCopy(code: String, @Suppress("UNUSED_PARAMETER") language: String?, style: TextStyle) {
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Text(
+            text = code,
+            style = style,
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(12.dp)
+                .padding(end = 32.dp), // leave room for the copy button
+        )
+        IconButton(
+            onClick = {
+                clipboard.setText(AnnotatedString(code))
+                Toast.makeText(context, "Code copied", Toast.LENGTH_SHORT).show()
+            },
+            modifier = Modifier.align(Alignment.TopEnd),
+        ) {
+            Icon(
+                Icons.Rounded.ContentCopy,
+                contentDescription = "Copy code",
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -278,9 +278,10 @@ private fun CodeWithCopy(code: String, @Suppress("UNUSED_PARAMETER") language: S
             text = code,
             style = style,
             modifier = Modifier
+                // Reserve the copy-button area OUTSIDE the scroll so long code never slides under it.
+                .padding(end = 44.dp)
                 .horizontalScroll(rememberScrollState())
-                .padding(12.dp)
-                .padding(end = 32.dp), // leave room for the copy button
+                .padding(12.dp),
         )
         IconButton(
             onClick = {

--- a/app/src/main/java/com/hermes/client/ui/nav/ShellViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/ShellViewModel.kt
@@ -3,6 +3,7 @@ package com.hermes.client.ui.nav
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hermes.client.data.network.ProfileDto
+import com.hermes.client.data.repository.ProfileAccentStore
 import com.hermes.client.data.repository.ProfileManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -12,6 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ShellViewModel @Inject constructor(
     private val profileManager: ProfileManager,
+    private val accentStore: ProfileAccentStore,
 ) : ViewModel() {
     val profiles: StateFlow<List<ProfileDto>> = profileManager.list
     val active: StateFlow<String?> = profileManager.active
@@ -19,4 +21,10 @@ class ShellViewModel @Inject constructor(
     init { viewModelScope.launch { profileManager.refresh() } }
 
     fun switchProfile(name: String) = viewModelScope.launch { profileManager.switchTo(name) }
+
+    /** Set a custom accent colour for [profile] (persisted; overrides the auto-hashed hue). */
+    fun setAccent(profile: String, argb: Int) = viewModelScope.launch { accentStore.setColor(profile, argb) }
+
+    /** Clear [profile]'s custom colour, reverting to the auto hue. */
+    fun clearAccent(profile: String) = viewModelScope.launch { accentStore.clear(profile) }
 }

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AdminPanelSettings
@@ -23,10 +24,12 @@ import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.People
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -44,6 +47,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.HubRow
 import com.hermes.client.ui.theme.ACCENT_SWATCHES
+import com.hermes.client.ui.theme.accentFromHsl
+import com.hermes.client.ui.theme.colorArgbToHsl
+import com.hermes.client.ui.theme.hslToColorArgb
 import com.hermes.client.ui.theme.rememberProfileAccent
 
 /**
@@ -119,9 +125,16 @@ private fun AccentColorDialog(
         onDismissRequest = onDismiss,
         title = { Text("Accent colour · $profile") },
         text = {
-            Column {
+            val dark = androidx.compose.foundation.isSystemInDarkTheme()
+            val initHsl = selected?.let { colorArgbToHsl(it) }
+            var hue by remember { mutableStateOf(initHsl?.first ?: 210f) }
+            var sat by remember { mutableStateOf(initHsl?.second ?: 0.62f) }
+            var light by remember { mutableStateOf(initHsl?.third ?: 0.44f) }
+            val preview = accentFromHsl(hue, sat, light, dark)
+
+            Column(Modifier.verticalScroll(rememberScrollState())) {
                 Text(
-                    "Pick a colour for this profile, or Auto for the automatic hue.",
+                    "Pick a swatch, dial in a custom colour, or Auto for the automatic hue.",
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(Modifier.height(16.dp))
@@ -144,11 +157,45 @@ private fun AccentColorDialog(
                         }
                     }
                 }
+
+                Spacer(Modifier.height(8.dp))
+                HorizontalDivider()
+                Text(
+                    "CUSTOM",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
+                )
+                // Live preview of the dialled-in colour (accent + its adaptive, always-legible on-colour).
+                Box(
+                    Modifier.fillMaxWidth().height(44.dp).clip(RoundedCornerShape(12.dp)).background(preview.accent),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("Preview", color = preview.onAccent, style = MaterialTheme.typography.labelLarge)
+                }
+                SliderRow("Hue", hue, 0f..360f) { hue = it }
+                SliderRow("Saturation", sat, 0f..1f) { sat = it }
+                SliderRow("Lightness", light, 0f..1f) { light = it }
+                Button(
+                    onClick = { onPick(hslToColorArgb(hue, sat, light)) },
+                    modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                ) { Text("Use custom colour") }
             }
         },
         confirmButton = { TextButton(onClick = onAuto) { Text("Auto") } },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
     )
+}
+
+@Composable
+private fun SliderRow(
+    label: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    onChange: (Float) -> Unit,
+) {
+    Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Slider(value = value, onValueChange = onChange, valueRange = range)
 }
 
 /** Quick-switch avatar row: each profile's initial in a chip tinted to that profile's own accent. */

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -16,23 +18,33 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AdminPanelSettings
 import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.People
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.HubRow
-import com.hermes.client.ui.theme.profileAccentColors
+import com.hermes.client.ui.theme.ACCENT_SWATCHES
+import com.hermes.client.ui.theme.rememberProfileAccent
 
 /**
  * "You" tab — profile identity + everything about the account/app: the profile quick-switch
@@ -45,6 +57,8 @@ fun YouHubScreen(
 ) {
     val profiles by vm.profiles.collectAsStateWithLifecycle()
     val active by vm.active.collectAsStateWithLifecycle()
+    var showColorPicker by remember { mutableStateOf(false) }
+    val currentOverride = active?.let { com.hermes.client.ui.theme.LocalProfileAccentOverrides.current[it] }
 
     Scaffold(topBar = { HermesTopBar(title = "You", subtitle = active?.let { "Active profile: $it" }) }) { padding ->
         Column(Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState())) {
@@ -59,6 +73,13 @@ fun YouHubScreen(
                 active = active,
                 onSwitch = { vm.switchProfile(it) },
             )
+            active?.let { a ->
+                HubRow(
+                    Icons.Rounded.Palette,
+                    "Accent colour",
+                    if (currentOverride != null) "Custom colour for \"$a\"" else "Auto colour for \"$a\"",
+                ) { showColorPicker = true }
+            }
             HorizontalDivider(Modifier.padding(vertical = 12.dp))
 
             HubRow(Icons.Rounded.People, "Profiles", "Manage tenant profiles") { onNavigate("profiles") }
@@ -70,6 +91,64 @@ fun YouHubScreen(
             HubRow(Icons.Rounded.Settings, "Settings", "App & connection settings") { onNavigate("settings") }
         }
     }
+
+    if (showColorPicker) {
+        active?.let { a ->
+            AccentColorDialog(
+                profile = a,
+                selected = currentOverride,
+                onPick = { argb -> vm.setAccent(a, argb); showColorPicker = false },
+                onAuto = { vm.clearAccent(a); showColorPicker = false },
+                onDismiss = { showColorPicker = false },
+            )
+        }
+    }
+}
+
+/** Curated-swatch colour picker for a profile's accent, with an Auto (clear) option. Swatches are
+ *  contrast-safe by construction, so any pick keeps chrome text legible. */
+@Composable
+private fun AccentColorDialog(
+    profile: String,
+    selected: Int?,
+    onPick: (Int) -> Unit,
+    onAuto: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Accent colour · $profile") },
+        text = {
+            Column {
+                Text(
+                    "Pick a colour for this profile, or Auto for the automatic hue.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(Modifier.height(16.dp))
+                ACCENT_SWATCHES.chunked(6).forEach { rowColors ->
+                    Row {
+                        rowColors.forEach { argb ->
+                            Box(
+                                Modifier
+                                    .padding(6.dp)
+                                    .size(40.dp)
+                                    .clip(CircleShape)
+                                    .background(Color(argb))
+                                    .clickable { onPick(argb) },
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                if (argb == selected) {
+                                    Icon(Icons.Rounded.Check, contentDescription = "Selected", tint = Color.White)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onAuto) { Text("Auto") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+    )
 }
 
 /** Quick-switch avatar row: each profile's initial in a chip tinted to that profile's own accent. */
@@ -83,7 +162,7 @@ private fun ProfileAvatarRow(profiles: List<String>, active: String?, onSwitch: 
             val selected = name == active
             // Each avatar previews that profile's own accent hue, so the switcher itself teaches
             // the color mapping.
-            val accent = profileAccentColors(name, dark)
+            val accent = rememberProfileAccent(name, dark)
             Column(
                 Modifier.padding(end = 12.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/hermes/client/ui/theme/ProfileAccent.kt
+++ b/app/src/main/java/com/hermes/client/ui/theme/ProfileAccent.kt
@@ -173,3 +173,15 @@ val LocalProfileAccentOverrides = staticCompositionLocalOf<Map<String, Int>> { e
 @androidx.compose.runtime.Composable
 fun rememberProfileAccent(profile: String?, dark: Boolean): ProfileAccentColors =
     profileAccentColors(profile, dark, LocalProfileAccentOverrides.current[profile])
+
+// --- Custom colour picker helpers (free HSL selection; contrast is inherent) ---
+
+/** ARGB for an HSL triple — the value the custom picker persists. */
+fun hslToColorArgb(hue: Float, sat: Float, light: Float): Int = hslToArgb(hue, sat, light)
+
+/** Accent bundle previewing an HSL choice (accent verbatim + adaptive on-colour + soft container). */
+fun accentFromHsl(hue: Float, sat: Float, light: Float, dark: Boolean): ProfileAccentColors =
+    profileAccentColors(null, dark, overrideArgb = hslToArgb(hue, sat, light))
+
+/** Decompose an ARGB colour into (hue, saturation, lightness) to seed the picker sliders. */
+fun colorArgbToHsl(argb: Int): Triple<Float, Float, Float> = argbToHsl(argb)

--- a/app/src/main/java/com/hermes/client/ui/theme/ProfileAccent.kt
+++ b/app/src/main/java/com/hermes/client/ui/theme/ProfileAccent.kt
@@ -114,9 +114,11 @@ data class ProfileAccentColors(
     val onContainer: Color,
 )
 
-fun profileAccentColors(profile: String?, dark: Boolean): ProfileAccentColors {
-    val a = accentArgb(profile, dark)
-    val c = containerArgb(profile, dark)
+fun profileAccentColors(profile: String?, dark: Boolean, overrideArgb: Int? = null): ProfileAccentColors {
+    // A user-chosen colour (if any) is used verbatim as the accent; otherwise fall back to the
+    // deterministic hashed hue. The soft container is derived from whichever colour we end up with.
+    val a = overrideArgb ?: accentArgb(profile, dark)
+    val c = if (overrideArgb != null) softContainerFrom(overrideArgb, dark) else containerArgb(profile, dark)
     return ProfileAccentColors(
         accent = Color(a),
         onAccent = Color(onColorFor(a)),
@@ -125,5 +127,49 @@ fun profileAccentColors(profile: String?, dark: Boolean): ProfileAccentColors {
     )
 }
 
+/** Soft accent-tinted container derived from a chosen accent colour (for the top-bar tint). */
+internal fun softContainerFrom(argb: Int, dark: Boolean): Int {
+    val (h, s, _) = argbToHsl(argb)
+    return hslToArgb(h, s * 0.55f, if (dark) 0.24f else 0.90f)
+}
+
+/** ARGB → HSL (hue in [0,360), saturation/lightness in [0,1]); alpha ignored. */
+internal fun argbToHsl(argb: Int): Triple<Float, Float, Float> {
+    val r = ((argb shr 16) and 0xFF) / 255f
+    val g = ((argb shr 8) and 0xFF) / 255f
+    val b = (argb and 0xFF) / 255f
+    val max = maxOf(r, g, b)
+    val min = minOf(r, g, b)
+    val l = (max + min) / 2f
+    if (max == min) return Triple(0f, 0f, l)
+    val d = max - min
+    val s = if (l > 0.5f) d / (2f - max - min) else d / (max + min)
+    val h = when (max) {
+        r -> (g - b) / d + (if (g < b) 6f else 0f)
+        g -> (b - r) / d + 2f
+        else -> (r - g) / d + 4f
+    } * 60f
+    return Triple(h, s, l)
+}
+
+/**
+ * Curated, contrast-safe accent swatches for the per-profile colour picker: evenly-spaced hues at
+ * a saturation/lightness whose on-colour stays legible (verified in tests). Lets users set a
+ * colour without a free wheel that could produce an illegible tint.
+ */
+// Contrast is guaranteed by construction: onColorFor() adaptively picks black or white, and the
+// worst-case max(black,white) contrast for any opaque colour is ~4.58 — always above the AA-large
+// 3.0 bar. So any chosen colour stays legible as long as chrome text uses the paired on-colour;
+// no colour needs to be rejected. (This is why the picker can even be a free wheel later.)
+val ACCENT_SWATCHES: List<Int> = (0 until 12).map { hslToArgb(it * 30f, 0.62f, 0.44f) }
+
 /** Available anywhere in the tree; defaults to the brand (no-profile) accent in light mode. */
 val LocalProfileAccent = staticCompositionLocalOf { profileAccentColors(null, dark = false) }
+
+/** Per-profile colour overrides (profile name → ARGB), provided at the app root from persistence. */
+val LocalProfileAccentOverrides = staticCompositionLocalOf<Map<String, Int>> { emptyMap() }
+
+/** Accent for [profile], consulting the user's override map from [LocalProfileAccentOverrides]. */
+@androidx.compose.runtime.Composable
+fun rememberProfileAccent(profile: String?, dark: Boolean): ProfileAccentColors =
+    profileAccentColors(profile, dark, LocalProfileAccentOverrides.current[profile])

--- a/app/src/main/java/com/hermes/client/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hermes/client/ui/theme/Theme.kt
@@ -30,7 +30,8 @@ fun HermesTheme(
         darkTheme -> HermesDarkColors
         else -> HermesLightColors
     }
-    val accent = profileAccentColors(profile, darkTheme)
+    // Honour a user-chosen colour for the active profile (falls back to the hashed hue).
+    val accent = profileAccentColors(profile, darkTheme, LocalProfileAccentOverrides.current[profile])
 
     CompositionLocalProvider(LocalProfileAccent provides accent) {
         MaterialTheme(

--- a/app/src/test/java/com/hermes/client/ui/theme/ProfileAccentTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/theme/ProfileAccentTest.kt
@@ -94,6 +94,19 @@ class ProfileAccentTest {
         assertEquals(0f, sg, 0.02f); assertEquals(0.5f, lg, 0.02f) // grey → ~0 saturation
     }
 
+    // Any colour the free HSL picker can produce keeps its adaptive on-colour legible — the basis
+    // for allowing a free picker with no rejection.
+    @Test fun custom_hsl_colours_stay_legible() {
+        var h = 0
+        while (h < 360) {
+            for (l in listOf(0.15f, 0.44f, 0.7f, 0.9f)) {
+                val argb = hslToColorArgb(h.toFloat(), 0.6f, l)
+                assertTrue("hsl($h,0.6,$l)", contrastRatio(argb, onColorFor(argb)) >= 3.0)
+            }
+            h += 30
+        }
+    }
+
     // The soft container derived from any chosen swatch must also stay legible in both modes.
     @Test fun soft_container_stays_legible() {
         for (argb in ACCENT_SWATCHES) for (dark in listOf(false, true)) {

--- a/app/src/test/java/com/hermes/client/ui/theme/ProfileAccentTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/theme/ProfileAccentTest.kt
@@ -67,4 +67,39 @@ class ProfileAccentTest {
         assertEquals(0xFFFFFFFF.toInt(), hslToArgb(0f, 0f, 1f))     // white
         assertEquals(0xFF000000.toInt(), hslToArgb(0f, 0f, 0f))     // black
     }
+
+    // Every picker swatch must keep its on-colour legible — the contrast guarantee for the
+    // user-settable accent feature (its adaptive on-colour clears AA-large).
+    @Test fun all_swatches_are_contrast_safe() {
+        assertEquals(12, ACCENT_SWATCHES.size)
+        ACCENT_SWATCHES.forEach {
+            assertTrue(
+                "swatch ${Integer.toHexString(it)}",
+                contrastRatio(it, onColorFor(it)) >= 3.0,
+            )
+        }
+    }
+
+    // The adaptive on-colour keeps *any* opaque colour legible — even a mid-grey, where black wins.
+    @Test fun adaptive_on_colour_keeps_any_colour_legible() {
+        for (argb in listOf(0xFF808080.toInt(), 0xFF3366CC.toInt(), 0xFFEEDD00.toInt())) {
+            assertTrue(contrastRatio(argb, onColorFor(argb)) >= 3.0)
+        }
+    }
+
+    @Test fun argb_to_hsl_known_values() {
+        val (hr, sr, lr) = argbToHsl(0xFFFF0000.toInt())
+        assertEquals(0f, hr, 1f); assertEquals(1f, sr, 0.02f); assertEquals(0.5f, lr, 0.02f)
+        val (_, sg, lg) = argbToHsl(0xFF808080.toInt())
+        assertEquals(0f, sg, 0.02f); assertEquals(0.5f, lg, 0.02f) // grey → ~0 saturation
+    }
+
+    // The soft container derived from any chosen swatch must also stay legible in both modes.
+    @Test fun soft_container_stays_legible() {
+        for (argb in ACCENT_SWATCHES) for (dark in listOf(false, true)) {
+            val c = softContainerFrom(argb, dark)
+            assertTrue("container for ${Integer.toHexString(argb)} dark=$dark",
+                contrastRatio(c, onColorFor(c)) >= 3.0)
+        }
+    }
 }

--- a/docs/ideas/interface-modernization.md
+++ b/docs/ideas/interface-modernization.md
@@ -118,15 +118,15 @@ now that it's public-facing).
   fixed brand color — decide when building the component.
 
 ## Deferred features (post-Phase-1)
-- **User-settable per-profile accent** — let users override the auto-hashed hue with a
-  chosen color per profile (persisted; falls back to the hash when unset). This also
-  sidesteps the birthday-problem collision risk for large profile sets.
-- **Hard contrast guarantee** — any user-chosen or auto color MUST keep chrome text/icons
-  legible. The accent already ships a WCAG-contrast-checked on-color; the rule is that
-  *every* element on a tinted surface uses that on-color (regression seen 0.1.19: the
-  Sessions "Archived" action rendered in theme-primary over the accent and was hard to
-  read — fixed by routing it through `AccentChrome.onBar`). A color picker must run the
-  same contrast check and reject/adjust failing choices.
+- ✅ **User-settable per-profile accent** *(shipped post-0.1.19)* — a curated-swatch picker
+  in the **You** tab writes a per-profile colour to `ProfileAccentStore` (DataStore);
+  `LocalProfileAccentOverrides` threads it through `HermesTheme` and every accent call site,
+  with "Auto" to revert to the hashed hue.
+- ✅ **Contrast guarantee** *(resolved by design)* — turns out no colour needs rejecting: the
+  adaptive `onColorFor()` picks black/white by max contrast, and the worst case for any opaque
+  colour is ~4.58 (above AA-large 3.0). So the guarantee is simply "every element on a tinted
+  surface uses the paired on-colour" (the 0.1.19 "Archived" regression, fixed via
+  `AccentChrome.onBar`). No picker guard required — even a free wheel would be safe.
 
 ## Status
 Idea refined 2026-07-02. Direction: **A now / B later**, hybrid chat, chrome-only


### PR DESCRIPTION
## Release 0.1.20 — accent customization + feed/chat polish

Promotes the post-0.1.19 work from `develop` to stable.

### User-settable per-profile accent
- **Curated swatches + a free custom HSL picker** (Hue/Saturation/Lightness sliders with a live preview) in the **You** tab. Choices persist per profile (`ProfileAccentStore`) and thread through the theme via `LocalProfileAccentOverrides`; **Auto** reverts to the hashed hue.
- No contrast guard needed — the adaptive on-colour keeps any colour legible (worst case ~4.58 vs the AA-large 3.0 bar); proved and unit-tested across the hue range.

### Mission Control
- **Pull-to-refresh** on the feed (indicator only for an explicit pull).

### Chat
- **Copyable code blocks** — a Copy button that copies just the code.

### Verification
- Unit tests green (accent/contrast/HSL suites); `assembleBeta`/`assembleRelease` build clean; exercised on a physical Pixel.
- gitleaks clean; no open HIGH/CRITICAL Dependabot alerts.

Version: `0.1.20` (versionCode 21).
