### PR TITLE
Pre-production hardening (scope leak + per-event DataStore read)

### DIFF
--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -57,7 +57,9 @@ class MainActivity : ComponentActivity() {
         val hasConfig = credentialStore.load() != null
         val crashReport = CrashReporter.read(this)
         // Resume the notification service if the user previously enabled it.
-        kotlinx.coroutines.MainScope().launch {
+        // lifecycleScope (not a bare MainScope) so the coroutine is cancelled with the activity
+        // instead of leaking on every recreation.
+        lifecycleScope.launch {
             if (notificationSettings.prefs.first().enabled) {
                 // On API 33+ the service posts notifications and needs POST_NOTIFICATIONS at
                 // runtime; if it isn't granted (e.g. revoked since last enable), don't auto-start

--- a/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
@@ -10,7 +10,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,18 +25,25 @@ class GatewayConnectionService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob())
 
+    // Latest notification prefs, kept current by a collector so the hot event loop never blocks on
+    // DataStore. @Volatile for cross-thread visibility (scope has no single-thread dispatcher).
+    @Volatile private var latestPrefs = NotificationPrefs()
+
     override fun onCreate() {
         super.onCreate()
         notifier.ensureChannels()
         startForeground(HermesNotifier.SERVICE_NOTIFICATION_ID, notifier.serviceNotification())
         client.connect()
+        // Track the latest prefs reactively so the event loop reads a cached value instead of
+        // collecting DataStore per event. Started first so its replayed value is in place before
+        // events arrive; also picks up mid-run toggles (e.g. approvals turned off).
+        scope.launch { settings.prefs.collect { latestPrefs = it } }
         scope.launch {
             client.events.collect { event ->
                 // One malformed/unexpected event must not crash the process — mirror the guard
                 // ChatViewModel's reduce() uses around event handling.
                 runCatching {
-                    val prefs = settings.prefs.first()
-                    toNotificationSpec(event, prefs)?.let { notifier.post(it) }
+                    toNotificationSpec(event, latestPrefs)?.let { notifier.post(it) }
                 }
             }
         }


### PR DESCRIPTION
## Pre-production hardening

Two fixes surfaced by automated review on the production-promotion PR (#49):

- **`MainActivity`** — the notification-service auto-start used a bare `MainScope().launch`, which is never cancelled and leaks a coroutine scope on every activity recreation (e.g. rotation). Switched to the already-imported `lifecycleScope`, which is cancelled with the activity.
- **`GatewayConnectionService`** — the WS event loop called `settings.prefs.first()` per event. Now a reactive collector keeps `latestPrefs` current and the loop reads the cached value (started before the event collector so its replayed value is in place). Also picks up mid-run prefs toggles.

Not addressed (false positive): CodeQL "implicit PendingIntent" on `HermesNotifier` — both Intents are explicit (`Intent(context, MainActivity/NotificationActionReceiver::class.java)`) and `pendingFlags()` is `FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE`, so they are explicit, immutable PendingIntents.

Compile + full unit suite green; gitleaks clean.
