### PR TITLE
Notifications: approvals-only (cron/messaging events aren't on the app WS)

### DIFF
--- a/app/src/main/java/com/hermes/client/data/repository/NotificationSettings.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/NotificationSettings.kt
@@ -10,24 +10,18 @@ import kotlinx.coroutines.flow.map
 
 private val Context.notificationDataStore by preferencesDataStore(name = "notifications")
 
-/** Device-local notification preferences (master toggle + per-type flags). Off by default. */
+/** Device-local notification preferences (master toggle + approvals). Off by default. */
 class NotificationSettings(private val context: Context) {
     private val kEnabled = booleanPreferencesKey("enabled")
     private val kApprovals = booleanPreferencesKey("approvals")
-    private val kCron = booleanPreferencesKey("cron")
-    private val kMessaging = booleanPreferencesKey("messaging")
 
     val prefs: Flow<NotificationPrefs> = context.notificationDataStore.data.map { p ->
         NotificationPrefs(
             enabled = p[kEnabled] ?: false,
             approvals = p[kApprovals] ?: true,
-            cron = p[kCron] ?: true,
-            messaging = p[kMessaging] ?: true,
         )
     }
 
     suspend fun setEnabled(v: Boolean) = context.notificationDataStore.edit { it[kEnabled] = v }
     suspend fun setApprovals(v: Boolean) = context.notificationDataStore.edit { it[kApprovals] = v }
-    suspend fun setCron(v: Boolean) = context.notificationDataStore.edit { it[kCron] = v }
-    suspend fun setMessaging(v: Boolean) = context.notificationDataStore.edit { it[kMessaging] = v }
 }

--- a/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+++ b/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
@@ -23,11 +23,6 @@ class HermesNotifier(private val context: Context) {
             },
         )
         sys.createNotificationChannel(
-            NotificationChannel(Notif.CHANNEL_ACTIVITY, "Agent activity", NotificationManager.IMPORTANCE_DEFAULT).apply {
-                lockscreenVisibility = android.app.Notification.VISIBILITY_PRIVATE
-            },
-        )
-        sys.createNotificationChannel(
             NotificationChannel(Notif.CHANNEL_SERVICE, "Connection", NotificationManager.IMPORTANCE_MIN),
         )
     }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -4,9 +4,9 @@ import com.hermes.client.data.network.ServerEvent
 import com.hermes.client.data.network.str
 
 /**
- * Pure mapping from a gateway event to a notification (or null). Centralizes every event-type
- * decision so verifying/adjusting the gateway's event names is a one-line change. A stable id is
- * derived from the session so repeats of the same event update rather than stack.
+ * Pure mapping from a gateway event to a notification (or null). Only `approval.request` is a
+ * notifiable event on the app's WebSocket (see the note on [Notif]); everything else returns null.
+ * A stable id is derived from the session so repeats of the same event update rather than stack.
  */
 fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs): NotificationSpec? {
     if (!prefs.enabled) return null
@@ -27,24 +27,6 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs): Notificati
                 NotifAction("Deny", Notif.ACTION_DENY, sid),
             ),
             groupKey = "approval",
-        )
-        Notif.EVENT_CRON_DONE -> if (!prefs.cron) null else NotificationSpec(
-            id = id,
-            channelId = Notif.CHANNEL_ACTIVITY,
-            title = event.str("name") ?: "Scheduled job finished",
-            body = "Run ${event.str("status") ?: "finished"}",
-            route = "chat/$sid",
-            actions = emptyList(),
-            groupKey = "cron",
-        )
-        Notif.EVENT_MSG -> if (!prefs.messaging) null else NotificationSpec(
-            id = id,
-            channelId = Notif.CHANNEL_ACTIVITY,
-            title = "Reply on ${event.str("platform") ?: "messaging"}",
-            body = event.str("preview") ?: event.str("text") ?: "New reply",
-            route = "chat/$sid",
-            actions = emptyList(),
-            groupKey = "messaging",
         )
         else -> null
     }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -4,8 +4,6 @@ package com.hermes.client.notifications
 data class NotificationPrefs(
     val enabled: Boolean = false,
     val approvals: Boolean = true,
-    val cron: Boolean = true,
-    val messaging: Boolean = true,
 )
 
 /** An inline notification action (Approve/Deny) carrying the target session. */
