### PR TITLE
Cron response inline in Agent Activity

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt
@@ -22,6 +22,9 @@ data class ActivityItem(
     val status: String?,
     // Navigation route to open the item ("chat/<id>" or "cron_detail/<id>").
     val route: String,
+    // Raw session id for a session-backed row (used to lazily load a cron run's response inline).
+    // Null for cron next-run items.
+    val sessionId: String? = null,
 )
 
 data class ActivitySection(val title: String, val items: List<ActivityItem>)
@@ -44,6 +47,7 @@ fun sessionsToActivity(sessions: List<Session>): List<ActivityItem> = sessions.m
         upcoming = false,
         status = null,
         route = "chat/${s.id}",
+        sessionId = s.id,
     )
 }
 

--- a/app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt
@@ -1,0 +1,23 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+
+/** Max length of the tool-result fallback summary before truncation. */
+const val CRON_RESPONSE_MAX = 500
+
+/**
+ * A cron run's "response" from its session messages: the last assistant message with text; else
+ * the last tool result summary; else a placeholder. Pure — unit-tested without network or clock.
+ */
+fun cronResponse(messages: List<ChatMessage>): String {
+    messages.lastOrNull { it.role == Role.ASSISTANT && it.text.isNotBlank() }
+        ?.let { return it.text.trim() }
+    messages.lastOrNull { m -> m.tools.any { it.output.isNotBlank() } }
+        ?.let { m ->
+            val tool = m.tools.last { it.output.isNotBlank() }
+            val summary = "${tool.name}: ${tool.output.trim()}"
+            return if (summary.length > CRON_RESPONSE_MAX) summary.take(CRON_RESPONSE_MAX) + "…" else summary
+        }
+    return "No text output."
+}

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -8,28 +8,36 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Chat
 import androidx.compose.material.icons.rounded.BarChart
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Extension
 import androidx.compose.material.icons.rounded.Forum
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -139,6 +147,14 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     // One VM instance per tenant page, keyed by profile name.
     val vm: MissionControlViewModel = hiltViewModel(key = "mc-${profile ?: "_"}")
     val state by vm.state.collectAsStateWithLifecycle()
+    val responses by vm.responses.collectAsStateWithLifecycle()
+    val expanded = remember { androidx.compose.runtime.mutableStateMapOf<String, Boolean>() }
+    val onToggle: (ActivityItem) -> Unit = { item ->
+        val open = !(expanded[item.id] ?: false)
+        expanded[item.id] = open
+        if (open) item.sessionId?.let { vm.loadResponse(it) }
+    }
+    val onRetryResponse: (ActivityItem) -> Unit = { item -> item.sessionId?.let { vm.loadResponse(it) } }
     val scope = rememberCoroutineScope()
     val now = remember(state.sections) { System.currentTimeMillis() }
 
@@ -160,7 +176,11 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
             isRefreshing = refreshing,
             onRefresh = { refreshing = true; vm.refresh() },
         ) {
-            MissionControlContent(state = state, nowMs = now, onRetry = { vm.refresh() }, onOpen = onOpen)
+            MissionControlContent(
+                state = state, nowMs = now, onRetry = { vm.refresh() },
+                responses = responses, expanded = expanded,
+                onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
+            )
         }
     }
 }
