### PR TITLE
Model picker: show confirmed model + clarify Settings default

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -67,6 +67,7 @@ fun ChatScreen(
     val connState by vm.connectionState.collectAsStateWithLifecycle()
     val unauthorized by vm.unauthorized.collectAsStateWithLifecycle()
     val models by vm.models.collectAsStateWithLifecycle()
+    val currentModel by vm.currentModel.collectAsStateWithLifecycle()
     val activeProfile by vm.activeProfile.collectAsStateWithLifecycle()
     val commands by vm.commands.collectAsStateWithLifecycle()
     val pathItems by vm.pathItems.collectAsStateWithLifecycle()
@@ -130,6 +131,7 @@ fun ChatScreen(
                     if (models.isNotEmpty()) {
                         ModelPickerButton(
                             models = models,
+                            currentModel = currentModel,
                             onSelect = { vm.selectModel(it.provider, it.model) },
                         )
                     }
@@ -274,11 +276,12 @@ private fun ConnectionBanner(state: ConnectionState, onRetry: () -> Unit) {
 @Composable
 private fun ModelPickerButton(
     models: List<ModelOptionDto>,
+    currentModel: String?,
     onSelect: (ModelOptionDto) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     TextButton(onClick = { expanded = true }) {
-        Text("Model")
+        Text(currentModel ?: "Model", maxLines = 1)
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
             models.forEach { option ->
                 DropdownMenuItem(

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -44,6 +44,12 @@ class ChatViewModel @Inject constructor(
     private val _models = MutableStateFlow<List<ModelOptionDto>>(emptyList())
     val models: StateFlow<List<ModelOptionDto>> = _models.asStateFlow()
 
+    // The model this session is confirmed to be using. Null until a switch succeeds (the gateway
+    // doesn't report the session's current model up-front), so the picker shows "Model" until the
+    // user changes it, then the chosen model as confirmation the switch took.
+    private val _currentModel = MutableStateFlow<String?>(null)
+    val currentModel: StateFlow<String?> = _currentModel.asStateFlow()
+
     private val _profiles = MutableStateFlow<List<ProfileDto>>(emptyList())
     val profiles: StateFlow<List<ProfileDto>> = _profiles.asStateFlow()
 
@@ -206,7 +212,10 @@ class ChatViewModel @Inject constructor(
                 // result (or an error like "Could not resolve credentials for …") in the slash
                 // output, and a worker failure ("slash worker closed pipe") throws. Previously
                 // both were discarded, so a failed switch looked like nothing happened.
-                .onSuccess { out -> appendSystem(out?.takeIf { it.isNotBlank() } ?: "Model set to $model.") }
+                .onSuccess { out ->
+                    _currentModel.value = model
+                    appendSystem(out?.takeIf { it.isNotBlank() } ?: "Model set to $model.")
+                }
                 .onFailure { e ->
                     // Don't swallow cancellation — rethrow so structured concurrency still works.
                     if (e is kotlinx.coroutines.CancellationException) throw e

--- a/app/src/main/java/com/hermes/client/ui/models/ModelsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/models/ModelsScreen.kt
@@ -52,6 +52,15 @@ fun ModelsScreen(
                 state.loading -> com.hermes.client.ui.components.LoadingState()
                 state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
                 else -> LazyColumn(Modifier.fillMaxSize()) {
+                    item(key = "hint") {
+                        Text(
+                            "Sets the default model for new sessions. A chat that's already running keeps " +
+                                "its own model — open that chat and use its Model picker to switch it.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        )
+                    }
                     state.providers.forEach { provider ->
                         item(key = "h-${provider.slug}") {
                             Text(


### PR DESCRIPTION
Small UX clarity fixes surfaced while debugging a "changing the model doesn't work" report (whose root cause was gateway-side, not the app).

- **In-chat Model picker** now shows the model after a successful switch, instead of a static "Model" label — so a successful change is actually visible.
- **Settings → Models** gains a one-line hint that it sets the default for *new* sessions and won't retroactively change an already-running chat (use that chat's own Model picker for that). This matches the gateway's per-session model_override behavior and removes the "nothing happened" confusion.

Compile + `testDebugUnitTest` green; gitleaks clean.