@@ -25,13 +23,13 @@ data class NotificationSpec(
 /** Channel ids, gateway event-type strings, and action names in one place. */
 object Notif {
     const val CHANNEL_APPROVALS = "approvals"
-    const val CHANNEL_ACTIVITY = "activity"
     const val CHANNEL_SERVICE = "service"
 
-    // approval.request is confirmed in ChatUiState. The other two are BEST-GUESS — verify in Task 8.
+    // `approval.request` is the only notifiable event on the app's WebSocket (/api/ws). Verified
+    // against the gateway source: it broadcasts approval + run/tool/message-stream lifecycle events,
+    // but NOT cron-finished (cron delivers to messaging platforms) or a messaging-inbound event —
+    // so those aren't offered here. See docs/superpowers/specs/2026-07-03-notifications-approvals-only.
     const val EVENT_APPROVAL = "approval.request"
-    const val EVENT_CRON_DONE = "cron.completed"
-    const val EVENT_MSG = "message.received"
 
     const val ACTION_APPROVE = "approve"
     const val ACTION_DENY = "deny"

--- a/app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
@@ -46,8 +46,6 @@ class NotificationsViewModel @Inject constructor(
 
     fun setEnabled(v: Boolean) = viewModelScope.launch { settings.setEnabled(v) }
     fun setApprovals(v: Boolean) = viewModelScope.launch { settings.setApprovals(v) }
-    fun setCron(v: Boolean) = viewModelScope.launch { settings.setCron(v) }
-    fun setMessaging(v: Boolean) = viewModelScope.launch { settings.setMessaging(v) }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -94,8 +92,6 @@ fun NotificationsScreen(onBack: () -> Unit, vm: NotificationsViewModel = hiltVie
             ) { on -> if (on) enable() else { vm.setEnabled(false); GatewayConnectionService.stop(context) } }
             HorizontalDivider()
             ToggleRow("Approval requests", "When the agent needs you to approve an action", prefs.approvals, enabled = prefs.enabled) { vm.setApprovals(it) }
-            ToggleRow("Cron runs", "When a scheduled job finishes", prefs.cron, enabled = prefs.enabled) { vm.setCron(it) }
-            ToggleRow("Messaging replies", "Replies on connected platforms", prefs.messaging, enabled = prefs.enabled) { vm.setMessaging(it) }
         }
     }
 }

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -23,23 +23,15 @@ class NotificationMapperTest {
         assertTrue(spec.actions.all { it.sessionId == "s1" })
     }
 
-    @Test fun cron_and_messaging_make_specs_without_actions() {
-        val cron = toNotificationSpec(event(Notif.EVENT_CRON_DONE, "c1", "name" to "Nightly", "status" to "success"), on)!!
-        assertEquals(Notif.CHANNEL_ACTIVITY, cron.channelId)
-        assertEquals("chat/c1", cron.route)
-        assertTrue(cron.actions.isEmpty())
-        val msg = toNotificationSpec(event(Notif.EVENT_MSG, "m1", "platform" to "Telegram", "preview" to "hi"), on)!!
-        assertTrue(msg.title.contains("Telegram"))
-    }
-
-    @Test fun per_type_toggles_and_master_toggle_suppress() {
+    @Test fun approvals_toggle_and_master_toggle_suppress() {
         assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL), on.copy(approvals = false)))
-        assertNull(toNotificationSpec(event(Notif.EVENT_CRON_DONE), on.copy(cron = false)))
-        assertNull(toNotificationSpec(event(Notif.EVENT_MSG), on.copy(messaging = false)))
         assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL), NotificationPrefs(enabled = false)))
     }
 
-    @Test fun unrelated_or_sessionless_events_are_null() {
+    @Test fun non_approval_and_sessionless_events_are_null() {
+        // Only approval.request is notifiable; run/cron/messaging-style events map to nothing.
+        assertNull(toNotificationSpec(event("run.completed", "c1", "status" to "success"), on))
+        assertNull(toNotificationSpec(event("message.received", "m1", "platform" to "Telegram"), on))
         assertNull(toNotificationSpec(event("message.delta"), on))
         assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL, sid = null), on))
     }

