### PR TITLE
Home: 'Needs you' strip (failed/overdue cron) + header rename

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -116,7 +116,7 @@ fun MissionControlScreen(
         Scaffold(
             topBar = {
                 Column {
-                    HermesTopBar(title = "Agent Activity", subtitle = currentProfile?.let { "Profile: $it" })
+                    HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })
                     if (names.size > 1) {
                         com.hermes.client.ui.components.ProfileChips(
                             names = names.filterNotNull(),
@@ -212,6 +212,12 @@ private fun MissionControlContent(
                 }
             }
         }
+        if (state.needsYou.isNotEmpty()) {
+            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size) }
+            items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+                NeedsYouRow(alert, onClick = { onOpen(alert.route) })
+            }
+        }
         when {
             state.loading && state.sections.isEmpty() -> item { LoadingState() }
             state.error != null -> item { ErrorState(message = state.error!!, onRetry = onRetry) }
@@ -257,6 +263,25 @@ private fun SectionHeader(label: String, count: Int) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+@Composable
+private fun NeedsYouRow(alert: CronAlert, onClick: () -> Unit) {
+    ListItem(
+        leadingContent = {
+            Icon(Icons.Rounded.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+        },
+        headlineContent = { Text(alert.name) },
+        supportingContent = {
+            Text(
+                when (alert.reason) {
+                    CronAlertReason.FAILED -> "Last run failed"
+                    CronAlertReason.OVERDUE -> "Overdue"
+                },
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -18,6 +18,7 @@ data class MissionControlState(
     val loading: Boolean = false,
     val error: String? = null,
     val unauthorized: Boolean = false,
+    val needsYou: List<CronAlert> = emptyList(),
 )
 
 /**
@@ -61,8 +62,12 @@ class MissionControlViewModel @Inject constructor(
             val scoped = if (profile.isNullOrBlank()) all else all.filter { it.profile == profile }
             // A cron failure (e.g. profile without cron) must not blank the whole feed.
             val crons = runCatching { tools.cronJobs(profile) }.getOrDefault(emptyList())
+            val now = System.currentTimeMillis()
             val items = sessionsToActivity(scoped) + cronsToActivity(crons)
-            _state.value = MissionControlState(sections = groupActivity(items, System.currentTimeMillis()))
+            _state.value = MissionControlState(
+                sections = groupActivity(items, now),
+                needsYou = needsAttention(crons, now),
+            )
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = MissionControlState(unauthorized = true)
             else _state.value = MissionControlState(error = e.message ?: "Failed to load")

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -63,10 +63,12 @@ class MissionControlViewModel @Inject constructor(
             // A cron failure (e.g. profile without cron) must not blank the whole feed.
             val crons = runCatching { tools.cronJobs(profile) }.getOrDefault(emptyList())
             val now = System.currentTimeMillis()
-            val items = sessionsToActivity(scoped) + cronsToActivity(crons)
+            val alerts = needsAttention(crons, now)
+            val alertIds = alerts.mapTo(mutableSetOf()) { it.jobId }
+            val items = sessionsToActivity(scoped) + cronsToActivity(crons.filterNot { it.id in alertIds })
             _state.value = MissionControlState(
                 sections = groupActivity(items, now),
-                needsYou = needsAttention(crons, now),
+                needsYou = alerts,
             )
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = MissionControlState(unauthorized = true)

--- a/app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt
@@ -1,0 +1,40 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.util.isoToEpochMs
+
+enum class CronAlertReason { FAILED, OVERDUE }
+
+data class CronAlert(
+    val jobId: String,
+    val name: String,
+    val reason: CronAlertReason,
+    val route: String,
+)
+
+/** Default grace before an un-run scheduled job counts as overdue. */
+const val NEEDS_YOU_GRACE_MS = 5 * 60_000L
+
+/**
+ * Cron jobs needing attention. FAILED (last run errored) takes priority — a broken job matters even
+ * if paused/disabled. Else OVERDUE: an enabled, non-paused job whose next run is more than [graceMs]
+ * past due. Pure — [nowMs] passed in so it unit-tests without a clock.
+ */
+fun needsAttention(
+    crons: List<CronJobDto>,
+    nowMs: Long,
+    graceMs: Long = NEEDS_YOU_GRACE_MS,
+): List<CronAlert> = crons.mapNotNull { job ->
+    val name = job.name?.ifBlank { null } ?: job.id
+    val route = "cron_detail/${job.id}"
+    val failed = job.lastStatus.equals("error", ignoreCase = true) ||
+        job.lastStatus.equals("failed", ignoreCase = true)
+    when {
+        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route)
+        job.enabled && !job.isPaused -> {
+            val next = isoToEpochMs(job.nextRunAt)
+            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route) else null
+        }
+        else -> null
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
@@ -1,0 +1,60 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", name: String? = null, enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, name = name, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class NeedsYouTest {
+    @Test fun failed_status_makes_a_FAILED_alert() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "error")), NOW).single().reason)
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "failed")), NOW).single().reason)
+    }
+
+    @Test fun healthy_success_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000))), NOW).isEmpty())
+    }
+
+    @Test fun enabled_past_due_beyond_grace_is_OVERDUE() {
+        assertEquals(CronAlertReason.OVERDUE, needsAttention(listOf(job(nextRunAt = iso(NOW - 10 * 60_000))), NOW).single().reason)
+    }
+
+    @Test fun future_next_run_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW + 60 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun within_grace_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW - 2 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_or_disabled_not_failed_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(enabled = false, nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+        assertTrue(needsAttention(listOf(job(state = "paused", nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_but_failed_still_shows_FAILED() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(state = "paused", lastStatus = "error")), NOW).single().reason)
+    }
+
+    @Test fun failed_and_past_due_is_a_single_FAILED() {
+        val alerts = needsAttention(listOf(job(lastStatus = "error", nextRunAt = iso(NOW - 10 * 60_000))), NOW)
+        assertEquals(1, alerts.size)
+        assertEquals(CronAlertReason.FAILED, alerts.single().reason)
+    }
+
+    @Test fun name_falls_back_to_id_and_route_is_cron_detail() {
+        val a = needsAttention(listOf(job(id = "abc", name = "  ", lastStatus = "error")), NOW).single()
+        assertEquals("abc", a.name)
+        assertEquals("cron_detail/abc", a.route)
+    }
+}