@@ -170,6 +190,10 @@ private fun MissionControlContent(
     state: MissionControlState,
     nowMs: Long,
     onRetry: () -> Unit,
+    responses: Map<String, MissionControlViewModel.CronResponseUi>,
+    expanded: androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean>,
+    onToggle: (ActivityItem) -> Unit,
+    onRetryResponse: (ActivityItem) -> Unit,
     onOpen: (String) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
@@ -200,7 +224,18 @@ private fun MissionControlContent(
             else -> state.sections.forEach { section ->
                 item(key = "h-${section.title}") { SectionHeader(section.title, section.items.size) }
                 items(section.items, key = { it.id }) { activity ->
-                    ActivityRow(activity, nowMs, onClick = { onOpen(activity.route) })
+                    val expandable = activity.kind == ActivityKind.CRON &&
+                        activity.sessionId != null && !activity.upcoming
+                    ActivityRow(
+                        item = activity,
+                        nowMs = nowMs,
+                        expandable = expandable,
+                        isExpanded = expanded[activity.id] == true,
+                        response = activity.sessionId?.let { responses[it] },
+                        onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
+                        onRetry = { onRetryResponse(activity) },
+                        onOpenFull = { onOpen(activity.route) },
+                    )
                 }
             }
         }
@@ -225,7 +260,16 @@ private fun SectionHeader(label: String, count: Int) {
 }
 
 @Composable
-private fun ActivityRow(item: ActivityItem, nowMs: Long, onClick: () -> Unit) {
+private fun ActivityRow(
+    item: ActivityItem,
+    nowMs: Long,
+    expandable: Boolean = false,
+    isExpanded: Boolean = false,
+    response: MissionControlViewModel.CronResponseUi? = null,
+    onClick: () -> Unit,
+    onRetry: () -> Unit = {},
+    onOpenFull: () -> Unit = {},
+) {
     val icon: ImageVector = when {
         item.kind == ActivityKind.CONVERSATION -> Icons.AutoMirrored.Rounded.Chat
         item.upcoming -> Icons.Rounded.Schedule
@@ -240,10 +284,57 @@ private fun ActivityRow(item: ActivityItem, nowMs: Long, onClick: () -> Unit) {
         else -> MaterialTheme.colorScheme.primary
     }
     val time = relativeTime(item.timestampMs, nowMs)
-    ListItem(
-        leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
-        headlineContent = { Text(item.title) },
-        supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
-        modifier = Modifier.clickable(onClick = onClick),
-    )
+    Column {
+        ListItem(
+            leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
+            headlineContent = { Text(item.title) },
+            supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
+            trailingContent = if (expandable) {
+                {
+                    Icon(
+                        if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse response" else "Show response",
+                    )
+                }
+            } else {
+                null
+            },
+            modifier = Modifier.clickable(onClick = onClick),
+        )
+        if (expandable && isExpanded) {
+            CronResponseCard(response = response, onRetry = onRetry, onOpenFull = onOpenFull)
+        }
+    }
+}
+
+@Composable
+private fun CronResponseCard(
+    response: MissionControlViewModel.CronResponseUi?,
+    onRetry: () -> Unit,
+    onOpenFull: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            when {
+                response == null || response.loading ->
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                response.error -> {
+                    Text("Couldn't load response", color = MaterialTheme.colorScheme.error)
+                    TextButton(onClick = onRetry) { Text("Retry") }
+                }
+                else -> {
+                    Text(
+                        response.text ?: "No text output.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.heightIn(max = 220.dp).verticalScroll(rememberScrollState()),
+                    )
+                    TextButton(onClick = onOpenFull) { Text("View full chat") }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -34,6 +34,12 @@ class MissionControlViewModel @Inject constructor(
     private val _state = MutableStateFlow(MissionControlState())
     val state: StateFlow<MissionControlState> = _state.asStateFlow()
 
+    /** Lazily-loaded cron-run responses, keyed by sessionId. */
+    data class CronResponseUi(val loading: Boolean = false, val text: String? = null, val error: Boolean = false)
+
+    private val _responses = MutableStateFlow<Map<String, CronResponseUi>>(emptyMap())
+    val responses: StateFlow<Map<String, CronResponseUi>> = _responses.asStateFlow()
+
     private var profile: String? = null
     private var loadJob: kotlinx.coroutines.Job? = null
 
@@ -72,6 +78,25 @@ class MissionControlViewModel @Inject constructor(
     suspend fun switchTo(profile: String?) {
         if (!profile.isNullOrBlank() && profile != profileManager.active.value) {
             profileManager.switchTo(profile)
+        }
+    }
+
+    /**
+     * Fetch a cron run's response on demand (one REST history call), caching by sessionId. A loaded
+     * or in-flight entry is not refetched; a prior error IS retryable (call again).
+     */
+    fun loadResponse(sessionId: String) {
+        val existing = _responses.value[sessionId]
+        if (existing != null && (existing.loading || existing.text != null)) return
+        _responses.value = _responses.value + (sessionId to CronResponseUi(loading = true))
+        viewModelScope.launch {
+            val result = runCatching { sessions.history(sessionId, profile) }
+            _responses.value = _responses.value + (
+                sessionId to result.fold(
+                    onSuccess = { CronResponseUi(text = cronResponse(it)) },
+                    onFailure = { CronResponseUi(error = true) },
+                )
+            )
         }
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt
@@ -94,4 +94,13 @@ class ActivityModelsTest {
         )
         assertEquals(emptyList<ActivityItem>(), cronsToActivity(listOf(job)))
     }
+
+    @Test fun sessionsToActivity_sets_sessionId_to_raw_id() {
+        val s = com.hermes.client.domain.Session(
+            id = "sess-42", title = "Nightly report", model = null, provider = null,
+            messageCount = 3, profile = "default", source = "cron", lastActive = 1_000L,
+        )
+        val item = sessionsToActivity(listOf(s)).single()
+        assertEquals("sess-42", item.sessionId)
+    }
 }

--- a/app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt
@@ -1,0 +1,50 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import com.hermes.client.domain.ToolCall
+import com.hermes.client.domain.ToolStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun msg(role: Role, text: String = "", tools: List<ToolCall> = emptyList()) =
+    ChatMessage(id = "x", role = role, text = text, tools = tools)
+
+class CronResponseTest {
+    @Test fun returns_last_assistant_text() {
+        val out = cronResponse(
+            listOf(msg(Role.USER, "run it"), msg(Role.ASSISTANT, "first"), msg(Role.ASSISTANT, "final answer")),
+        )
+        assertEquals("final answer", out)
+    }
+
+    @Test fun trims_assistant_text() {
+        assertEquals("hi", cronResponse(listOf(msg(Role.ASSISTANT, "  hi  "))))
+    }
+
+    @Test fun falls_back_to_last_tool_output_when_no_assistant_text() {
+        val out = cronResponse(
+            listOf(
+                msg(Role.USER, "go"),
+                msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t1", "search", ToolStatus.DONE, "42 results"))),
+            ),
+        )
+        assertEquals("search: 42 results", out)
+    }
+
+    @Test fun truncates_long_tool_output() {
+        val long = "y".repeat(CRON_RESPONSE_MAX + 50)
+        val out = cronResponse(listOf(msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t", "run", ToolStatus.DONE, long)))))
+        assertEquals(CRON_RESPONSE_MAX + 1, out.length)
+        assertTrue(out.endsWith("…"))
+    }
+
+    @Test fun empty_messages_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(emptyList()))
+    }
+
+    @Test fun blank_assistant_and_no_tools_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(listOf(msg(Role.ASSISTANT, "   "))))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
@@ -1,0 +1,59 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.data.repository.ToolsRepository
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MissionControlViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val sessions = mockk<SessionRepository>()
+    private val tools = mockk<ToolsRepository>(relaxed = true)
+    private val profileManager = mockk<ProfileManager>(relaxed = true)
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private fun vm() = MissionControlViewModel(sessions, tools, profileManager)
+
+    @Test fun loadResponse_sets_text_on_success() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "the answer"))
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertEquals("the answer", vm.responses.value["s1"]?.text)
+    }
+
+    @Test fun loadResponse_sets_error_on_failure() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } throws RuntimeException("boom")
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertTrue(vm.responses.value["s1"]?.error == true)
+    }
+
+    @Test fun loadResponse_caches_and_does_not_refetch() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "x"))
+        val vm = vm()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        coVerify(exactly = 1) { sessions.history("s1", any()) }
+    }
+}