--- a/docs/superpowers/specs/2026-07-03-notifications-approvals-only.md
+++ b/docs/superpowers/specs/2026-07-03-notifications-approvals-only.md
@@ -1,0 +1,37 @@
+# Notifications: Approvals-Only (event-type finding)
+
+**Date:** 2026-07-03
+**Status:** Implemented on `feature/notifications-approvals-only`
+**Supersedes the cron/messaging parts of:** `docs/superpowers/specs/2026-07-02-push-notifications-design.md`
+
+## Finding
+
+The push-notifications feature shipped with three toggles — **Approvals**, **Cron runs**, **Messaging replies** — but the cron/messaging event-type strings were best-guess placeholders (`cron.completed`, `message.received`). Verifying against the gateway source (`~/.hermes/hermes-agent`) showed:
+
+The app's WebSocket (`/api/ws`, served by `gateway/platforms/api_server.py`) broadcasts exactly:
+`approval.request`, `approval.responded`, `run.started/completed/failed/cancelled`, `tool.started/completed`, `message.started/delta`, `assistant.completed`, `reasoning.available`, `error`, `done`.
+
+- **`approval.request`** — real; the only notifiable event. Confirmed working on-device.
+- **Cron finished** — no such event on this stream. Cron jobs run in the scheduler and **deliver results to messaging platforms** (`gateway/delivery.py`), not the dashboard WS. The `run.completed`/`run.failed` events that *are* on the WS fire on **every interactive turn** (and dashboard-initiated async runs), not cron — so they can't stand in for "cron finished".
+- **Messaging reply** — `message.received` exists only in the gateway's **tests**, never in production; nothing equivalent reaches the app's WS.
+
+So under the **no-bridge-changes** constraint, cron and messaging notifications cannot fire. Keying `run.completed`/`run.failed` for "cron" would notify on every chat turn and still be wrong.
+
+## Decision
+
+**Approvals-only.** Remove the Cron and Messaging toggles and their (dead) mapping; keep Approvals. The Notifications screen now offers only *Enable* + *Approval requests*, both of which actually work.
+
+## Changes
+
+- `NotificationPrefs` → `(enabled, approvals)` (dropped `cron`, `messaging`).
+- `Notif` → dropped `CHANNEL_ACTIVITY`, `EVENT_CRON_DONE`, `EVENT_MSG`.
+- `toNotificationSpec` → only the `approval.request` branch.
+- `NotificationSettings` → dropped the cron/messaging keys + setters.
+- `NotificationsScreen` / `NotificationsViewModel` → dropped the two toggle rows + setters.
+- `HermesNotifier.ensureChannels` → dropped the unused `activity` channel.
+- `NotificationMapperTest` → dropped the cron/messaging cases; added assertions that `run.completed`/`message.received` map to null.
+
+## Future (needs a different mechanism, not this stream)
+
+- **Cron-finished** could be done with a periodic REST poll of `/api/cron/jobs` (`last_run_at` + `last_status`) via WorkManager — a separate opt-in feature (delayed, battery cost), not a WS push.
+- **Messaging** has no client-visible signal today without a gateway change.


### PR DESCRIPTION
## Notifications: approvals-only (event-type correction)

The push-notifications feature shipped with **Approvals / Cron / Messaging** toggles, but the cron/messaging event types were best-guess placeholders. Verifying against the gateway source proved they can't work:

The app's WebSocket (`/api/ws`) broadcasts `approval.request`, run/tool lifecycle, and message-stream events — but **no cron-finished event** (cron jobs deliver to messaging platforms via `delivery.py`, not the dashboard WS) and **no messaging-inbound event** (`message.received` exists only in gateway tests). The `run.completed`/`run.failed` events that *are* on the WS fire on every chat turn, not cron.

So under the no-bridge-changes rule, only **Approvals** can fire. This removes the two dead toggles and their unreachable mapping, keeping the working Approval alerts — the feature now does exactly what it says.

### Changes
`NotificationPrefs` → `(enabled, approvals)`; dropped `CHANNEL_ACTIVITY`/`EVENT_CRON_DONE`/`EVENT_MSG`; `toNotificationSpec` approval-only; settings/screen/notifier trimmed; tests updated (now assert `run.completed`/`message.received` → null). DataStore is forward-safe (orphaned keys ignored).

### Verification
compile + `testDebugUnitTest` + `assembleBeta` green; gitleaks clean; reviewed clean.

Rationale + the full gateway event list: `docs/superpowers/specs/2026-07-03-notifications-approvals-only.md`.

### Future (separate, opt-in)
Cron-finished would need a WorkManager poll of `/api/cron/jobs`; messaging needs a gateway change.
