### PR TITLE
Share-to-Hermes: share links/text into a new pre-filled chat

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,11 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -26,6 +26,7 @@ import com.hermes.client.ui.theme.HermesTheme
 import com.hermes.client.ui.theme.LocalToolCallTechnical
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -37,6 +38,8 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var profileManager: ProfileManager
     @Inject lateinit var profileAccentStore: com.hermes.client.data.repository.ProfileAccentStore
     @Inject lateinit var notificationSettings: com.hermes.client.data.repository.NotificationSettings
+    @Inject lateinit var chat: com.hermes.client.data.repository.ChatRepository
+    @Inject lateinit var pendingShare: com.hermes.client.share.PendingShareStore
 
     /**
      * Route requested by a tapped notification (see `HermesNotifier.openIntent`'s
@@ -49,6 +52,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         pendingRoute.value = intent?.getStringExtra("extra_route")
         intent?.removeExtra("extra_route")
+        handleShare(intent)
         val hasConfig = credentialStore.load() != null
         val crashReport = CrashReporter.read(this)
         // Resume the notification service if the user previously enabled it.
@@ -115,6 +119,7 @@ class MainActivity : ComponentActivity() {
         setIntent(intent)
         pendingRoute.value = intent.getStringExtra("extra_route")
         intent.removeExtra("extra_route")
+        handleShare(intent)
     }
 
     /** Share the saved crash trace via the system share sheet. */
@@ -125,5 +130,35 @@ class MainActivity : ComponentActivity() {
             putExtra(Intent.EXTRA_TEXT, report)
         }
         startActivity(Intent.createChooser(intent, "Share crash report"))