--- a/docs/ideas/activity-home-and-cron-response.md
+++ b/docs/ideas/activity-home-and-cron-response.md
@@ -1,0 +1,53 @@
+# Activity Home + Cron Response-at-a-Glance
+
+## Problem Statement
+**How might we** make opening the app land you on *what's happening and what needs you* (never a stale resumed chat), and let you see *what a scheduled job actually answered* without wading through its full transcript — using only existing endpoints + native APIs?
+
+## Context (grounded in the code)
+- **Launch today:** `HermesNav` sets `start = if (hasConfig) "sessions" else "setup"` — a cold launch opens the **Sessions list**. A notification tap already deep-links to `chat/<id>` via the `extra_route` rail.
+- **Agent Activity today:** the `activity` tab is **Mission Control** — already a "unified activity feed merging conversations + cron for the active profile, time-grouped." Cron runs are stored as real `source="cron"` **sessions**; tapping one opens the *full* transcript. `ActivityItem.status` already carries cron `last_status`; `CronJobDto` carries `lastRunAt`/`nextRunAt`.
+- **Product vs Technical toggle** already exists (`SettingsStore.toolCallTechnical`): Product mode hides tool payloads.
+- **Data reality (verified this session):** the WS stream emits `approval.request/responded`, `run.*`, `tool.*`, `message.*` — but there is **no REST list of pending approvals**, and cron-finished/messaging events are **not** on the app's WS. Cron state and messaging pairing ARE available over REST (`/api/cron/*`, `/api/pairing`).
+
+## Recommended Direction
+
+Two complementary, independently shippable pieces on the **same surface** — the existing Mission Control feed. Ship the small one first.
+
+**Piece 1 (ship first) — Cron response inline in Agent Activity.**
+A cron item in the feed expands **inline** to show the run's **final assistant message** (the "response"), Product-mode-filtered so tool payloads are hidden. Tap-through to the full transcript is preserved. The response is the last `role = assistant` `ChatMessage` in the cron-produced session, fetched **lazily on expand** (one history call for the tapped item — no upfront N calls). For a run with only tool output and no final assistant text, fall back to the **last tool result summary**. Small, clean, no data gaps.
+
+**Piece 2 — Home = Mission Control promoted, with a "Needs you" strip, set as the launch destination.**
+Flip the start destination from `sessions` to the activity home so a cold launch lands on *what's happening* — never a resumed stale chat (this is the real fix for "it remembers the session"). The bottom-nav tab is **relabeled "Home"** (concept: the Situation Room) rather than "Agent Activity". A compact **"Needs you"** strip sits on top of the existing time-grouped feed and **auto-refreshes on resume** via a cheap REST poll of cron + pairing. Notification taps still deep-link to their session unchanged. "New chat" scopes to the **last-used profile**.
+
+**The honest constraint on "Needs you":** it leads with what's **reliable over REST** — **failed / overdue cron** (from `last_status` + `next_run`, already in the feed's data) and **waiting messaging** (`/api/pairing`). *Pending agent approvals* — the thing you'd most want — are WS-only and transient, so they appear **only as a bonus when the foreground service is live** (from its in-memory cache), never as a promised cold-launch count. We do **not** build "Needs you = approvals count"; it would be empty and misleading most of the time.
+
+Rationale: Piece 1 is a painkiller with zero data gaps — it ships this week and makes the cron feature actually useful on a phone. Piece 2 reuses the shipped Mission Control feed rather than duplicating it as a new screen, and is honest about the one weak input (approvals) instead of building the whole thing around it.
+
+## Key Assumptions to Validate
+- [ ] **A cron run has a clean "final answer."** Bet: the last `assistant` message in the `source="cron"` session is the response. Test: expand several real cron runs (single-step and multi-step); confirm the last assistant text reads as "the answer." Fallback: for a tool-only run with no final assistant text, show the **last tool result summary**.
+- [ ] **Failed/overdue cron is derivable without new endpoints.** Bet: `CronJobDto.lastStatus` + `nextRunAt` (already mapped) are enough to flag "failed" and "overdue." Test: force a failing cron + a missed schedule; confirm both surface in "Needs you."
+- [ ] **Landing on the home doesn't fight the notification deep-link.** Bet: start on home, then `deepLinkRoute` navigates on top as today. Test: cold-launch from an approval notification → lands on the session, not the home.
+- [ ] **Last-used profile is safe as the new-chat default.** Bet: reopening the last tenant is what you want. Risk: cross-tenant mis-send. Test: dogfood; if it ever feels risky, fall back to a pinned default or a picker (both already considered).
+
+## MVP Scope
+**In:**
+- **Piece 1:** cron feed items expand to the final assistant message (Product-mode-filtered), lazy-fetched on expand; full-transcript tap preserved.
+- **Piece 2:** start destination → activity home (bottom-nav tab relabeled **"Home"**); a "Needs you" strip = failed/overdue cron (+ messaging-pairing waits) that **auto-refreshes on resume**; "New chat" uses last-used profile; notification deep-link unchanged.
+
+**Out (this MVP):**
+- A separate net-new "Situation Room" screen (we promote Mission Control instead).
+- A guaranteed cold-launch pending-approvals count (WS-only; bonus-when-service-on only).
+- Any new gateway endpoint.
+- A profile picker / pinned-default-profile launch flow (revisit only if last-used feels unsafe in daily use).
+
+## Not Doing (and Why)
+- **Duplicate Situation Room screen** — Mission Control already is the unified feed; a second screen would fork the code and the data. Promote, don't duplicate.
+- **"Needs you" built around approvals** — no REST list + transient + service-dependent; it would be blank on cold launch. Cron/messaging lead; approvals are a live-only bonus.
+- **New-chat-on-launch (the original ask)** — superseded: landing on the home already removes the stale-session-resume problem, and gives orientation before you start typing. A one-tap "New" is right there.
+- **Eager-loading every cron response in the feed** — N history calls on every open. Lazy-on-expand instead.
+- **A new Product/Technical control for cron** — reuse the existing toggle; the cron response is just an assistant message with payloads hidden.
+
+## Resolved Decisions
+- **Launch tab is relabeled "Home"** (concept: the Situation Room), not kept as "Agent Activity" — it becomes the start destination with the "Needs you" strip on top.
+- **"Needs you" auto-refreshes on resume** via a cheap REST poll of cron + pairing (not pull/tab-enter only).
+- **Tool-only cron runs** (no final assistant text) show the **last tool result summary** as the "response".

