### PR TITLE
Quick Settings tile: arm/disarm the notification service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,16 @@
             android:name=".notifications.GatewayConnectionService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+        <service
+            android:name=".notifications.NotificationTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_stat_hermes"
+            android:label="Hermes"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
         <receiver
             android:name=".notifications.NotificationActionReceiver"
             android:exported="false" />

--- a/app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt
@@ -1,0 +1,81 @@
+package com.hermes.client.notifications
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.core.content.ContextCompat
+import com.hermes.client.MainActivity
+import com.hermes.client.R
+import com.hermes.client.data.repository.NotificationSettings
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+/**
+ * Quick Settings tile that shows and toggles the notification service — mirrors the
+ * Settings > Notifications "Enable" switch. On/off state is [NotificationSettings.prefs].enabled.
+ * TileService callbacks run on the main thread; a single fast DataStore read via runBlocking is fine.
+ */
+@AndroidEntryPoint
+class NotificationTileService : TileService() {
+    @Inject lateinit var settings: NotificationSettings
+
+    override fun onStartListening() {
+        super.onStartListening()
+        renderTile(runBlocking { settings.prefs.first().enabled })
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val enabled = runBlocking { settings.prefs.first().enabled }
+        val canStart = Build.VERSION.SDK_INT < 33 ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+        when (tileClickAction(enabled, canStart)) {
+            TileAction.ENABLE -> {
+                runBlocking { settings.setEnabled(true) }
+                GatewayConnectionService.start(this)
+                renderTile(true)
+            }
+            TileAction.DISABLE -> {
+                runBlocking { settings.setEnabled(false) }
+                GatewayConnectionService.stop(this)
+                renderTile(false)
+            }
+            TileAction.OPEN_FOR_PERMISSION -> openNotificationSettings()
+        }
+    }
+
+    private fun renderTile(enabled: Boolean) {
+        val tile = qsTile ?: return
+        tile.state = if (enabled) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = "Hermes"
+        tile.icon = Icon.createWithResource(this, R.drawable.ic_stat_hermes)
+        if (Build.VERSION.SDK_INT >= 29) tile.subtitle = if (enabled) "On" else "Off"
+        tile.updateTile()
+    }
+
+    /** Open the app at Settings > Notifications so its Enable switch can run the permission flow. */
+    private fun openNotificationSettings() {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("extra_route", "settings_notifications")
+        }
+        if (Build.VERSION.SDK_INT >= 34) {
+            val pi = PendingIntent.getActivity(
+                this, 0, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            startActivityAndCollapse(pi)
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/notifications/TileLogic.kt
+++ b/app/src/main/java/com/hermes/client/notifications/TileLogic.kt
@@ -1,0 +1,15 @@
+package com.hermes.client.notifications
+
+/** What a Quick Settings tile tap should do, given current state. */
+enum class TileAction { ENABLE, DISABLE, OPEN_FOR_PERMISSION }
+
+/**
+ * Pure: decide the tile-tap action. [canStart] = the service can be started now (API < 33, or
+ * POST_NOTIFICATIONS granted). On → turn off; off and can start → on; off and can't start (a tile
+ * can't request a runtime permission) → route into the app to grant it.
+ */
+fun tileClickAction(enabled: Boolean, canStart: Boolean): TileAction = when {
+    enabled -> TileAction.DISABLE
+    canStart -> TileAction.ENABLE
+    else -> TileAction.OPEN_FOR_PERMISSION
+}

--- a/app/src/test/java/com/hermes/client/notifications/TileLogicTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/TileLogicTest.kt
@@ -1,0 +1,19 @@
+package com.hermes.client.notifications
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TileLogicTest {
+    @Test fun enabled_disables_regardless_of_canStart() {
+        assertEquals(TileAction.DISABLE, tileClickAction(enabled = true, canStart = true))
+        assertEquals(TileAction.DISABLE, tileClickAction(enabled = true, canStart = false))
+    }
+
+    @Test fun disabled_and_can_start_enables() {
+        assertEquals(TileAction.ENABLE, tileClickAction(enabled = false, canStart = true))
+    }
+
+    @Test fun disabled_and_cannot_start_routes_for_permission() {
+        assertEquals(TileAction.OPEN_FOR_PERMISSION, tileClickAction(enabled = false, canStart = false))
+    }
+}

--- a/docs/superpowers/plans/2026-07-03-qs-tile.md
+++ b/docs/superpowers/plans/2026-07-03-qs-tile.md
@@ -1,0 +1,259 @@
+# Quick Settings Tile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A pull-down Quick Settings tile ("Hermes") that shows whether notifications are on and toggles the background notification service in one tap.
+
+**Architecture:** A pure `tileClickAction()` decision function + a `NotificationTileService` (`TileService`) that reflects `NotificationSettings.enabled` and, on tap, enables/disables `GatewayConnectionService` or routes into the app to grant permission via the existing `extra_route` deep-link. No bridge changes.
+
+**Tech Stack:** Kotlin, Hilt, Android `TileService`, JUnit.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Reuse `NotificationSettings` (DataStore: `prefs.enabled`, `setEnabled`), `GatewayConnectionService.start/stop`, and the `extra_route` → `HermesNav` deep-link (`"settings_notifications"`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Follow patterns: pure unit tests like `NotificationMapperTest`; Hilt `@AndroidEntryPoint` services like `GatewayConnectionService`/`NotificationActionReceiver`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/notifications/TileLogic.kt` — `TileAction` enum + pure `tileClickAction`.
+- Create `app/src/test/java/com/hermes/client/notifications/TileLogicTest.kt`.
+- Create `app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt` — the `TileService`.
+- Modify `app/src/main/AndroidManifest.xml` — the `QS_TILE` `<service>`.
+
+---
+
+### Task 1: Pure `tileClickAction` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/notifications/TileLogic.kt`
+- Test: `app/src/test/java/com/hermes/client/notifications/TileLogicTest.kt`
+
+**Interfaces:**
+- Produces: `enum class TileAction { ENABLE, DISABLE, OPEN_FOR_PERMISSION }`; `fun tileClickAction(enabled: Boolean, canStart: Boolean): TileAction`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.notifications
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TileLogicTest {
+    @Test fun enabled_disables_regardless_of_canStart() {
+        assertEquals(TileAction.DISABLE, tileClickAction(enabled = true, canStart = true))
+        assertEquals(TileAction.DISABLE, tileClickAction(enabled = true, canStart = false))
+    }
+
+    @Test fun disabled_and_can_start_enables() {
+        assertEquals(TileAction.ENABLE, tileClickAction(enabled = false, canStart = true))
+    }
+
+    @Test fun disabled_and_cannot_start_routes_for_permission() {
+        assertEquals(TileAction.OPEN_FOR_PERMISSION, tileClickAction(enabled = false, canStart = false))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*TileLogicTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `tileClickAction`/`TileAction`.
+
+- [ ] **Step 3: Write the enum + pure function**
+
+```kotlin
+package com.hermes.client.notifications
+
+/** What a Quick Settings tile tap should do, given current state. */
+enum class TileAction { ENABLE, DISABLE, OPEN_FOR_PERMISSION }
+
+/**
+ * Pure: decide the tile-tap action. [canStart] = the service can be started now (API < 33, or
+ * POST_NOTIFICATIONS granted). On → turn off; off and can start → on; off and can't start (a tile
+ * can't request a runtime permission) → route into the app to grant it.
+ */
+fun tileClickAction(enabled: Boolean, canStart: Boolean): TileAction = when {
+    enabled -> TileAction.DISABLE
+    canStart -> TileAction.ENABLE
+    else -> TileAction.OPEN_FOR_PERMISSION
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*TileLogicTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/TileLogic.kt app/src/test/java/com/hermes/client/notifications/TileLogicTest.kt
+git commit -m "feat(tile): pure tileClickAction decision with tests"
+```
+
+---
+
+### Task 2: `NotificationTileService` + manifest
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt`
+- Modify: `app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: `tileClickAction`/`TileAction` (Task 1); `NotificationSettings` (`prefs.enabled`, `setEnabled`); `GatewayConnectionService.start/stop`; `MainActivity` (`extra_route`); `R.drawable.ic_stat_hermes`.
+
+- [ ] **Step 1: Create the TileService**
+
+```kotlin
+package com.hermes.client.notifications
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.core.content.ContextCompat
+import com.hermes.client.MainActivity
+import com.hermes.client.R
+import com.hermes.client.data.repository.NotificationSettings
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+/**
+ * Quick Settings tile that shows and toggles the notification service — mirrors the
+ * Settings > Notifications "Enable" switch. On/off state is [NotificationSettings.prefs].enabled.
+ * TileService callbacks run on the main thread; a single fast DataStore read via runBlocking is fine.
+ */
+@AndroidEntryPoint
+class NotificationTileService : TileService() {
+    @Inject lateinit var settings: NotificationSettings
+
+    override fun onStartListening() {
+        super.onStartListening()
+        renderTile(runBlocking { settings.prefs.first().enabled })
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val enabled = runBlocking { settings.prefs.first().enabled }
+        val canStart = Build.VERSION.SDK_INT < 33 ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+        when (tileClickAction(enabled, canStart)) {
+            TileAction.ENABLE -> {
+                runBlocking { settings.setEnabled(true) }
+                GatewayConnectionService.start(this)
+                renderTile(true)
+            }
+            TileAction.DISABLE -> {
+                runBlocking { settings.setEnabled(false) }
+                GatewayConnectionService.stop(this)
+                renderTile(false)
+            }
+            TileAction.OPEN_FOR_PERMISSION -> openNotificationSettings()
+        }
+    }
+
+    private fun renderTile(enabled: Boolean) {
+        val tile = qsTile ?: return
+        tile.state = if (enabled) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = "Hermes"
+        tile.icon = Icon.createWithResource(this, R.drawable.ic_stat_hermes)
+        if (Build.VERSION.SDK_INT >= 29) tile.subtitle = if (enabled) "On" else "Off"
+        tile.updateTile()
+    }
+
+    /** Open the app at Settings > Notifications so its Enable switch can run the permission flow. */
+    private fun openNotificationSettings() {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("extra_route", "settings_notifications")
+        }
+        if (Build.VERSION.SDK_INT >= 34) {
+            val pi = PendingIntent.getActivity(
+                this, 0, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+            startActivityAndCollapse(pi)
+        } else {
+            @Suppress("DEPRECATION")
+            startActivityAndCollapse(intent)
+        }
+    }
+}
+```
+
+> Rationale for the SDK branch: `startActivityAndCollapse(Intent)` throws on API 34+, and the `PendingIntent` overload only exists on API 34+. minSdk is 26, so both branches are reachable.
+
+- [ ] **Step 2: Add the `<service>` to `AndroidManifest.xml`**
+
+Inside `<application>`, alongside the existing `GatewayConnectionService` (`.notifications.GatewayConnectionService`):
+
+```xml
+        <service
+            android:name=".notifications.NotificationTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_stat_hermes"
+            android:label="Hermes"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+```
+
+- [ ] **Step 3: Compile + full unit suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt app/src/main/AndroidManifest.xml
+git commit -m "feat(tile): Quick Settings tile to arm/disarm the notification service"
+```
+
+---
+
+### Task 3: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk` (or `-d` for a device). Point it at a working gateway (or the mock at `http://10.0.2.2:8899`).
+
+- [ ] **Step 2: Verify the tile**
+
+- Open Quick Settings → edit tiles → the **Hermes** tile is available; add it.
+- With `POST_NOTIFICATIONS` **granted** (enable once from Settings → Notifications first, or grant on first prompt): tap the tile → it flips **On** and the persistent "Hermes — Connected" service notification appears; tap again → **Off** and the service notification goes away. The Settings → Notifications "Enable" switch reflects the same state next time it's opened.
+- With `POST_NOTIFICATIONS` **denied** (fresh install, tile off): tap the tile → the app opens at **Settings → Notifications** (via the `extra_route` deep-link) rather than silently failing.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(tile): verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure `tileClickAction` decision + `TileAction` enum, unit-tested (Task 1) ✓; `NotificationTileService` reflecting `enabled` on `onStartListening` and toggling on `onClick` with the `canStart` computation (Task 2) ✓; ENABLE/DISABLE reuse `setEnabled` + `GatewayConnectionService.start/stop` (Task 2) ✓; `OPEN_FOR_PERMISSION` via `startActivityAndCollapse` (PendingIntent on API 34+) to the `settings_notifications` deep-link (Task 2) ✓; manifest `QS_TILE` service with `BIND_QUICK_SETTINGS_TILE` (Task 2) ✓; on-device incl. the permission-denied route (Task 3) ✓; no counts/second tile/widget ✓; no bridge changes ✓. The optional `requestListeningState` live-sync is intentionally **not** included — `onStartListening` refreshes the tile on every shade open, which is sufficient (YAGNI).
+- **Placeholder scan:** every code step has full code; the only "if needed" is a conditional verification commit.
+- **Type consistency:** `TileAction.{ENABLE,DISABLE,OPEN_FOR_PERMISSION}`, `tileClickAction(enabled, canStart)`, `NotificationSettings.prefs`/`setEnabled`, `GatewayConnectionService.start/stop`, `ic_stat_hermes`, and the `"extra_route"="settings_notifications"` deep-link are used consistently across Tasks 1–2.
+
+**Ordering note:** Task 1 is the pure/testable core (compiles alone). Task 2 depends on Task 1. Task 3 verifies on-device.

--- a/docs/superpowers/specs/2026-07-03-qs-tile-design.md
+++ b/docs/superpowers/specs/2026-07-03-qs-tile-design.md
@@ -1,0 +1,97 @@
+# Quick Settings Tile — Design
+
+**Date:** 2026-07-03
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/qs-tile`
+**Parent idea:** `docs/ideas/native-command-surface.md` (Ship 2 — Native Pager, the Quick Settings tile piece)
+
+## Goal
+
+A pull-down Quick Settings tile ("Hermes") that shows whether notifications are on and toggles the background notification service in one tap — mirroring the Settings → Notifications "Enable" switch, without opening the app. Pure native Android; no gateway/bridge changes.
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Reuse `NotificationSettings` (DataStore), `GatewayConnectionService.start/stop`, and the existing `extra_route` → `HermesNav` deep-link.
+- Follow existing patterns: Hilt (`@AndroidEntryPoint`), pure unit-tested decision logic, existing `ic_stat_hermes` drawable.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `NotificationSettings` (DataStore): `val prefs: Flow<NotificationPrefs>` (`enabled`, `approvals`), `suspend fun setEnabled(Boolean)`. Hilt-provided.
+- `GatewayConnectionService.start(context)` / `stop(context)` — the foreground notifier service.
+- `NotificationsScreen` enable flow: on API 33+ requests `POST_NOTIFICATIONS`, then `setEnabled(true)` + `GatewayConnectionService.start`. Reached via `HermesNav` route `"settings_notifications"`.
+- `MainActivity` reads an `"extra_route"` intent extra into `pendingRoute` → `HermesNav.deepLinkRoute` navigates there.
+- `ic_stat_hermes` drawable exists.
+- `enabled` in `NotificationSettings` is the single source of truth (the service runs iff enabled + permission).
+
+## Architecture
+
+A `TileService` that reflects `NotificationSettings.enabled` and, on tap, applies a **pure decision** to enable/disable the service or route the user to the app to grant permission.
+
+### Components
+
+1. **Pure `tileClickAction(enabled: Boolean, canStart: Boolean): TileAction`** — `app/src/main/java/com/hermes/client/notifications/TileLogic.kt`. The unit-tested core.
+   - `TileAction` = `DISABLE | ENABLE | OPEN_FOR_PERMISSION`.
+   - `enabled == true` → `DISABLE`.
+   - `enabled == false && canStart` → `ENABLE`.
+   - `enabled == false && !canStart` → `OPEN_FOR_PERMISSION`.
+   - `canStart` is computed by the caller as `Build.VERSION.SDK_INT < 33 || POST_NOTIFICATIONS granted`.
+
+2. **`NotificationTileService`** — `app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt`. `@AndroidEntryPoint TileService`, injects `NotificationSettings`.
+   - `onStartListening()` (fires when the shade opens): `val enabled = runBlocking { settings.prefs.first().enabled }`; call `renderTile(enabled)` → set `qsTile` label `"Hermes"`, subtitle `"On"`/`"Off"`, `state = Tile.STATE_ACTIVE`/`STATE_INACTIVE`, icon `ic_stat_hermes`; `qsTile.updateTile()`.
+   - `onClick()`:
+     - `val enabled = runBlocking { settings.prefs.first().enabled }`.
+     - `val canStart = Build.VERSION.SDK_INT < 33 || ContextCompat.checkSelfPermission(this, POST_NOTIFICATIONS) == PERMISSION_GRANTED`.
+     - `when (tileClickAction(enabled, canStart))`:
+       - `ENABLE` → `runBlocking { settings.setEnabled(true) }`; `GatewayConnectionService.start(this)`; `renderTile(true)`.
+       - `DISABLE` → `runBlocking { settings.setEnabled(false) }`; `GatewayConnectionService.stop(this)`; `renderTile(false)`.
+       - `OPEN_FOR_PERMISSION` → `startActivityAndCollapse(PendingIntent for MainActivity with extra "extra_route" = "settings_notifications", FLAG_IMMUTABLE)`; leave the tile as-is (the app's Enable switch runs the permission flow). On Android 14+ `startActivityAndCollapse` requires a `PendingIntent`.
+
+3. **Manifest** — a `<service>` alongside `GatewayConnectionService`:
+   ```xml
+   <service
+       android:name=".notifications.NotificationTileService"
+       android:exported="true"
+       android:icon="@drawable/ic_stat_hermes"
+       android:label="Hermes"
+       android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+       <intent-filter>
+           <action android:name="android.service.quicksettings.action.QS_TILE" />
+       </intent-filter>
+   </service>
+   ```
+
+### Optional live-sync (include only if trivial)
+
+When the Settings → Notifications toggle flips `enabled`, the tile is stale until the shade re-opens. `TileService.requestListeningState(context, ComponentName(context, NotificationTileService::class.java))` pushes an `onStartListening` refresh. If it's a clean one-liner from the enable/disable handler, include it; otherwise skip — `onStartListening` already refreshes on every shade open.
+
+## Data flow
+
+```
+shade opens → onStartListening → settings.prefs.enabled → renderTile(on/off)
+tap → onClick → (enabled, canStart) → tileClickAction [pure]
+   ENABLE  → setEnabled(true)  + GatewayConnectionService.start + renderTile(true)
+   DISABLE → setEnabled(false) + GatewayConnectionService.stop  + renderTile(false)
+   OPEN_FOR_PERMISSION → startActivityAndCollapse(MainActivity, extra_route="settings_notifications")
+```
+
+## Error handling
+
+- DataStore reads in `onStartListening`/`onClick` use `runBlocking { prefs.first() }` — acceptable in the short-lived, main-thread TileService callbacks (a single fast DataStore read).
+- If the service can't be started because permission isn't granted, the tile routes into the app (`OPEN_FOR_PERMISSION`) rather than failing silently.
+- Starting `GatewayConnectionService` from `onClick` is a legal foreground-service start (user-initiated from the QS tile).
+
+## Testing
+
+- **Unit (pure), TDD — `TileLogicTest`:** `tileClickAction(enabled = true, …) → DISABLE`; `(false, canStart = true) → ENABLE`; `(false, canStart = false) → OPEN_FOR_PERMISSION`.
+- **On-device:** add the Hermes tile to Quick Settings; toggle it → confirm the notification service starts/stops and the tile label flips On/Off; with `POST_NOTIFICATIONS` denied, tapping to enable opens the app at Settings → Notifications.
+
+## Not doing (YAGNI)
+
+- Showing counts or any state beyond On/Off.
+- A second tile, an app widget, or per-type toggles on the tile.
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Whether to include the optional `requestListeningState` live-sync from the Settings toggle — decide in the plan based on how clean it is.


### PR DESCRIPTION
## Quick Settings tile

Adds a pull-down Quick Settings tile ("Hermes") that shows whether notifications are on and arms/disarms the background notification service in one tap — mirroring Settings → Notifications, without opening the app. Pure native Android; no bridge changes.

### How it works
- A pure, unit-tested `tileClickAction(enabled, canStart) → {ENABLE, DISABLE, OPEN_FOR_PERMISSION}`.
- `NotificationTileService` (`@AndroidEntryPoint TileService`) reflects `NotificationSettings.enabled`, and on tap enables/disables `GatewayConnectionService`, or — when `POST_NOTIFICATIONS` isn't granted (a tile can't request runtime permission) — routes into the app at Settings → Notifications via the existing `extra_route` deep-link.
- Manifest `QS_TILE` service with `BIND_QUICK_SETTINGS_TILE`.

### Verification
- 3 new unit tests for the decision logic; full suite + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task reviews + a final whole-branch review: "ready to merge").
- On-device: the `QS_TILE` service is registered and system-recognized (the Hermes tile appears in the QS editor); beta installs clean.

### Follow-ups (non-blocking)
- The TileService reads DataStore via `runBlocking` on its main-thread callbacks (spec-accepted; sub-ms once warm) — a coroutine-scoped async update is a reasonable fast-follow.
- The `canStart` permission predicate is duplicated across TileService/MainActivity/NotificationsScreen — extract a helper if touched again.

Spec/plan: `docs/superpowers/specs/2026-07-03-qs-tile-design.md`, `docs/superpowers/plans/2026-07-03-qs-tile.md` (Ship 2 of `docs/ideas/native-command-surface.md`).