--- a/docs/superpowers/plans/2026-07-04-needs-you.md
+++ b/docs/superpowers/plans/2026-07-04-needs-you.md
@@ -1,0 +1,332 @@
+# "Needs you" strip (2b) + Home header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a "Needs you" strip (failed/overdue cron) atop the per-profile Home feed, and rename the Home header from "Agent Activity" to "Home".
+
+**Architecture:** A pure `needsAttention(crons, now)` deriver → `MissionControlState.needsYou` (computed from the cron list `loadInner` already fetches) → a top section in `MissionControlContent`; plus a one-line header rename. No gateway/bridge changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, MVVM + StateFlow, JUnit.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Reuse `ToolsRepository.cronJobs(profile)` (already called in `loadInner`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Follow patterns: pure unit tests like `CronResponseTest`/`ActivityModelsTest`; Material3 `ListItem` rows; the existing `SectionHeader`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+- "Needs you" is **cron-only**, **per-profile**; FAILED takes priority over OVERDUE.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt` — `CronAlertReason`, `CronAlert`, `needsAttention`.
+- Create `app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt` — `MissionControlState.needsYou` + compute in `loadInner`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt` — top "Needs you" section + `NeedsYouRow` + header rename.
+
+---
+
+### Task 1: Pure `needsAttention` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt`
+
+**Interfaces:**
+- Produces: `enum class CronAlertReason { FAILED, OVERDUE }`; `data class CronAlert(jobId, name, reason, route)`; `const val NEEDS_YOU_GRACE_MS`; `fun needsAttention(crons: List<CronJobDto>, nowMs: Long, graceMs: Long = NEEDS_YOU_GRACE_MS): List<CronAlert>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", name: String? = null, enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, name = name, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class NeedsYouTest {
+    @Test fun failed_status_makes_a_FAILED_alert() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "error")), NOW).single().reason)
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "failed")), NOW).single().reason)
+    }
+
+    @Test fun healthy_success_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000))), NOW).isEmpty())
+    }
+
+    @Test fun enabled_past_due_beyond_grace_is_OVERDUE() {
+        assertEquals(CronAlertReason.OVERDUE, needsAttention(listOf(job(nextRunAt = iso(NOW - 10 * 60_000))), NOW).single().reason)
+    }
+
+    @Test fun future_next_run_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW + 60 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun within_grace_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW - 2 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_or_disabled_not_failed_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(enabled = false, nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+        assertTrue(needsAttention(listOf(job(state = "paused", nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_but_failed_still_shows_FAILED() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(state = "paused", lastStatus = "error")), NOW).single().reason)
+    }
+
+    @Test fun failed_and_past_due_is_a_single_FAILED() {
+        val alerts = needsAttention(listOf(job(lastStatus = "error", nextRunAt = iso(NOW - 10 * 60_000))), NOW)
+        assertEquals(1, alerts.size)
+        assertEquals(CronAlertReason.FAILED, alerts.single().reason)
+    }
+
+    @Test fun name_falls_back_to_id_and_route_is_cron_detail() {
+        val a = needsAttention(listOf(job(id = "abc", name = "  ", lastStatus = "error")), NOW).single()
+        assertEquals("abc", a.name)
+        assertEquals("cron_detail/abc", a.route)
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NeedsYouTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `needsAttention`/`CronAlert`/`CronAlertReason`.
+
+- [ ] **Step 3: Implement `NeedsYou.kt`**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.util.isoToEpochMs
+
+enum class CronAlertReason { FAILED, OVERDUE }
+
+data class CronAlert(
+    val jobId: String,
+    val name: String,
+    val reason: CronAlertReason,
+    val route: String,
+)
+
+/** Default grace before an un-run scheduled job counts as overdue. */
+const val NEEDS_YOU_GRACE_MS = 5 * 60_000L
+
+/**
+ * Cron jobs needing attention. FAILED (last run errored) takes priority — a broken job matters even
+ * if paused/disabled. Else OVERDUE: an enabled, non-paused job whose next run is more than [graceMs]
+ * past due. Pure — [nowMs] passed in so it unit-tests without a clock.
+ */
+fun needsAttention(
+    crons: List<CronJobDto>,
+    nowMs: Long,
+    graceMs: Long = NEEDS_YOU_GRACE_MS,
+): List<CronAlert> = crons.mapNotNull { job ->
+    val name = job.name?.ifBlank { null } ?: job.id
+    val route = "cron_detail/${job.id}"
+    val failed = job.lastStatus.equals("error", ignoreCase = true) ||
+        job.lastStatus.equals("failed", ignoreCase = true)
+    when {
+        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route)
+        job.enabled && !job.isPaused -> {
+            val next = isoToEpochMs(job.nextRunAt)
+            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route) else null
+        }
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NeedsYouTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
+git commit -m "feat(activity): pure needsAttention (failed/overdue cron) with tests"
+```
+
+---
+
+### Task 2: Surface `needsYou` on the ViewModel state
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt`
+
+**Interfaces:**
+- Consumes: `needsAttention` / `CronAlert` (Task 1).
+- Produces: `MissionControlState.needsYou: List<CronAlert>`.
+
+- [ ] **Step 1: Add `needsYou` to `MissionControlState`**
+
+```kotlin
+data class MissionControlState(
+    val sections: List<ActivitySection> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val unauthorized: Boolean = false,
+    val needsYou: List<CronAlert> = emptyList(),
+)
+```
+
+- [ ] **Step 2: Compute it in `loadInner`'s success branch**
+
+In `loadInner`, the success path currently reads:
+
+```kotlin
+            val items = sessionsToActivity(scoped) + cronsToActivity(crons)
+            _state.value = MissionControlState(sections = groupActivity(items, System.currentTimeMillis()))
+```
+
+Replace with (compute `now` once; derive `needsYou` from the already-fetched `crons`):
+
+```kotlin
+            val now = System.currentTimeMillis()
+            val items = sessionsToActivity(scoped) + cronsToActivity(crons)
+            _state.value = MissionControlState(
+                sections = groupActivity(items, now),
+                needsYou = needsAttention(crons, now),
+            )
+```
+
+Leave the `catch (HermesApiException)` / `catch (Exception)` branches unchanged (they build a `MissionControlState` without `needsYou`, so it defaults to empty).
+
+- [ ] **Step 3: Compile + full unit suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+git commit -m "feat(activity): expose needsYou cron alerts on MissionControl state"
+```
+
+---
+
+### Task 3: Render the "Needs you" section + rename header
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+**Interfaces:**
+- Consumes: `MissionControlState.needsYou` (Task 2); `CronAlert`/`CronAlertReason` (Task 1); existing `SectionHeader`, `onOpen`.
+
+- [ ] **Step 1: Rename the header**
+
+Change (line ~119):
+
+```kotlin
+                    HermesTopBar(title = "Agent Activity", subtitle = currentProfile?.let { "Profile: $it" })
+```
+
+to:
+
+```kotlin
+                    HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })
+```
+
+- [ ] **Step 2: Add the "Needs you" section to `MissionControlContent`**
+
+In `MissionControlContent`'s `LazyColumn`, immediately **after** the `item(key = "quicklinks") { … }` block and **before** the `when { … }`, add:
+
+```kotlin
+        if (state.needsYou.isNotEmpty()) {
+            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size) }
+            items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+                NeedsYouRow(alert, onClick = { onOpen(alert.route) })
+            }
+        }
+```
+
+- [ ] **Step 3: Add the `NeedsYouRow` composable**
+
+Add near `ActivityRow`:
+
+```kotlin
+@Composable
+private fun NeedsYouRow(alert: CronAlert, onClick: () -> Unit) {
+    ListItem(
+        leadingContent = {
+            Icon(Icons.Rounded.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+        },
+        headlineContent = { Text(alert.name) },
+        supportingContent = {
+            Text(
+                when (alert.reason) {
+                    CronAlertReason.FAILED -> "Last run failed"
+                    CronAlertReason.OVERDUE -> "Overdue"
+                },
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
+```
+
+`Icons.Rounded.ErrorOutline`, `ListItem`, `Icon`, `Text`, `MaterialTheme`, `Modifier.clickable` are already imported/used by `ActivityRow` in this file — add any that the compiler reports missing.
+
+- [ ] **Step 4: Compile + full unit suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(activity): Needs-you strip on Home; rename header to Home"
+```
+
+---
+
+### Task 4: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point it at a gateway with a **failed** cron job (`last_status` = error) or an **overdue** one (enabled, `next_run_at` in the past). The mock at `http://10.0.2.2:8899` can be given such a job.
+
+- [ ] **Step 2: Verify**
+
+- Home header reads **"Home"** (not "Agent Activity").
+- A profile with a failed/overdue cron shows a red **"Needs you"** section at the **top** of the feed; each row shows the job name + "Last run failed"/"Overdue"; tapping opens **cron detail**.
+- A profile with only healthy cron shows **no** "Needs you" section.
+- Background the app + resume → the strip refreshes (via the existing `ON_RESUME` reload).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(activity): needs-you verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure `needsAttention` — FAILED (error/failed, priority, even paused/disabled), OVERDUE (enabled + !paused + past-grace), name fallback, route, `graceMs=5min`, unit-tested (Task 1) ✓; `MissionControlState.needsYou` computed from the fetched `crons` on the success branch, empty on error/unauthorized (Task 2) ✓; top "Needs you" section (only when non-empty) with `SectionHeader` + `NeedsYouRow` (error-tinted, name, reason text, tap → cron_detail) (Task 3) ✓; header rename → "Home" (Task 3 Step 1) ✓; auto-refresh via existing `ON_RESUME` (unchanged) ✓; on-device incl. healthy-profile-no-strip + resume (Task 4) ✓; cron-only/per-profile, no new endpoint ✓.
+- **Placeholder scan:** every code step has full before/after; the only conditional is the Task 4 verification-only commit and "add any imports the compiler reports missing."
+- **Type consistency:** `needsAttention(crons, nowMs, graceMs)`, `CronAlert(jobId, name, reason, route)`, `CronAlertReason.{FAILED,OVERDUE}`, `MissionControlState.needsYou`, and `NeedsYouRow(alert, onClick)` are consistent across Tasks 1–3. `CronJobDto(id, name, enabled, state, pausedAt, nextRunAt, lastStatus)` + `isPaused` + `isoToEpochMs` match the app.
+
+**Ordering note:** Task 1 (pure) stands alone. Task 2 depends on Task 1. Task 3 depends on Tasks 1 + 2. Task 4 verifies on-device.

--- a/docs/superpowers/specs/2026-07-04-needs-you-design.md
+++ b/docs/superpowers/specs/2026-07-04-needs-you-design.md
@@ -1,0 +1,95 @@
+# "Needs you" strip (2b) + Home header — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/needs-you`
+**Parent idea:** `docs/ideas/activity-home-and-cron-response.md` (Piece 2, sub-piece 2b)
+
+## Goal
+
+Add a compact **"Needs you"** strip to the top of the Home (Mission Control) feed that surfaces cron jobs needing attention — **failed** or **overdue** — for the current profile, and rename the Home screen's header from "Agent Activity" to **"Home"**. **No gateway/bridge changes** (reuses the cron list the feed already fetches).
+
+## Decided
+
+- "Needs you" flags **failed + overdue** cron (per the user): failed = last run errored; overdue = an enabled, non-paused job whose next run is >5 min past due.
+- **Cron-only** (messaging `/api/pairing` isn't wired in the app; approvals are WS-only) — established in the idea doc.
+- **Per-profile** (matches the existing per-profile feed pager).
+- Auto-refresh on resume is **already provided** by the feed's `LifecycleEventEffect(ON_RESUME) { vm.refresh() }`.
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Reuse `ToolsRepository.cronJobs(profile)` (already called in `loadInner`).
+- Follow existing patterns: pure unit-tested logic (like `cronsToActivity`), `MissionControlState`, Material3 rows.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `MissionControlViewModel.loadInner`: fetches `val crons = runCatching { tools.cronJobs(profile) }.getOrDefault(emptyList())`, builds `sessionsToActivity(scoped) + cronsToActivity(crons)`, then `_state.value = MissionControlState(sections = groupActivity(items, now))`.
+- `MissionControlState(sections, loading, error, unauthorized)`.
+- `CronJobDto(id, name, enabled, state, pausedAt, nextRunAt, lastRunAt, lastStatus, lastError, …)`; computed `val isPaused = pausedAt != null || state == "paused"`; `val scheduleText`.
+- `isoToEpochMs(iso: String?): Long?` (`com.hermes.client.ui.util`).
+- `MissionControlScreen`: per-profile pager; top bar `HermesTopBar(title = "Agent Activity", subtitle = currentProfile?.let { "Profile: $it" })` (line ~119); `MissionControlContent` renders a `LazyColumn` (quicklinks item, then sections); `onOpen(route)` awaits `switchTo(profile)` + `onNavigate(route)`.
+- `cron_detail/<id>` is a registered route.
+
+## Architecture
+
+Add a pure alert-deriver, surface its result on the VM state, render a top section on the feed, and rename the header. Each unit is small + independently testable.
+
+### Components
+
+1. **Pure `needsAttention(crons: List<CronJobDto>, nowMs: Long, graceMs: Long = 5 * 60_000L): List<CronAlert>`** — `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt`. The unit-tested core.
+   - `enum class CronAlertReason { FAILED, OVERDUE }`.
+   - `data class CronAlert(val jobId: String, val name: String, val reason: CronAlertReason, val route: String)`.
+   - For each job:
+     - **FAILED** if `lastStatus.equals("error", true) || lastStatus.equals("failed", true)`.
+     - else **OVERDUE** if `enabled && !isPaused && nextRunAt != null && isoToEpochMs(nextRunAt)` is non-null and `< nowMs - graceMs`.
+     - else no alert.
+   - Failed takes priority (a job is at most one alert). Skip paused/disabled jobs for OVERDUE (but a **disabled/paused** job that *failed* still shows FAILED — a broken job matters regardless of whether it's scheduled again; matches "last run errored").
+   - `name = job.name?.ifBlank { null } ?: job.id` (same as `cronsToActivity`); `route = "cron_detail/${job.id}"`.
+
+2. **`MissionControlState.needsYou: List<CronAlert> = emptyList()`** — computed in `loadInner`:
+   `_state.value = MissionControlState(sections = groupActivity(items, now), needsYou = needsAttention(crons, now))`. (The error/unauthorized branches leave `needsYou` empty, as today.)
+
+3. **`MissionControlContent` — "Needs you" section** at the top of the `LazyColumn`, **after** the quicklinks item and **before** the `when { … sections … }`, rendered only when `state.needsYou.isNotEmpty()`:
+   - A `SectionHeader("Needs you", state.needsYou.size)` (reuse the existing header composable).
+   - `items(state.needsYou, key = { "needs-${it.jobId}" }) { alert -> NeedsYouRow(alert, onClick = { onOpen(alert.route) }) }`.
+   - **`NeedsYouRow`:** a Material3 `ListItem` — leading `Icons.Rounded.ErrorOutline` tinted `colorScheme.error`; headline `alert.name`; supporting `when (alert.reason) { FAILED -> "Last run failed"; OVERDUE -> "Overdue" }`; `Modifier.clickable(onClick)`.
+
+4. **Header rename** — `HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })`.
+
+### Data flow
+
+```
+feed load / ON_RESUME refresh → loadInner → tools.cronJobs(profile)
+  → needsAttention(crons, now) → MissionControlState.needsYou
+  → MissionControlContent renders "Needs you" section on top (when non-empty)
+  → tap an alert → onOpen("cron_detail/<id>") → switchTo(profile) + navigate  (existing)
+top bar → "Home"
+```
+
+## Error handling
+
+- A cron fetch failure already degrades gracefully (`getOrDefault(emptyList())`) → `needsAttention([]) = []` → no strip; the conversation feed still renders.
+- `isoToEpochMs` returns null for unparseable/absent `nextRunAt` → that job is simply not OVERDUE.
+- The feed's own loading/error/empty states are unchanged; the strip is additive.
+
+## Testing
+
+- **Unit (pure), TDD — `NeedsYouTest`:**
+  - failed (`lastStatus="error"` and `"failed"`) → FAILED alert; healthy (`"success"`) → none.
+  - overdue: enabled, not paused, `nextRunAt` 10 min in the past → OVERDUE; `nextRunAt` in the future → none; within grace (2 min past) → none.
+  - paused/disabled job that is NOT failed → no alert (not OVERDUE); paused/disabled job that **failed** → FAILED.
+  - failed **and** past-due → a single FAILED alert (priority), not two.
+  - `name` falls back to `jobId` when name blank/null; `route == "cron_detail/<id>"`.
+- **On-device:** a profile with a failed cron shows a red "Needs you" strip at the top; tapping it opens the job detail; a healthy profile shows no strip; the header reads **"Home"**; backgrounding + resuming refreshes the strip.
+
+## Not doing (YAGNI)
+
+- Messaging-pairing or approvals in "Needs you" (unavailable; see idea doc).
+- A cross-profile aggregated strip (stays per-profile with the pager).
+- Dismiss/snooze/ack of alerts, or a badge on the Home tab.
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Grace window for OVERDUE (`5 min` proposed) — a pure `graceMs` param, trivially tunable.


### PR DESCRIPTION
## "Needs you" strip (2b) + Home header

Adds a compact **"Needs you"** section pinned to the top of the Home (Mission Control) feed, surfacing cron jobs that need attention for the current profile — **FAILED** (last run errored) or **OVERDUE** (an enabled, non-paused job whose next run is >5 min past due). Also renames the Home header from "Agent Activity" to **"Home"**. **No gateway/bridge changes** — reuses the cron list the feed already fetches and the existing `ON_RESUME` refresh.

### How it works
- Pure `needsAttention(crons, now, grace=5m): List<CronAlert>` — FAILED takes priority (shown even if paused/disabled); else OVERDUE. Unit-tested.
- `MissionControlState.needsYou` computed in `loadInner` from the already-fetched cron list.
- A top LazyColumn section (only when non-empty): `SectionHeader("Needs you", n)` + `NeedsYouRow`s (red ⚠️, job name, "Last run failed"/"Overdue"), tap → `cron_detail/<id>`.
- **Dedup:** jobs in "Needs you" are excluded from the feed's cron rows, so an overdue/failed job doesn't also appear under "Upcoming".

### Scope
Cron-only, per-profile (matches the pager). Messaging (`/api/pairing` not wired) and approvals (WS-only) are deliberately out — see `docs/ideas/activity-home-and-cron-response.md`.

### Verification
- Unit tests: `needsAttention` (9 cases — failed/overdue/grace/priority/paused/name/route). Full suite + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task reviews + an opus final whole-branch review: "ready to merge"; the double-listing finding was fixed via dedup).
- On-device (emulator vs mock): header reads **"Home"**; a failed + an overdue cron show in "Needs you" (red icons, correct reasons) at the top and are NOT double-listed in "Upcoming"; healthy profiles show no strip.

This is sub-piece **2b** of the Home roadmap. Spec/plan: `docs/superpowers/specs/2026-07-04-needs-you-design.md`, `docs/superpowers/plans/2026-07-04-needs-you.md`.