+    }
+
+    /**
+     * Handle an incoming ACTION_SEND text share: open a new chat with the shared text pre-filled.
+     * Reuses the notification deep-link rail (pendingRoute -> HermesNav.deepLinkRoute).
+     */
+    private fun handleShare(intent: Intent?) {
+        val text = com.hermes.client.share.sharedText(
+            intent?.action,
+            intent?.type,
+            intent?.getStringExtra(Intent.EXTRA_SUBJECT),
+            intent?.getStringExtra(Intent.EXTRA_TEXT),
+        ) ?: return
+        // Not configured yet -> the app opens to setup; drop the share in v1.
+        if (credentialStore.load() == null) return
+        lifecycleScope.launch {
+            chat.connect()  // idempotent; a cold-start share has no open socket yet, and
+                            // createSession() would otherwise block on the ready-gate forever.
+            runCatching { chat.createSession() }
+                .onSuccess { id ->
+                    pendingShare.put(id, text)
+                    pendingRoute.value = "chat/$id"
+                }
+                .onFailure { e ->
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    android.widget.Toast.makeText(
+                        this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+        }
     }
 }

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -143,11 +143,17 @@ class MainActivity : ComponentActivity() {
             intent?.getStringExtra(Intent.EXTRA_SUBJECT),
             intent?.getStringExtra(Intent.EXTRA_TEXT),
         ) ?: return
+        // Consume the share so a config-change recreation doesn't re-fire it (mirrors the
+        // extra_route handling) — creating a duplicate session and hijacking navigation.
+        intent?.removeExtra(Intent.EXTRA_TEXT)
+        intent?.removeExtra(Intent.EXTRA_SUBJECT)
         // Not configured yet -> the app opens to setup; drop the share in v1.
         if (credentialStore.load() == null) return
         lifecycleScope.launch {
-            chat.connect()  // idempotent; a cold-start share has no open socket yet, and
-                            // createSession() would otherwise block on the ready-gate forever.
+            // connect() first — a cold-start share has no open socket yet, and createSession()
+            // would otherwise fail after the ready-gate timeout. connect() is idempotent, so
+            // this is safe even when already connected.
+            chat.connect()
             runCatching { chat.createSession() }
                 .onSuccess { id ->
                     pendingShare.put(id, text)

--- a/app/src/main/java/com/hermes/client/share/PendingShareStore.kt
+++ b/app/src/main/java/com/hermes/client/share/PendingShareStore.kt
@@ -1,0 +1,27 @@
+package com.hermes.client.share
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One-shot, in-process handoff of shared text from the share entry point to the chat that opens for
+ * it. Not persisted — it only needs to survive a single navigation. take() is keyed by sessionId so
+ * a normal chat open never consumes a share meant for a different (freshly-created) session.
+ */
+@Singleton
+class PendingShareStore @Inject constructor() {
+    private var pending: Pair<String, String>? = null
+
+    @Synchronized
+    fun put(sessionId: String, text: String) {
+        pending = sessionId to text
+    }
+
+    @Synchronized
+    fun take(sessionId: String): String? {
+        val p = pending ?: return null
+        if (p.first != sessionId) return null
+        pending = null
+        return p.second
+    }
+}

--- a/app/src/main/java/com/hermes/client/share/ShareIntent.kt
+++ b/app/src/main/java/com/hermes/client/share/ShareIntent.kt
@@ -1,0 +1,22 @@
+package com.hermes.client.share
+
+import android.content.Intent
+
+/**
+ * Pure: the shareable text from an ACTION_SEND share, or null if this isn't a usable text share.
+ * A shared link commonly puts the page title in EXTRA_SUBJECT and the URL in EXTRA_TEXT, so the two
+ * are combined ("subject\ntext") when they differ. Takes primitives (not an Intent) so it stays
+ * pure and JVM-unit-testable.
+ */
+fun sharedText(action: String?, type: String?, subject: String?, text: String?): String? {
+    if (action != Intent.ACTION_SEND) return null
+    if (type == null || !type.startsWith("text/")) return null
+    val s = subject?.trim().orEmpty()
+    val t = text?.trim().orEmpty()
+    return when {
+        s.isNotEmpty() && t.isNotEmpty() && s != t -> "$s\n$t"
+        t.isNotEmpty() -> t
+        s.isNotEmpty() -> s
+        else -> null
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -74,6 +74,10 @@ fun ChatScreen(
     val commands by vm.commands.collectAsStateWithLifecycle()
     val pathItems by vm.pathItems.collectAsStateWithLifecycle()
     var draft by remember { mutableStateOf("") }
+    val initialDraft by vm.initialDraft.collectAsStateWithLifecycle()
+    androidx.compose.runtime.LaunchedEffect(initialDraft) {
+        initialDraft?.takeIf { it.isNotEmpty() }?.let { draft = it; vm.clearInitialDraft() }
+    }
     // Slash-command palette: when the draft is a "/query", show matching commands.
     val slashMatches = if (draft.startsWith("/") && !draft.contains(' ')) {
         val q = draft.drop(1).lowercase()

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -31,6 +31,7 @@ class ChatViewModel @Inject constructor(
     private val profileRepo: ProfileRepository,
     private val profileManager: ProfileManager,
     private val favoritesStore: com.hermes.client.data.repository.ModelFavoritesStore,
+    private val pendingShareStore: com.hermes.client.share.PendingShareStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ChatUiState.empty())
@@ -55,6 +56,11 @@ class ChatViewModel @Inject constructor(
     // Provider of the confirmed session model (set together with _currentModel on a successful switch).
     private val _currentProvider = MutableStateFlow<String?>(null)
     val currentProvider: kotlinx.coroutines.flow.StateFlow<String?> = _currentProvider.asStateFlow()
+
+    // Text handed off from a share (Share-to-Hermes). ChatScreen pre-fills the composer with it once.
+    private val _initialDraft = MutableStateFlow<String?>(null)
+    val initialDraft: StateFlow<String?> = _initialDraft.asStateFlow()
+    fun clearInitialDraft() { _initialDraft.value = null }
 
     val favorites: kotlinx.coroutines.flow.StateFlow<Set<String>> =
         favoritesStore.favorites.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5_000), emptySet())
@@ -89,6 +95,8 @@ class ChatViewModel @Inject constructor(
     fun open(id: String) {
         sessionId = id
         connJob?.cancel()
+        // A share created this session and stashed its text; surface it as the initial composer draft.
+        pendingShareStore.take(id)?.let { _initialDraft.value = it }
         com.hermes.client.data.diagnostics.DebugLog.log("session", "open($id)")
         viewModelScope.launch {
             try {

--- a/app/src/test/java/com/hermes/client/share/PendingShareStoreTest.kt
+++ b/app/src/test/java/com/hermes/client/share/PendingShareStoreTest.kt
@@ -1,0 +1,23 @@
+package com.hermes.client.share
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PendingShareStoreTest {
+    @Test fun put_then_take_same_id_returns_text_once() {
+        val store = PendingShareStore()
+        store.put("s1", "hello")
+        assertEquals("hello", store.take("s1"))
+        assertNull(store.take("s1"))   // consumed — one-shot
+    }
+    @Test fun take_other_id_returns_null_and_keeps_value() {
+        val store = PendingShareStore()
+        store.put("s1", "hello")
+        assertNull(store.take("s2"))            // not the target session
+        assertEquals("hello", store.take("s1")) // still available for the right session
+    }
+    @Test fun take_when_empty_is_null() {
+        assertNull(PendingShareStore().take("s1"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/share/ShareIntentTest.kt
+++ b/app/src/test/java/com/hermes/client/share/ShareIntentTest.kt
@@ -1,0 +1,34 @@
+package com.hermes.client.share
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ShareIntentTest {
+    private val send = Intent.ACTION_SEND
+
+    @Test fun text_only_returns_trimmed_text() {
+        assertEquals("https://x.com", sharedText(send, "text/plain", null, "  https://x.com  "))
+    }
+    @Test fun subject_and_text_combined_when_different() {
+        assertEquals("My Page\nhttps://x.com", sharedText(send, "text/plain", "My Page", "https://x.com"))
+    }
+    @Test fun subject_equal_to_text_not_duplicated() {
+        assertEquals("https://x.com", sharedText(send, "text/plain", "https://x.com", "https://x.com"))
+    }
+    @Test fun only_subject_returns_subject() {
+        assertEquals("A note", sharedText(send, "text/plain", "A note", null))
+    }
+    @Test fun non_send_action_is_null() {
+        assertNull(sharedText(Intent.ACTION_VIEW, "text/plain", null, "hi"))
+    }
+    @Test fun non_text_type_is_null() {
+        assertNull(sharedText(send, "image/png", null, "hi"))
+    }
+    @Test fun blank_or_absent_returns_null() {
+        assertNull(sharedText(send, "text/plain", "  ", ""))
+        assertNull(sharedText(send, "text/plain", null, null))
+        assertNull(sharedText(send, null, "s", "t"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -39,6 +39,7 @@ class ChatViewModelTest {
     private val profileRepo = mockk<ProfileRepository>(relaxed = true)
     private val profileManager = mockk<com.hermes.client.data.repository.ProfileManager>(relaxed = true)
     private val favoritesStore = mockk<ModelFavoritesStore>(relaxed = true)
+    private val pendingShareStore = com.hermes.client.share.PendingShareStore()
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -55,7 +56,7 @@ class ChatViewModelTest {
         every { favoritesStore.favorites } returns MutableStateFlow(emptySet())
     }
 
-    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore)
+    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore)
 
     @Test fun streamed_delta_appears_in_state() = runTest {
         val vm = buildVm()

--- a/docs/superpowers/plans/2026-07-03-share-to-hermes.md
+++ b/docs/superpowers/plans/2026-07-03-share-to-hermes.md
@@ -1,0 +1,415 @@
+# Share-to-Hermes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user share a link/text from any Android app into Hermes; it opens a new chat in the active profile with the shared content pre-filled in the composer, ready to review and send.
+
+**Architecture:** A pure `sharedText()` extractor + a one-shot `PendingShareStore` handoff, wired into `MainActivity`'s existing intent/deep-link rail (`pendingRoute` → `HermesNav.deepLinkRoute`) and the chat composer. No gateway/bridge changes — reuses `ChatRepository.connect()`/`createSession()`.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Hilt, JUnit.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Reuse `ChatRepository.connect()` (idempotent), `ChatRepository.createSession()` (`session.create`), the existing `pendingRoute`→`HermesNav.deepLinkRoute` deep-link, and `ChatScreen`'s local `draft` composer state.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Unit tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta APK: `./gradlew :app:assembleBeta`.
+- Follow patterns: pure unit tests like `NotificationMapperTest`/`ModelSelectorTest`; Hilt constructor injection (`@Inject constructor`); MVVM + StateFlow.
+- **No AI/assistant attribution** in commits, files, or PRs.
+- v1 scope: **text/plain only**, new session in the **active profile**, **not auto-sent** (composer pre-filled). Images, profile/session chooser, `ACTION_SEND_MULTIPLE`, auto-send are out.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/share/ShareIntent.kt` — pure `sharedText(...)`.
+- Create `app/src/main/java/com/hermes/client/share/PendingShareStore.kt` — `@Singleton` one-shot handoff.
+- Create `app/src/test/java/com/hermes/client/share/ShareIntentTest.kt`, `PendingShareStoreTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt` — `initialDraft` + consume the store in `open()`.
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt` — pre-fill `draft`.
+- Modify `app/src/main/java/com/hermes/client/MainActivity.kt` — `handleShare(intent)`.
+- Modify `app/src/main/AndroidManifest.xml` — `ACTION_SEND` `text/plain` intent-filter.
+
+---
+
+### Task 1: Pure `sharedText()` extractor (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/share/ShareIntent.kt`
+- Test: `app/src/test/java/com/hermes/client/share/ShareIntentTest.kt`
+
+**Interfaces:**
+- Produces: `fun sharedText(action: String?, type: String?, subject: String?, text: String?): String?`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.share
+
+import android.content.Intent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ShareIntentTest {
+    private val send = Intent.ACTION_SEND
+
+    @Test fun text_only_returns_trimmed_text() {
+        assertEquals("https://x.com", sharedText(send, "text/plain", null, "  https://x.com  "))
+    }
+    @Test fun subject_and_text_combined_when_different() {
+        assertEquals("My Page\nhttps://x.com", sharedText(send, "text/plain", "My Page", "https://x.com"))
+    }
+    @Test fun subject_equal_to_text_not_duplicated() {
+        assertEquals("https://x.com", sharedText(send, "text/plain", "https://x.com", "https://x.com"))
+    }
+    @Test fun only_subject_returns_subject() {
+        assertEquals("A note", sharedText(send, "text/plain", "A note", null))
+    }
+    @Test fun non_send_action_is_null() {
+        assertNull(sharedText(Intent.ACTION_VIEW, "text/plain", null, "hi"))
+    }
+    @Test fun non_text_type_is_null() {
+        assertNull(sharedText(send, "image/png", null, "hi"))
+    }
+    @Test fun blank_or_absent_returns_null() {
+        assertNull(sharedText(send, "text/plain", "  ", ""))
+        assertNull(sharedText(send, "text/plain", null, null))
+        assertNull(sharedText(send, null, "s", "t"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ShareIntentTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `sharedText`.
+
+- [ ] **Step 3: Write the pure function**
+
+```kotlin
+package com.hermes.client.share
+
+import android.content.Intent
+
+/**
+ * Pure: the shareable text from an ACTION_SEND share, or null if this isn't a usable text share.
+ * A shared link commonly puts the page title in EXTRA_SUBJECT and the URL in EXTRA_TEXT, so the two
+ * are combined ("subject\ntext") when they differ. Takes primitives (not an Intent) so it stays
+ * pure and JVM-unit-testable.
+ */
+fun sharedText(action: String?, type: String?, subject: String?, text: String?): String? {
+    if (action != Intent.ACTION_SEND) return null
+    if (type == null || !type.startsWith("text/")) return null
+    val s = subject?.trim().orEmpty()
+    val t = text?.trim().orEmpty()
+    return when {
+        s.isNotEmpty() && t.isNotEmpty() && s != t -> "$s\n$t"
+        t.isNotEmpty() -> t
+        s.isNotEmpty() -> s
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ShareIntentTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/share/ShareIntent.kt app/src/test/java/com/hermes/client/share/ShareIntentTest.kt
+git commit -m "feat(share): pure sharedText() extractor with tests"
+```
+
+---
+
+### Task 2: `PendingShareStore` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/share/PendingShareStore.kt`
+- Test: `app/src/test/java/com/hermes/client/share/PendingShareStoreTest.kt`
+
+**Interfaces:**
+- Produces: `@Singleton class PendingShareStore @Inject constructor()` with `fun put(sessionId: String, text: String)` and `fun take(sessionId: String): String?`.
+- Note: constructor-injected `@Singleton` — Hilt provides it automatically, **no `AppModule` change needed**.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.share
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PendingShareStoreTest {
+    @Test fun put_then_take_same_id_returns_text_once() {
+        val store = PendingShareStore()
+        store.put("s1", "hello")
+        assertEquals("hello", store.take("s1"))
+        assertNull(store.take("s1"))   // consumed — one-shot
+    }
+    @Test fun take_other_id_returns_null_and_keeps_value() {
+        val store = PendingShareStore()
+        store.put("s1", "hello")
+        assertNull(store.take("s2"))            // not the target session
+        assertEquals("hello", store.take("s1")) // still available for the right session
+    }
+    @Test fun take_when_empty_is_null() {
+        assertNull(PendingShareStore().take("s1"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*PendingShareStoreTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `PendingShareStore`.
+
+- [ ] **Step 3: Write the store**
+
+```kotlin
+package com.hermes.client.share
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One-shot, in-process handoff of shared text from the share entry point to the chat that opens for
+ * it. Not persisted — it only needs to survive a single navigation. take() is keyed by sessionId so
+ * a normal chat open never consumes a share meant for a different (freshly-created) session.
+ */
+@Singleton
+class PendingShareStore @Inject constructor() {
+    private var pending: Pair<String, String>? = null
+
+    @Synchronized
+    fun put(sessionId: String, text: String) {
+        pending = sessionId to text
+    }
+
+    @Synchronized
+    fun take(sessionId: String): String? {
+        val p = pending ?: return null
+        if (p.first != sessionId) return null
+        pending = null
+        return p.second
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*PendingShareStoreTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/share/PendingShareStore.kt app/src/test/java/com/hermes/client/share/PendingShareStoreTest.kt
+git commit -m "feat(share): PendingShareStore one-shot handoff with tests"
+```
+
+---
+
+### Task 3: Composer pre-fill (`ChatViewModel` + `ChatScreen`)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+- Modify (if present): `app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt` (constructor gains a param)
+
+**Interfaces:**
+- Consumes: `PendingShareStore` (Task 2).
+- Produces (on `ChatViewModel`): `val initialDraft: StateFlow<String?>`, `fun clearInitialDraft()`.
+
+- [ ] **Step 1: Add `initialDraft` to `ChatViewModel`**
+
+Add the store to the constructor (it currently ends `..., private val favoritesStore: ModelFavoritesStore,`):
+
+```kotlin
+    private val favoritesStore: com.hermes.client.data.repository.ModelFavoritesStore,
+    private val pendingShareStore: com.hermes.client.share.PendingShareStore,
+) : ViewModel() {
+```
+
+Add the state (near `_currentModel`/`_providers`):
+
+```kotlin
+    // Text handed off from a share (Share-to-Hermes). ChatScreen pre-fills the composer with it once.
+    private val _initialDraft = MutableStateFlow<String?>(null)
+    val initialDraft: StateFlow<String?> = _initialDraft.asStateFlow()
+    fun clearInitialDraft() { _initialDraft.value = null }
+```
+
+In `open(id)`, consume the store synchronously near the top (right after `connJob?.cancel()`, before the `viewModelScope.launch { ... }`):
+
+```kotlin
+        // A share created this session and stashed its text; surface it as the initial composer draft.
+        pendingShareStore.take(id)?.let { _initialDraft.value = it }
+```
+
+- [ ] **Step 2: Pre-fill the composer in `ChatScreen`**
+
+Where `draft` is declared (`var draft by remember { mutableStateOf("") }`), add the collection + one-time fill right after it:
+
+```kotlin
+    var draft by remember { mutableStateOf("") }
+    val initialDraft by vm.initialDraft.collectAsStateWithLifecycle()
+    androidx.compose.runtime.LaunchedEffect(initialDraft) {
+        initialDraft?.takeIf { it.isNotEmpty() }?.let { draft = it; vm.clearInitialDraft() }
+    }
+```
+
+(`collectAsStateWithLifecycle` is already imported in `ChatScreen.kt`.)
+
+- [ ] **Step 3: Fix `ChatViewModelTest` construction (if it exists)**
+
+If `ChatViewModelTest.kt` constructs `ChatViewModel(...)` directly, add a real `PendingShareStore()` argument (it's a plain no-arg class — use the real one, not a mock) in the matching constructor position. Do not weaken existing assertions.
+
+- [ ] **Step 4: Compile + full unit suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+git commit -m "feat(share): pre-fill chat composer from a pending share"
+```
+
+---
+
+### Task 4: Share entry point (`MainActivity` + manifest)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/MainActivity.kt`
+- Modify: `app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: `sharedText(...)` (Task 1), `PendingShareStore` (Task 2), `ChatRepository.connect()`/`createSession()`, the existing `pendingRoute`.
+
+- [ ] **Step 1: Inject the deps into `MainActivity`**
+
+Add after the existing `@Inject` fields (below `notificationSettings`):
+
+```kotlin
+    @Inject lateinit var chat: com.hermes.client.data.repository.ChatRepository
+    @Inject lateinit var pendingShare: com.hermes.client.share.PendingShareStore
+```
+
+- [ ] **Step 2: Add `handleShare` and call it from create + new-intent**
+
+Add the method (next to `shareCrash`):
+
+```kotlin
+    /**
+     * Handle an incoming ACTION_SEND text share: open a new chat with the shared text pre-filled.
+     * Reuses the notification deep-link rail (pendingRoute -> HermesNav.deepLinkRoute).
+     */
+    private fun handleShare(intent: Intent?) {
+        val text = com.hermes.client.share.sharedText(
+            intent?.action,
+            intent?.type,
+            intent?.getStringExtra(Intent.EXTRA_SUBJECT),
+            intent?.getStringExtra(Intent.EXTRA_TEXT),
+        ) ?: return
+        // Not configured yet -> the app opens to setup; drop the share in v1.
+        if (credentialStore.load() == null) return
+        lifecycleScope.launch {
+            chat.connect()  // idempotent; a cold-start share has no open socket yet, and
+                            // createSession() would otherwise block on the ready-gate forever.
+            runCatching { chat.createSession() }
+                .onSuccess { id ->
+                    pendingShare.put(id, text)
+                    pendingRoute.value = "chat/$id"
+                }
+                .onFailure { e ->
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    android.widget.Toast.makeText(
+                        this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+        }
+    }
+```
+
+Call it in `onCreate` right after the `extra_route` read (after `intent?.removeExtra("extra_route")`):
+
+```kotlin
+        handleShare(intent)
+```
+
+And in `onNewIntent`, after the `extra_route` handling (after `intent.removeExtra("extra_route")`):
+
+```kotlin
+        handleShare(intent)
+```
+
+Add the import (near the other imports):
+
+```kotlin
+import androidx.lifecycle.lifecycleScope
+```
+
+- [ ] **Step 3: Add the intent-filter to `AndroidManifest.xml`**
+
+Inside `MainActivity`'s `<activity>` element (the launcher activity — it already has the `MAIN`/`LAUNCHER` intent-filter; add a second `<intent-filter>` alongside it):
+
+```xml
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+```
+
+- [ ] **Step 4: Compile + full unit suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/MainActivity.kt app/src/main/AndroidManifest.xml
+git commit -m "feat(share): ACTION_SEND text share opens a new pre-filled chat"
+```
+
+---
+
+### Task 5: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -1` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk` (or `-d` for a device). Point it at a working gateway (real, or the mock at `http://10.0.2.2:8899`).
+
+- [ ] **Step 2: Verify the share flow**
+
+- From Chrome (or any app), use the system **Share** → confirm **Hermes Beta** appears in the sheet for a link/text.
+- Tap it → a **new Hermes chat opens** in the active profile with the shared URL/text **in the composer** (not sent).
+- Add a note and send → the message goes through normally.
+- Repeat while the app is already open (backgrounded) → `onNewIntent` still routes to a fresh pre-filled chat.
+- Share when the app is not yet configured → it opens to setup without crashing (share dropped).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(share): share verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** `ACTION_SEND` text/plain intent-filter (Task 4) ✓; pure `sharedText` extractor unit-tested (Task 1) ✓; `chat.connect()` (idempotent) + `createSession()` (Task 4) ✓; `PendingShareStore` race-proof by sessionId, unit-tested (Task 2) ✓; reuse of `pendingRoute` deep-link (Task 4) ✓; `ChatViewModel.initialDraft` consumed in `open()` + `ChatScreen` pre-fill (Task 3) ✓; not-configured drops share, `createSession` failure → Toast + no navigation (Task 4) ✓; on-device verify incl. onNewIntent + not-configured (Task 5) ✓; text/plain-only scope, images/chooser/auto-send excluded ✓; no bridge changes ✓.
+- **Placeholder scan:** every code step has full code; the only "if needed" is a conditional verification commit.
+- **Type consistency:** `sharedText(action, type, subject, text): String?`, `PendingShareStore.put(sessionId, text)`/`take(sessionId): String?`, `ChatViewModel.initialDraft: StateFlow<String?>`/`clearInitialDraft()`, `handleShare(intent)`, and the reused `pendingRoute`/`ChatRepository.connect()`/`createSession()` are consistent across Tasks 1–4.
+
+**Ordering note:** Tasks 1 & 2 are the pure/testable core (independent, compile alone). Task 3 (pre-fill) depends on Task 2. Task 4 (entry) depends on Tasks 1, 2, and 3. Task 5 verifies the whole.

--- a/docs/superpowers/specs/2026-07-03-share-to-hermes-design.md
+++ b/docs/superpowers/specs/2026-07-03-share-to-hermes-design.md
@@ -1,0 +1,115 @@
+# Share-to-Hermes — Design
+
+**Date:** 2026-07-03
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/share-to-hermes`
+**Parent idea:** `docs/ideas/native-command-surface.md` (Ship 2 — Native Pager, piece 1 of 4)
+
+## Goal
+
+Let the user share a link or text from any Android app into Hermes: it opens a new chat in the active profile with the shared content pre-filled in the composer, ready to review, annotate, and send. Native Android + existing bridge APIs only — no gateway/bridge changes. This is a capability the official WebView app (PR #52673) structurally cannot offer.
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Reuse `ChatRepository.createSession()` (`session.create`) and the existing chat submit path; no new endpoints.
+- Native Android: an `ACTION_SEND` intent-filter + the existing deep-link rail.
+- Follow existing patterns: Hilt DI, MVVM + StateFlow, pure unit-tested helpers, the `pendingRoute` → `HermesNav.deepLinkRoute` navigation already in `MainActivity`.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Scope (v1)
+
+- **In:** shared **text/plain** (links, selected text, notes) → new session in the **active profile** → chat opens with the content in the composer (not auto-sent).
+- **Out (documented follow-ups):** images/screenshots (`image/*`, needs `/api/files/upload` + composer attachments), a profile/session chooser on the share path, `ACTION_SEND_MULTIPLE`, auto-send.
+
+## What the app already provides (grounding)
+
+- `MainActivity` (`@AndroidEntryPoint`) already handles intents: it reads `extra_route` into `pendingRoute: MutableState<String?>`, clears it, and handles `onNewIntent`; `HermesNav(deepLinkRoute = pendingRoute)` navigates when it changes.
+- `ChatRepository.createSession(): String` → `session.create` WS RPC, returns a new session id.
+- `ChatScreen` owns the composer text locally: `var draft by remember { mutableStateOf("") }`; send goes through `ChatViewModel.send(text)`.
+- `ChatViewModel.open(id)` runs on chat open (loads history, resumes, loads providers/profiles/commands).
+- Gateway-configured check: `credentialStore.load() != null` (in `MainActivity.onCreate`, drives `hasConfig`).
+
+## Architecture
+
+A pure text-extractor + a one-shot in-memory handoff store, wired into `MainActivity`'s existing intent/deep-link path and the chat composer. Each unit is small and independently testable.
+
+### Components
+
+1. **Pure `sharedText(action, type, subject, text): String?`** — `app/src/main/java/com/hermes/client/share/ShareIntent.kt`. The unit-tested core; takes primitives (not an `Intent`) so it stays pure/JVM-testable.
+   - Returns null unless `action == Intent.ACTION_SEND` and `type` starts with `"text/"`.
+   - Otherwise builds the shared text from `subject` + `text`:
+     - both present and different → `"$subject\n$text"` (a shared link often carries the page title in SUBJECT and the URL in TEXT);
+     - only one present → that one, trimmed;
+     - both blank/absent → null.
+   - Signature: `fun sharedText(action: String?, type: String?, subject: String?, text: String?): String?`
+
+2. **`PendingShareStore`** — `app/src/main/java/com/hermes/client/share/PendingShareStore.kt`. A `@Singleton` in-memory one-shot handoff (no persistence needed — it lives for one navigation within the process).
+   - Holds a nullable `Pair<String, String>?` = (sessionId, text).
+   - `fun put(sessionId: String, text: String)`.
+   - `fun take(sessionId: String): String?` — returns the text and clears the store **only if** the stored sessionId matches (race-proof: a normal chat open won't consume a share meant for a different session).
+   - Provided via Hilt `@Provides @Singleton` in `AppModule` (mirrors the other store providers).
+
+3. **`MainActivity` share branch** — inject `ChatRepository` (Hilt). Add a `handleShare(intent)` called from `onCreate` and `onNewIntent`:
+   - `val shared = sharedText(intent.action, intent.type, intent.getStringExtra(EXTRA_SUBJECT), intent.getStringExtra(EXTRA_TEXT))`.
+   - If `shared == null`, do nothing (fall through to existing `extra_route` handling).
+   - If the gateway is not configured (`credentialStore.load() == null`), skip creating a session (the app opens to setup); optionally set a pending message — v1 drops the share.
+   - Else `lifecycleScope.launch { chat.connect(); runCatching { chat.createSession() }.onSuccess { id -> pendingShareStore.put(id, shared); pendingRoute.value = "chat/$id" }.onFailure { /* brief toast: couldn't start a chat */ } }`. **`chat.connect()` first** — on a cold start from a share no screen has opened the socket yet, and `createSession` would otherwise block forever on the ready-gate. `connect()` is idempotent (made so in the notifications work), so this is safe even when already connected.
+
+4. **`ChatViewModel` pre-fill** — inject `PendingShareStore`. In `open(id)`, `val shared = pendingShareStore.take(id)`; expose `initialDraft: StateFlow<String?>` set to `shared` (null for a normal open). Add `fun clearInitialDraft()`.
+
+5. **`ChatScreen` pre-fill** — collect `initialDraft`; `LaunchedEffect(initialDraft) { initialDraft?.let { if (it.isNotEmpty()) { draft = it; vm.clearInitialDraft() } } }`. The composer TextField is unchanged otherwise.
+
+6. **Manifest** — add to `MainActivity`'s `<activity>` (already `exported="true"` as launcher):
+   ```xml
+   <intent-filter>
+       <action android:name="android.intent.action.SEND" />
+       <category android:name="android.intent.category.DEFAULT" />
+       <data android:mimeType="text/plain" />
+   </intent-filter>
+   ```
+
+## Data flow
+
+```
+Another app → Share → "Hermes"
+  → MainActivity (ACTION_SEND, text/plain)
+  → sharedText(...) [pure] → text
+  → gateway configured? → chat.connect() (idempotent) → chat.createSession() → new id
+  → PendingShareStore.put(id, text); pendingRoute = "chat/<id>"
+  → HermesNav deep-links to chat/<id>
+  → ChatViewModel.open(id) → PendingShareStore.take(id) → initialDraft
+  → ChatScreen sets draft = initialDraft (once)
+  → user reviews / annotates / sends via ChatViewModel.send(text)
+```
+
+## Error handling
+
+- **Not configured** (`credentialStore.load() == null`): the share does not create a session; the app opens to setup. The shared text is dropped in v1 (documented limitation).
+- **`createSession` fails** (not connected / RPC error): no deep-link fires; the app opens to the sessions list; a brief message ("Couldn't start a chat — try again") is surfaced. Shared text is dropped.
+- **Cold start latency:** `createSession` awaits the WS ready-gate (existing `client.call` behavior), so it's a short delay on a cold launch, not a failure.
+- **Non-text share** (image, etc.): `sharedText` returns null → ignored (Hermes won't be offered for non-text in the share sheet anyway, given the `text/plain` filter).
+
+## Testing
+
+- **Unit (pure), TDD — `ShareIntentTest`:**
+  - `ACTION_SEND` + `text/plain` + text only → that text (trimmed);
+  - subject + text (different) → `"subject\ntext"`;
+  - subject == text → text once (no duplication);
+  - only subject → subject;
+  - non-`ACTION_SEND` action → null;
+  - non-`text/*` type → null;
+  - both blank/null → null.
+- **`PendingShareStore`:** small unit test — `put` then `take(sameId)` returns text and a second `take(sameId)` returns null; `take(otherId)` returns null and leaves the value.
+- **On-device (emulator/device):** from Chrome (or any app) share a URL → the share sheet lists Hermes → tap → a new Hermes chat opens with the URL in the composer; add a note and send.
+
+## Not doing (YAGNI)
+
+- Images / `image/*` / `/api/files/upload` (fast follow-up).
+- Profile or existing-session chooser on the share path (v1 = active profile, new session).
+- `ACTION_SEND_MULTIPLE`, auto-send, or a custom share Chooser UI.
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Whether to keep the shared text across a not-configured share (route through setup then land it) — deferred; v1 drops it.
+- Exact "couldn't start a chat" surface (Toast vs a Snackbar on the sessions screen) — plan picks one.


### PR DESCRIPTION
## Share-to-Hermes

Adds an Android share target: from any app, share a link or text into Hermes and it opens a **new chat in the active profile with the content pre-filled in the composer** — review, annotate, and send. A native capability the WebView-based mobile app can't offer. No gateway/bridge changes.

### How it works
- An `ACTION_SEND` `text/plain` intent-filter on `MainActivity` puts Hermes in the share sheet.
- A pure, unit-tested `sharedText()` extracts the shared text (combines EXTRA_SUBJECT + EXTRA_TEXT for links).
- `MainActivity.handleShare` → `chat.connect()` (idempotent) → `createSession()` → stashes the text in a one-shot `PendingShareStore` (keyed by session id) → reuses the existing `pendingRoute` deep-link → the new chat consumes it and pre-fills its composer.

### Verification
- New unit tests: `ShareIntentTest` (7), `PendingShareStoreTest` (3); full suite 115 tests + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task reviews + a final whole-branch review). The final review caught and I fixed an **Important** bug: the share intent extras weren't cleared, so a config-change recreation (rotation, dark-mode toggle) would re-fire the share and spawn a duplicate session — now consumed like the notification `extra_route`.
- **On-device (emulator + mock):** the SEND filter is registered (Hermes appears in the share sheet); sharing a URL creates a session and opens the chat with the URL in the composer (confirmed `session.create`/`session.resume`).

### Scope
v1 is **text/links only**, new session in the active profile, not auto-sent. Follow-ups: images/screenshots (`/api/files/upload`), a profile/session chooser.

### Docs
`docs/superpowers/specs/2026-07-03-share-to-hermes-design.md`, `docs/superpowers/plans/2026-07-03-share-to-hermes.md` (Ship 2 of `docs/ideas/native-command-surface.md`).
