### PR TITLE
Home landing: open to Home tab (2a) + pager crash fix

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -133,9 +133,9 @@ fun MissionControlScreen(
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.padding(padding).fillMaxSize(),
-                key = { names[it] ?: "_$it" },
+                key = { names.getOrNull(it) ?: "_$it" },
             ) { page ->
-                MissionControlPage(profile = names[page], dark = dark, onNavigate = onNavigate)
+                MissionControlPage(profile = names.getOrNull(page), dark = dark, onNavigate = onNavigate)
             }
         }
     }

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Chat
-import androidx.compose.material.icons.rounded.Bolt
+import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -45,8 +45,8 @@ import com.hermes.client.ui.usage.UsageScreen
 private data class Tab(val route: String, val label: String, val icon: ImageVector)
 
 private val TABS = listOf(
+    Tab("activity", "Home", Icons.Rounded.Home),
     Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
-    Tab("activity", "Agent Activity", Icons.Rounded.Bolt),
     Tab("you", "You", Icons.Rounded.Person),
 )
 
@@ -68,7 +68,7 @@ private val TABS = listOf(
 @Composable
 fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsumed: () -> Unit = {}) {
     val nav = rememberNavController()
-    val start = if (hasConfig) "sessions" else "setup"
+    val start = if (hasConfig) "activity" else "setup"
 
     LaunchedEffect(deepLinkRoute) { deepLinkRoute?.let { nav.navigate(it); onDeepLinkConsumed() } }
 
@@ -123,7 +123,7 @@ fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsu
             composable("setup") {
                 SetupScreen(
                     onSaved = {
-                        nav.navigate("sessions") { popUpTo("setup") { inclusive = true } }
+                        nav.navigate("activity") { popUpTo("setup") { inclusive = true } }
                     },
                 )
             }

--- a/docs/superpowers/plans/2026-07-04-home-landing.md
+++ b/docs/superpowers/plans/2026-07-04-home-landing.md
@@ -1,0 +1,132 @@
+# Home Landing (2a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The app opens to the Home tab (Mission Control activity feed) instead of the Sessions list, with the bottom nav leading with Home.
+
+**Architecture:** A navigation-config change entirely in `HermesNav.kt` — reorder/relabel the `TABS` list, flip the start destination to `"activity"`, and point the post-setup jump at `"activity"`. The `"activity"` route id is unchanged (only its visible label changes).
+
+**Tech Stack:** Kotlin, Jetpack Compose, Navigation Compose.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Pure navigation config.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Full suite: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Do **not** touch `MissionControlScreen`, the deep-link rail, `SessionsScreen`, or any repository. Keep the `"activity"` route id.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## File Structure
+
+- Modify `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt` — `TABS`, `start`, post-setup nav, imports.
+
+---
+
+### Task 1: Home landing nav change
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt`
+
+**Interfaces:** none exported (internal nav config).
+
+- [ ] **Step 1: Reorder + relabel `TABS`**
+
+Replace the existing `TABS` list:
+
+```kotlin
+private val TABS = listOf(
+    Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
+    Tab("activity", "Agent Activity", Icons.Rounded.Bolt),
+    Tab("you", "You", Icons.Rounded.Person),
+)
+```
+
+with (Home first, relabeled, Home icon):
+
+```kotlin
+private val TABS = listOf(
+    Tab("activity", "Home", Icons.Rounded.Home),
+    Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
+    Tab("you", "You", Icons.Rounded.Person),
+)
+```
+
+- [ ] **Step 2: Fix icon imports**
+
+Add `import androidx.compose.material.icons.rounded.Home`. If `Icons.Rounded.Bolt` is now unused elsewhere in the file, remove `import androidx.compose.material.icons.rounded.Bolt` (verify with a search before removing).
+
+- [ ] **Step 3: Flip the start destination**
+
+Change:
+
+```kotlin
+val start = if (hasConfig) "sessions" else "setup"
+```
+
+to:
+
+```kotlin
+val start = if (hasConfig) "activity" else "setup"
+```
+
+- [ ] **Step 4: Point the post-setup jump at Home**
+
+Change (around line 126):
+
+```kotlin
+                        nav.navigate("sessions") { popUpTo("setup") { inclusive = true } }
+```
+
+to:
+
+```kotlin
+                        nav.navigate("activity") { popUpTo("setup") { inclusive = true } }
+```
+
+- [ ] **Step 5: Compile + full unit suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`. (No tests change; this confirms nothing regressed and the icon import resolves.)
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+git commit -m "feat(nav): land on Home tab; bottom nav leads with Home"
+```
+
+---
+
+### Task 2: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Use a build already configured with a gateway (or complete setup against the mock at `http://10.0.2.2:8899`).
+
+- [ ] **Step 2: Verify**
+
+- **Cold launch (configured):** the app opens on **Home** — the Mission Control activity feed (LIVE NOW / UPCOMING / RECENT) — not the Sessions list. The bottom nav reads **Home · Chats · You** with **Home** selected.
+- **Chats tab:** tapping Chats shows the Sessions list; its **New** button still creates + opens a session.
+- **Notification deep-link:** launching from a notification (or `adb shell am start ... --es extra_route "chat/<id>"`) still opens that session, not Home.
+- **Fresh setup:** clear data, complete setup → lands on **Home** (not Sessions).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(nav): home-landing verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** `TABS` reorder + relabel + Home icon (Task 1 Steps 1–2) ✓; `start = "activity"` (Step 3) ✓; post-setup jump → `"activity"` (Step 4) ✓; route id `"activity"` kept (only label changes) ✓; no touch to MissionControlScreen/deep-link/SessionsScreen/repos ✓; on-device incl. notification deep-link + fresh-setup + Chats/New regression (Task 2) ✓; no bridge changes ✓; "Needs you"/approvals/messaging excluded ✓.
+- **Placeholder scan:** every code step shows the exact before/after; the only conditional is the "remove Bolt import if now unused" (guarded by a search) and the Task 2 verification-only commit.
+- **Type consistency:** `Tab(route, label, icon)`, the `"activity"`/`"sessions"`/`"you"` route ids, and `Icons.Rounded.Home` are consistent with the existing `HermesNav` structure.
+
+**Ordering note:** Task 1 is the whole change (one file, compiles + suite green). Task 2 verifies on-device.

--- a/docs/superpowers/specs/2026-07-04-home-landing-design.md
+++ b/docs/superpowers/specs/2026-07-04-home-landing-design.md
@@ -1,0 +1,76 @@
+# Home Landing (2a) — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/home-landing`
+**Parent idea:** `docs/ideas/activity-home-and-cron-response.md` (Piece 2, sub-piece 2a — ship first)
+
+## Goal
+
+Open the app to the **Home** tab (today's Mission Control activity feed) instead of the Sessions list, and lead the bottom nav with Home — so a cold launch lands on *what's happening*, never a resumed stale surface. The "Needs you" strip is a later sub-piece (2b).
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Pure navigation-config change.
+- Follow existing patterns (the `HermesNav` `TABS` list + `NavHost`).
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `HermesNav.kt`: `private data class Tab(route, label, icon)`; `TABS = [Tab("sessions","Chats",Chat), Tab("activity","Agent Activity",Bolt), Tab("you","You",Person)]`; `val start = if (hasConfig) "sessions" else "setup"`; a bottom `NavigationBar` rendering `TABS`; `composable("activity") { MissionControlScreen(...) }`.
+- Post-setup jump (line ~126): `nav.navigate("sessions") { popUpTo("setup") { inclusive = true } }`.
+- Notification deep-link: `MainActivity` reads `extra_route` → `pendingRoute` → `HermesNav`'s `LaunchedEffect(deepLinkRoute) { nav.navigate(it) }` — navigates **on top of** the start destination.
+- The "New" FAB (`SessionsScreen`) uses `vm.createSession()`, already scoped to the active/selected profile — decision (f) ("New chat → last-used profile") needs no change and is out of scope here.
+
+## Architecture / changes (all in `HermesNav.kt`)
+
+1. **Reorder + relabel `TABS`** to lead with Home:
+   ```kotlin
+   private val TABS = listOf(
+       Tab("activity", "Home", Icons.Rounded.Home),
+       Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
+       Tab("you", "You", Icons.Rounded.Person),
+   )
+   ```
+   (Relabel `"Agent Activity"` → `"Home"`; swap the tab's `Icons.Rounded.Bolt` for `Icons.Rounded.Home`. Add the `Home` icon import.)
+
+2. **Start destination** → land on Home when configured:
+   ```kotlin
+   val start = if (hasConfig) "activity" else "setup"
+   ```
+
+3. **Post-setup nav** → also land on Home after fresh setup:
+   ```kotlin
+   nav.navigate("activity") { popUpTo("setup") { inclusive = true } }
+   ```
+
+No change to the `MissionControlScreen` composable, the deep-link rail, `SessionsScreen`, or any repository.
+
+## Data flow
+
+```
+cold launch (configured) → start = "activity" → Home (Mission Control feed)
+notification tap → extra_route="chat/<id>" → pendingRoute → navigate on top → the session (unchanged)
+setup complete → navigate("activity") → Home
+bottom nav order → Home · Chats · You  (Home selected at launch)
+```
+
+## Error handling
+
+- Not configured → `start = "setup"` (unchanged).
+- The `MissionControlScreen` already handles its own loading/empty/error states for the feed; landing there adds no new failure mode.
+
+## Testing
+
+Navigation-config change with no new pure logic. Verified **on-device**:
+- Cold launch (configured) lands on **Home** (the activity feed), with the bottom nav reading **Home · Chats · You** and **Home** selected.
+- A notification tap still opens its `chat/<id>` (deep-link on top of Home).
+- **Chats** tab still shows the Sessions list; its **New** FAB still creates + opens a session.
+- Fresh setup completes onto **Home** (not the Sessions list).
+
+## Not doing (YAGNI)
+
+- The "Needs you" strip (sub-piece 2b).
+- Approvals / messaging-pairing data, or any new endpoint.
+- Any change to the "New" FAB / new-chat profile logic (existing behavior already satisfies decision (f)).
+- Renaming the `"activity"` route id (only the visible label changes; keeping the route id avoids churn in the deep-link/nav wiring).


### PR DESCRIPTION
## Home landing (2a)

The app now opens to the **Home** tab (the Mission Control activity feed) instead of the Sessions list, and the bottom nav leads with Home — so a cold launch lands on *what's happening*, not a resumed session list. **No gateway/bridge changes.**

### Changes (`HermesNav.kt`)
- Reorder + relabel the bottom-nav tabs to **Home · Chats · You** (`"Agent Activity"` → **"Home"**, Home icon).
- `start = if (hasConfig) "activity" else "setup"`; the post-setup jump also lands on Home.
- The `"activity"` route id is unchanged (only the visible label); notification deep-links, Sessions, and the New FAB are untouched.

### Launch-crash fix (found by on-device verification)
Making MissionControl the *start* destination mounts it *during* the async profile-list load, which exposed a latent crash: the profile pager indexed `names[page]` / `names[it]` directly, throwing `IndexOutOfBoundsException` on a size-1 list (this bug shipped in 0.1.28 but only reliably triggers at cold start). Hardened both to `names.getOrNull(...)` — the transient null renders the default page until the `LaunchedEffect` scrolls to the active profile.

### Verification
- Full unit suite + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task review clean).
- On-device (emulator vs mock): fresh setup lands on **Home** with no crash; bottom nav reads **Home · Chats · You**; a cold launch with `extra_route=chat/<id>` opens that chat (deep-link bypasses Home).

### Scope
This is sub-piece **2a** of `docs/ideas/activity-home-and-cron-response.md`. The **"Needs you" strip (2b)** is a separate follow-up. Noted minor: the Home screen's top-bar title still reads "Agent Activity" (out of 2a's `HermesNav`-only scope).

Spec/plan: `docs/superpowers/specs/2026-07-04-home-landing-design.md`, `docs/superpowers/plans/2026-07-04-home-landing.md`.