--- a/docs/superpowers/plans/2026-07-04-cron-response-inline.md
+++ b/docs/superpowers/plans/2026-07-04-cron-response-inline.md
@@ -1,0 +1,529 @@
+# Cron Response Inline (Agent Activity) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tapping a cron run in the Agent Activity feed expands its response (the run's final assistant message) inline, with a "View full chat" link to the transcript.
+
+**Architecture:** A pure `cronResponse(messages)` extractor + an `ActivityItem.sessionId` + a lazy per-run loader on `MissionControlViewModel` (`SessionRepository.history()` REST, cached by sessionId) + response-first inline expansion in `MissionControlScreen`. No gateway/bridge changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, MVVM + StateFlow, JUnit + MockK + coroutines-test.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Reuse `SessionRepository.history(sessionId, profile): List<ChatMessage>` (REST `GET /api/sessions/<id>/messages`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Follow patterns: pure unit tests like `ActivityModelsTest`; VM tests with MockK + `runTest`; Material3 `ListItem` rows.
+- **No AI/assistant attribution** in commits, files, or PRs.
+- Only **cron runs** expand (`kind == CRON && sessionId != null && !upcoming`); conversations + upcoming next-runs navigate as today.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt` — pure `cronResponse` + `CRON_RESPONSE_MAX`.
+- Create `app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt` — `ActivityItem.sessionId`.
+- Modify `app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt` — assert `sessionId`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt` — `CronResponseUi`, `responses`, `loadResponse`.
+- Create `app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt` — inline expansion.
+
+---
+
+### Task 1: Pure `cronResponse` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt`
+
+**Interfaces:**
+- Produces: `const val CRON_RESPONSE_MAX = 500`; `fun cronResponse(messages: List<ChatMessage>): String`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import com.hermes.client.domain.ToolCall
+import com.hermes.client.domain.ToolStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun msg(role: Role, text: String = "", tools: List<ToolCall> = emptyList()) =
+    ChatMessage(id = "x", role = role, text = text, tools = tools)
+
+class CronResponseTest {
+    @Test fun returns_last_assistant_text() {
+        val out = cronResponse(
+            listOf(msg(Role.USER, "run it"), msg(Role.ASSISTANT, "first"), msg(Role.ASSISTANT, "final answer")),
+        )
+        assertEquals("final answer", out)
+    }
+
+    @Test fun trims_assistant_text() {
+        assertEquals("hi", cronResponse(listOf(msg(Role.ASSISTANT, "  hi  "))))
+    }
+
+    @Test fun falls_back_to_last_tool_output_when_no_assistant_text() {
+        val out = cronResponse(
+            listOf(
+                msg(Role.USER, "go"),
+                msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t1", "search", ToolStatus.DONE, "42 results"))),
+            ),
+        )
+        assertEquals("search: 42 results", out)
+    }
+
+    @Test fun truncates_long_tool_output() {
+        val long = "y".repeat(CRON_RESPONSE_MAX + 50)
+        val out = cronResponse(listOf(msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t", "run", ToolStatus.DONE, long)))))
+        assertEquals(CRON_RESPONSE_MAX + 1, out.length)
+        assertTrue(out.endsWith("…"))
+    }
+
+    @Test fun empty_messages_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(emptyList()))
+    }
+
+    @Test fun blank_assistant_and_no_tools_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(listOf(msg(Role.ASSISTANT, "   "))))
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronResponseTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `cronResponse`/`CRON_RESPONSE_MAX`.
+
+- [ ] **Step 3: Implement `CronResponse.kt`**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+
+/** Max length of the tool-result fallback summary before truncation. */
+const val CRON_RESPONSE_MAX = 500
+
+/**
+ * A cron run's "response" from its session messages: the last assistant message with text; else
+ * the last tool result summary; else a placeholder. Pure — unit-tested without network or clock.
+ */
+fun cronResponse(messages: List<ChatMessage>): String {
+    messages.lastOrNull { it.role == Role.ASSISTANT && it.text.isNotBlank() }
+        ?.let { return it.text.trim() }
+    messages.lastOrNull { m -> m.tools.any { it.output.isNotBlank() } }
+        ?.let { m ->
+            val tool = m.tools.last { it.output.isNotBlank() }
+            val summary = "${tool.name}: ${tool.output.trim()}"
+            return if (summary.length > CRON_RESPONSE_MAX) summary.take(CRON_RESPONSE_MAX) + "…" else summary
+        }
+    return "No text output."
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronResponseTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt
+git commit -m "feat(activity): pure cronResponse extractor with tests"
+```
+
+---
+
+### Task 2: `ActivityItem.sessionId`
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt`
+
+**Interfaces:**
+- Produces: `ActivityItem.sessionId: String?` — the raw session id, set by `sessionsToActivity`, null from `cronsToActivity`.
+
+- [ ] **Step 1: Add the failing test** — append to `ActivityModelsTest`:
+
+```kotlin
+    @Test fun sessionsToActivity_sets_sessionId_to_raw_id() {
+        val s = com.hermes.client.domain.Session(
+            id = "sess-42", title = "Nightly report", model = null, provider = null,
+            messageCount = 3, profile = "default", source = "cron", lastActive = 1_000L,
+        )
+        val item = sessionsToActivity(listOf(s)).single()
+        assertEquals("sess-42", item.sessionId)
+    }
+```
+
+Ensure `import org.junit.Assert.assertEquals` is present in the test file.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ActivityModelsTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — `sessionId` unresolved.
+
+- [ ] **Step 3: Add the field + set it**
+
+In `ActivityModels.kt`, add to the `ActivityItem` data class (after `route`):
+
+```kotlin
+    // Raw session id for a session-backed row (used to lazily load a cron run's response inline).
+    // Null for cron next-run items.
+    val sessionId: String? = null,
+```
+
+In `sessionsToActivity`, add `sessionId = s.id,` to the `ActivityItem(...)` constructor (alongside `route = "chat/${s.id}"`). Leave `cronsToActivity` unchanged (defaults to null).
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ActivityModelsTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt
+git commit -m "feat(activity): carry sessionId on ActivityItem for inline response loading"
+```
+
+---
+
+### Task 3: `MissionControlViewModel` lazy response loader
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: `cronResponse` (Task 1); `SessionRepository.history(sessionId, profile)`.
+- Produces: `data class CronResponseUi(loading: Boolean = false, text: String? = null, error: Boolean = false)`; `val responses: StateFlow<Map<String, CronResponseUi>>`; `fun loadResponse(sessionId: String)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.data.repository.ToolsRepository
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MissionControlViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val sessions = mockk<SessionRepository>()
+    private val tools = mockk<ToolsRepository>(relaxed = true)
+    private val profileManager = mockk<ProfileManager>(relaxed = true)
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private fun vm() = MissionControlViewModel(sessions, tools, profileManager)
+
+    @Test fun loadResponse_sets_text_on_success() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "the answer"))
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertEquals("the answer", vm.responses.value["s1"]?.text)
+    }
+
+    @Test fun loadResponse_sets_error_on_failure() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } throws RuntimeException("boom")
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertTrue(vm.responses.value["s1"]?.error == true)
+    }
+
+    @Test fun loadResponse_caches_and_does_not_refetch() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "x"))
+        val vm = vm()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        coVerify(exactly = 1) { sessions.history("s1", any()) }
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MissionControlViewModelTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `responses`/`loadResponse`/`CronResponseUi`.
+
+- [ ] **Step 3: Add the loader to `MissionControlViewModel`**
+
+Add imports if missing: `kotlinx.coroutines.flow.asStateFlow` (already present), `kotlinx.coroutines.launch` (already present).
+
+Add inside the class body (e.g. after the `state` declaration):
+
+```kotlin
+    /** Lazily-loaded cron-run responses, keyed by sessionId. */
+    data class CronResponseUi(val loading: Boolean = false, val text: String? = null, val error: Boolean = false)
+
+    private val _responses = MutableStateFlow<Map<String, CronResponseUi>>(emptyMap())
+    val responses: StateFlow<Map<String, CronResponseUi>> = _responses.asStateFlow()
+
+    /**
+     * Fetch a cron run's response on demand (one REST history call), caching by sessionId. A loaded
+     * or in-flight entry is not refetched; a prior error IS retryable (call again).
+     */
+    fun loadResponse(sessionId: String) {
+        val existing = _responses.value[sessionId]
+        if (existing != null && (existing.loading || existing.text != null)) return
+        _responses.value = _responses.value + (sessionId to CronResponseUi(loading = true))
+        viewModelScope.launch {
+            val result = runCatching { sessions.history(sessionId, profile) }
+            _responses.value = _responses.value + (
+                sessionId to result.fold(
+                    onSuccess = { CronResponseUi(text = cronResponse(it)) },
+                    onFailure = { CronResponseUi(error = true) },
+                )
+            )
+        }
+    }
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MissionControlViewModelTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
+git commit -m "feat(activity): lazy per-run cron response loader on MissionControlViewModel"
+```
+
+---
+
+### Task 4: Inline expansion in `MissionControlScreen`
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+**Interfaces:**
+- Consumes: `ActivityItem.sessionId` (Task 2); `MissionControlViewModel.responses`/`loadResponse`/`CronResponseUi` (Task 3).
+
+- [ ] **Step 1: Thread response state through `MissionControlPage`**
+
+In `MissionControlPage`, after `val state by vm.state.collectAsStateWithLifecycle()` add:
+
+```kotlin
+    val responses by vm.responses.collectAsStateWithLifecycle()
+    val expanded = remember { androidx.compose.runtime.mutableStateMapOf<String, Boolean>() }
+    val onToggle: (ActivityItem) -> Unit = { item ->
+        val open = !(expanded[item.id] ?: false)
+        expanded[item.id] = open
+        if (open) item.sessionId?.let { vm.loadResponse(it) }
+    }
+    val onRetryResponse: (ActivityItem) -> Unit = { item -> item.sessionId?.let { vm.loadResponse(it) } }
+```
+
+Update the `MissionControlContent(...)` call to pass them:
+
+```kotlin
+            MissionControlContent(
+                state = state, nowMs = now, onRetry = { vm.refresh() },
+                responses = responses, expanded = expanded,
+                onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
+            )
+```
+
+- [ ] **Step 2: Update `MissionControlContent` signature + the item row**
+
+Change the signature to:
+
+```kotlin
+@Composable
+private fun MissionControlContent(
+    state: MissionControlState,
+    nowMs: Long,
+    onRetry: () -> Unit,
+    responses: Map<String, MissionControlViewModel.CronResponseUi>,
+    expanded: androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean>,
+    onToggle: (ActivityItem) -> Unit,
+    onRetryResponse: (ActivityItem) -> Unit,
+    onOpen: (String) -> Unit,
+) {
+```
+
+Replace the `items(section.items, …)` block with:
+
+```kotlin
+                items(section.items, key = { it.id }) { activity ->
+                    val expandable = activity.kind == ActivityKind.CRON &&
+                        activity.sessionId != null && !activity.upcoming
+                    ActivityRow(
+                        item = activity,
+                        nowMs = nowMs,
+                        expandable = expandable,
+                        isExpanded = expanded[activity.id] == true,
+                        response = activity.sessionId?.let { responses[it] },
+                        onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
+                        onRetry = { onRetryResponse(activity) },
+                        onOpenFull = { onOpen(activity.route) },
+                    )
+                }
+```
+
+- [ ] **Step 3: Rewrite `ActivityRow` + add `CronResponseCard`**
+
+Replace the existing `ActivityRow` composable with:
+
+```kotlin
+@Composable
+private fun ActivityRow(
+    item: ActivityItem,
+    nowMs: Long,
+    expandable: Boolean = false,
+    isExpanded: Boolean = false,
+    response: MissionControlViewModel.CronResponseUi? = null,
+    onClick: () -> Unit,
+    onRetry: () -> Unit = {},
+    onOpenFull: () -> Unit = {},
+) {
+    val icon: ImageVector = when {
+        item.kind == ActivityKind.CONVERSATION -> Icons.AutoMirrored.Rounded.Chat
+        item.upcoming -> Icons.Rounded.Schedule
+        item.status.equals("success", ignoreCase = true) -> Icons.Rounded.CheckCircle
+        item.status.equals("error", ignoreCase = true) ||
+            item.status.equals("failed", ignoreCase = true) -> Icons.Rounded.ErrorOutline
+        else -> Icons.Rounded.History
+    }
+    val tint = when {
+        item.status.equals("error", ignoreCase = true) ||
+            item.status.equals("failed", ignoreCase = true) -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val time = relativeTime(item.timestampMs, nowMs)
+    Column {
+        ListItem(
+            leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
+            headlineContent = { Text(item.title) },
+            supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
+            trailingContent = if (expandable) {
+                {
+                    Icon(
+                        if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse response" else "Show response",
+                    )
+                }
+            } else {
+                null
+            },
+            modifier = Modifier.clickable(onClick = onClick),
+        )
+        if (expandable && isExpanded) {
+            CronResponseCard(response = response, onRetry = onRetry, onOpenFull = onOpenFull)
+        }
+    }
+}
+
+@Composable
+private fun CronResponseCard(
+    response: MissionControlViewModel.CronResponseUi?,
+    onRetry: () -> Unit,
+    onOpenFull: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            when {
+                response == null || response.loading ->
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                response.error -> {
+                    Text("Couldn't load response", color = MaterialTheme.colorScheme.error)
+                    TextButton(onClick = onRetry) { Text("Retry") }
+                }
+                else -> {
+                    Text(
+                        response.text ?: "No text output.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.heightIn(max = 220.dp).verticalScroll(rememberScrollState()),
+                    )
+                    TextButton(onClick = onOpenFull) { Text("View full chat") }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add missing imports + build**
+
+Add any imports the compiler reports as missing (candidates, verify against the file's existing imports):
+`androidx.compose.foundation.layout.Column`, `androidx.compose.foundation.rememberScrollState`, `androidx.compose.foundation.verticalScroll`, `androidx.compose.foundation.layout.heightIn`, `androidx.compose.foundation.layout.size`, `androidx.compose.material.icons.rounded.ExpandLess`, `androidx.compose.material.icons.rounded.ExpandMore`, `androidx.compose.material3.CircularProgressIndicator`, `androidx.compose.material3.Surface`, `androidx.compose.material3.TextButton`, `androidx.compose.runtime.remember`.
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`. Iterate on any `^e:` import/type error until clean.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(activity): response-first inline expansion for cron runs"
+```
+
+---
+
+### Task 5: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point it at a gateway that has at least one completed cron run (a `source="cron"` session).
+
+- [ ] **Step 2: Verify**
+
+- Open **Agent Activity**. A completed cron run shows a chevron; tap the row → it expands, shows a spinner, then the run's **response** text; a **"View full chat"** button opens the full transcript.
+- Tap again → collapses. Re-expand → no refetch (instant).
+- A **conversation** row and an **upcoming** cron next-run still navigate (no expansion).
+- Force a history failure (airplane mode mid-expand) → "Couldn't load response" + **Retry**; Retry re-loads.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(activity): cron-response verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure `cronResponse` (last assistant text → tool-result summary → placeholder, `MAX=500` truncation), unit-tested (Task 1) ✓; `ActivityItem.sessionId` set by `sessionsToActivity` (Task 2) ✓; lazy `loadResponse` with `CronResponseUi` loading/text/error, cached by sessionId, retry-on-error, one-history-call guard, VM-tested (Task 3) ✓; response-first inline expansion — tap cron run toggles + loads, spinner/error+Retry/text, "View full chat", only `kind==CRON && sessionId!=null && !upcoming` expand, others navigate (Task 4) ✓; states + on-device incl. failure path (Task 5) ✓; no Product-toggle threading (response is text) ✓; no bridge changes (reuses `history`) ✓.
+- **Placeholder scan:** every code step has full code; the only conditional is the Task 5 verification-only commit and the "add missing imports" step (candidate list given).
+- **Type consistency:** `cronResponse(messages)`/`CRON_RESPONSE_MAX`, `ActivityItem.sessionId`, `MissionControlViewModel.CronResponseUi(loading/text/error)`, `responses`/`loadResponse(sessionId)`, and the `ActivityRow(expandable/isExpanded/response/onClick/onRetry/onOpenFull)` params are consistent across Tasks 1–4. `ToolStatus.DONE`, `Role.ASSISTANT`, `ToolCall(id,name,status,output)`, `Session(...)` match the domain models.
+
+**Ordering note:** Task 1 (pure) and Task 2 (data field) are independent and each green. Task 3 depends on Task 1 (`cronResponse`). Task 4 depends on Tasks 2 + 3. Task 5 verifies on-device.

--- a/docs/superpowers/specs/2026-07-04-cron-response-inline-design.md
+++ b/docs/superpowers/specs/2026-07-04-cron-response-inline-design.md
@@ -1,0 +1,91 @@
+# Cron Response Inline (Agent Activity) — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/cron-response-inline`
+**Parent idea:** `docs/ideas/activity-home-and-cron-response.md` (Piece 1 — ship first)
+
+## Goal
+
+In the Agent Activity (Mission Control) feed, tapping a **cron run** expands its **response** — the run's final assistant message — **inline**, so you see what the scheduled job answered without opening the full transcript. A "View full chat" link inside the expanded card still opens the complete session. **No gateway/bridge changes.**
+
+## Interaction (decided: response-first)
+
+- Tapping a **cron-run row** expands/collapses its response inline (response-first — the response is the primary thing).
+- The expanded card carries a **"View full chat"** affordance that navigates to the full transcript (`chat/<id>`, today's behavior).
+- **Only cron runs expand.** Conversation rows and **upcoming** cron next-runs keep today's behavior (tap → navigate to their `route`).
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Reuse `SessionRepository.history(sessionId, profile)` (REST `GET /api/sessions/<id>/messages`).
+- Follow existing patterns: pure unit-tested logic (like `ActivityModels`/`sessionsToActivity`), Hilt VM, Material3 `ListItem` feed rows.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `MissionControlViewModel` (Hilt): injects `SessionRepository sessions`, `ToolsRepository tools`, `ProfileManager`; exposes `state: StateFlow<MissionControlState>` of `ActivitySection`/`ActivityItem`; `load/refresh`, and `switchTo(profile)`.
+- `ActivityItem(id, kind: CONVERSATION|CRON, title, subtitle, timestampMs, upcoming, status, route)`. Cron **runs** come from `sessionsToActivity` (source="cron" sessions → `kind=CRON`, `route="chat/<id>"`, `upcoming=false`); cron **next-runs** come from `cronsToActivity` (`upcoming=true`, `route="cron_detail/<id>"`).
+- `SessionRepository.history(sessionId, profile): List<ChatMessage>` — REST, no socket.
+- `ChatMessage(id, role: USER|ASSISTANT|SYSTEM, text, tools: List<ToolCall>, thinking, …)`; `ToolCall(id, name, status, output)`.
+- `MissionControlScreen`: `LazyColumn` → `items(section.items){ ActivityRow(item, nowMs, onClick = { onOpen(item.route) }) }`; `onOpen(route)` awaits `vm.switchTo(profile)` then `onNavigate(route)`. `ActivityRow` is a Material3 `ListItem`.
+
+## Architecture
+
+Add a small pure extractor, a lazy per-run response loader on the VM, an `ActivityItem.sessionId`, and inline expansion in the feed row. Each unit is independently testable.
+
+### Components
+
+1. **Pure `cronResponse(messages: List<ChatMessage>): String`** — `app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt`. The unit-tested core.
+   - Last message with `role == Role.ASSISTANT && text.isNotBlank()` → its `text.trim()`.
+   - Else the last message that has a tool with non-blank `output` → `"${tool.name}: ${tool.output.trim()}"` truncated to a summary length (`MAX = 500` chars, ellipsis if longer).
+   - Else `"No text output."`.
+
+2. **`ActivityItem.sessionId: String? = null`** — `ActivityModels.kt`. Set to the raw session id in `sessionsToActivity` (`sessionId = s.id`). Left null by `cronsToActivity`. Expansion is offered only when `kind == ActivityKind.CRON && sessionId != null && !upcoming`.
+
+3. **`MissionControlViewModel` — lazy response loader.**
+   - `data class CronResponseUi(val loading: Boolean = false, val text: String? = null, val error: Boolean = false)`.
+   - `private val _responses = MutableStateFlow<Map<String, CronResponseUi>>(emptyMap())`; `val responses: StateFlow<Map<String, CronResponseUi>>` keyed by **sessionId**.
+   - `fun loadResponse(sessionId: String)`: if the map already has a non-loading success/entry for it, return (cache). Else set `loading=true`; `viewModelScope.launch { runCatching { sessions.history(sessionId, profile) }.onSuccess { put(sessionId, CronResponseUi(text = cronResponse(it))) }.onFailure { put(sessionId, CronResponseUi(error = true)) } }`. A retry clears the errored entry and re-calls.
+   - Uses the VM's existing `profile` field; no profile switch needed to *read* history (the REST call takes the profile param), but the "View full chat" navigation reuses the existing `onOpen`/`switchTo` path.
+
+4. **`MissionControlScreen` — inline expansion.**
+   - Expansion state: `val expanded = remember { mutableStateMapOf<String, Boolean>() }` in `MissionControlPage`, keyed by `ActivityItem.id`. Collect `vm.responses` as state.
+   - `ActivityRow` gains: `expandable: Boolean`, `isExpanded: Boolean`, `response: CronResponseUi?`, `onToggle: () -> Unit`, `onOpenFull: () -> Unit`. For an expandable item, the row's `onClick` calls `onToggle` (and on first expand, `vm.loadResponse(sessionId)`); a trailing chevron rotates with state. Non-expandable rows keep `onClick = onOpen(route)`.
+   - Expanded content (below the row): `loading` → a small `CircularProgressIndicator`; `error` → "Couldn't load response" + a "Retry" text button; else the response `text` in a card (selectable, capped height with internal scroll), followed by a **"View full chat"** text button → `onOpen(item.route)`.
+
+### Data flow
+
+```
+tap cron-run row → toggle expanded[item.id]
+   on first expand → vm.loadResponse(sessionId)
+      → sessions.history(sessionId, profile)  [REST]
+      → cronResponse(messages)  [pure]
+      → _responses[sessionId] = CronResponseUi(text=…)   (or error=true)
+   screen renders responses[sessionId]: spinner | error+retry | text
+"View full chat" → onOpen("chat/<id>")  → switchTo(profile) + navigate  (unchanged)
+```
+
+## Error handling
+
+- **History fetch fails:** `CronResponseUi(error = true)` → inline "Couldn't load response" + Retry (clears the entry and re-calls). The feed itself is unaffected.
+- **Empty / non-text run:** the fallback chain yields the tool-result summary or "No text output." — never a blank card.
+- **Rapid expand/collapse:** the response is cached by sessionId, so re-expanding doesn't refetch; an in-flight load isn't re-launched (guard on `loading`).
+- **Profile:** history is read with the VM's `profile` param; opening the full chat still routes through the existing `switchTo` so the chat screen acts on the right per-profile DB.
+
+## Testing
+
+- **Unit (pure), TDD — `CronResponseTest`:** assistant-text case (picks the **last** assistant message when several); tool-only fallback (`"name: output"`, and truncation past `MAX`); empty list → "No text output."; a run whose only assistant messages are blank → falls through to tool/none.
+- **Unit — `MissionControlViewModel` response loader:** `loadResponse` sets `loading` then `text` on success and `error` on failure (mock `SessionRepository.history`); a second `loadResponse` for the same sessionId does **not** refetch (verify one `history` call).
+- **On-device:** in Agent Activity, tap a cron run → response expands inline (spinner → text); "View full chat" opens the transcript; tapping a conversation or an upcoming cron next-run navigates as before; a failing history fetch shows the error + Retry.
+
+## Not doing (YAGNI)
+
+- Expanding **conversation** rows or **upcoming** cron next-runs (cron runs only).
+- Threading the Product/Technical toggle through this view — the response is the assistant's **text**, inherently payload-free; the toggle still governs the full transcript.
+- Pre-fetching responses for the whole feed (lazy on expand only).
+- Streaming/live updates of a running cron's partial output (show the stored final message).
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Exact truncation length for the tool-result fallback (`MAX = 500` proposed) and response card max height before internal scroll.


### PR DESCRIPTION
## Cron response inline (Agent Activity)

Tapping a **cron run** in the Agent Activity feed now expands its **response** — the run's final assistant message — **inline**, so you see what the scheduled job answered without opening the full transcript. A "View full chat" link inside the expanded card still opens the complete session. **No gateway/bridge changes.**

### How it works
- Pure `cronResponse(messages)`: last assistant message with text → else the last tool result summary (`name: output`, truncated) → else "No text output."
- `ActivityItem.sessionId` carries the raw session id for cron-run rows.
- `MissionControlViewModel.loadResponse(sessionId)`: lazy, one `SessionRepository.history()` REST call on expand, cached by sessionId (in-flight/loaded guard; errors retryable).
- `MissionControlScreen`: response-first inline expansion — tap a cron run to toggle; only `kind==CRON && sessionId!=null && !upcoming` expand (conversations + upcoming next-runs navigate as before).

### Verification
- Unit tests: `cronResponse` (6), `ActivityItem.sessionId`, VM loader (3, incl. the no-refetch cache guard). Full suite + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task reviews + an opus final whole-branch review: "ready to merge"; end-to-end chain, expandable gate, per-profile tenant isolation, and lifecycle all verified).
- On-device (emulator): tapping the acme "Nightly summary" cron run expands to its incident-summary response (not the transcript) with "View full chat"; upcoming next-runs + conversations show no chevron.

Spec/plan: `docs/superpowers/specs/2026-07-04-cron-response-inline-design.md`, `docs/superpowers/plans/2026-07-04-cron-response-inline.md` (Piece 1 of `docs/ideas/activity-home-and-cron-response.md`).
