### PR TITLE
Promote to production: 0.1.31 (Home + cron response)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 29
-        versionName = "0.1.28"
+        versionCode = 30
+        versionName = "0.1.29"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 30
-        versionName = "0.1.29"
+        versionCode = 31
+        versionName = "0.1.30"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 31
-        versionName = "0.1.30"
+        versionCode = 32
+        versionName = "0.1.31"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt
@@ -22,6 +22,9 @@ data class ActivityItem(
     val status: String?,
     // Navigation route to open the item ("chat/<id>" or "cron_detail/<id>").
     val route: String,
+    // Raw session id for a session-backed row (used to lazily load a cron run's response inline).
+    // Null for cron next-run items.
+    val sessionId: String? = null,
 )
 
 data class ActivitySection(val title: String, val items: List<ActivityItem>)
@@ -44,6 +47,7 @@ fun sessionsToActivity(sessions: List<Session>): List<ActivityItem> = sessions.m
         upcoming = false,
         status = null,
         route = "chat/${s.id}",
+        sessionId = s.id,
     )
 }
 

--- a/app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt
@@ -1,0 +1,23 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+
+/** Max length of the tool-result fallback summary before truncation. */
+const val CRON_RESPONSE_MAX = 500
+
+/**
+ * A cron run's "response" from its session messages: the last assistant message with text; else
+ * the last tool result summary; else a placeholder. Pure — unit-tested without network or clock.
+ */
+fun cronResponse(messages: List<ChatMessage>): String {
+    messages.lastOrNull { it.role == Role.ASSISTANT && it.text.isNotBlank() }
+        ?.let { return it.text.trim() }
+    messages.lastOrNull { m -> m.tools.any { it.output.isNotBlank() } }
+        ?.let { m ->
+            val tool = m.tools.last { it.output.isNotBlank() }
+            val summary = "${tool.name}: ${tool.output.trim()}"
+            return if (summary.length > CRON_RESPONSE_MAX) summary.take(CRON_RESPONSE_MAX) + "…" else summary
+        }
+    return "No text output."
+}

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -133,9 +133,9 @@ fun MissionControlScreen(
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.padding(padding).fillMaxSize(),
-                key = { names[it] ?: "_$it" },
+                key = { names.getOrNull(it) ?: "_$it" },
             ) { page ->
-                MissionControlPage(profile = names[page], dark = dark, onNavigate = onNavigate)
+                MissionControlPage(profile = names.getOrNull(page), dark = dark, onNavigate = onNavigate)
             }
         }
     }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -8,28 +8,36 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Chat
 import androidx.compose.material.icons.rounded.BarChart
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Extension
 import androidx.compose.material.icons.rounded.Forum
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -139,6 +147,14 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     // One VM instance per tenant page, keyed by profile name.
     val vm: MissionControlViewModel = hiltViewModel(key = "mc-${profile ?: "_"}")
     val state by vm.state.collectAsStateWithLifecycle()
+    val responses by vm.responses.collectAsStateWithLifecycle()
+    val expanded = remember { androidx.compose.runtime.mutableStateMapOf<String, Boolean>() }
+    val onToggle: (ActivityItem) -> Unit = { item ->
+        val open = !(expanded[item.id] ?: false)
+        expanded[item.id] = open
+        if (open) item.sessionId?.let { vm.loadResponse(it) }
+    }
+    val onRetryResponse: (ActivityItem) -> Unit = { item -> item.sessionId?.let { vm.loadResponse(it) } }
     val scope = rememberCoroutineScope()
     val now = remember(state.sections) { System.currentTimeMillis() }
 
@@ -160,7 +176,11 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
             isRefreshing = refreshing,
             onRefresh = { refreshing = true; vm.refresh() },
         ) {
-            MissionControlContent(state = state, nowMs = now, onRetry = { vm.refresh() }, onOpen = onOpen)
+            MissionControlContent(
+                state = state, nowMs = now, onRetry = { vm.refresh() },
+                responses = responses, expanded = expanded,
+                onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
+            )
         }
     }
 }
@@ -170,6 +190,10 @@ private fun MissionControlContent(
     state: MissionControlState,
     nowMs: Long,
     onRetry: () -> Unit,
+    responses: Map<String, MissionControlViewModel.CronResponseUi>,
+    expanded: androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean>,
+    onToggle: (ActivityItem) -> Unit,
+    onRetryResponse: (ActivityItem) -> Unit,
     onOpen: (String) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
@@ -200,7 +224,18 @@ private fun MissionControlContent(
             else -> state.sections.forEach { section ->
                 item(key = "h-${section.title}") { SectionHeader(section.title, section.items.size) }
                 items(section.items, key = { it.id }) { activity ->
-                    ActivityRow(activity, nowMs, onClick = { onOpen(activity.route) })
+                    val expandable = activity.kind == ActivityKind.CRON &&
+                        activity.sessionId != null && !activity.upcoming
+                    ActivityRow(
+                        item = activity,
+                        nowMs = nowMs,
+                        expandable = expandable,
+                        isExpanded = expanded[activity.id] == true,
+                        response = activity.sessionId?.let { responses[it] },
+                        onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
+                        onRetry = { onRetryResponse(activity) },
+                        onOpenFull = { onOpen(activity.route) },
+                    )
                 }
             }
         }
@@ -225,7 +260,16 @@ private fun SectionHeader(label: String, count: Int) {
 }
 
 @Composable
-private fun ActivityRow(item: ActivityItem, nowMs: Long, onClick: () -> Unit) {
+private fun ActivityRow(
+    item: ActivityItem,
+    nowMs: Long,
+    expandable: Boolean = false,
+    isExpanded: Boolean = false,
+    response: MissionControlViewModel.CronResponseUi? = null,
+    onClick: () -> Unit,
+    onRetry: () -> Unit = {},
+    onOpenFull: () -> Unit = {},
+) {
     val icon: ImageVector = when {
         item.kind == ActivityKind.CONVERSATION -> Icons.AutoMirrored.Rounded.Chat
         item.upcoming -> Icons.Rounded.Schedule
@@ -240,10 +284,57 @@ private fun ActivityRow(item: ActivityItem, nowMs: Long, onClick: () -> Unit) {
         else -> MaterialTheme.colorScheme.primary
     }
     val time = relativeTime(item.timestampMs, nowMs)
-    ListItem(
-        leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
-        headlineContent = { Text(item.title) },
-        supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
-        modifier = Modifier.clickable(onClick = onClick),
-    )
+    Column {
+        ListItem(
+            leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
+            headlineContent = { Text(item.title) },
+            supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
+            trailingContent = if (expandable) {
+                {
+                    Icon(
+                        if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse response" else "Show response",
+                    )
+                }
+            } else {
+                null
+            },
+            modifier = Modifier.clickable(onClick = onClick),
+        )
+        if (expandable && isExpanded) {
+            CronResponseCard(response = response, onRetry = onRetry, onOpenFull = onOpenFull)
+        }
+    }
+}
+
+@Composable
+private fun CronResponseCard(
+    response: MissionControlViewModel.CronResponseUi?,
+    onRetry: () -> Unit,
+    onOpenFull: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            when {
+                response == null || response.loading ->
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                response.error -> {
+                    Text("Couldn't load response", color = MaterialTheme.colorScheme.error)
+                    TextButton(onClick = onRetry) { Text("Retry") }
+                }
+                else -> {
+                    Text(
+                        response.text ?: "No text output.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.heightIn(max = 220.dp).verticalScroll(rememberScrollState()),
+                    )
+                    TextButton(onClick = onOpenFull) { Text("View full chat") }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -116,7 +116,7 @@ fun MissionControlScreen(
         Scaffold(
             topBar = {
                 Column {
-                    HermesTopBar(title = "Agent Activity", subtitle = currentProfile?.let { "Profile: $it" })
+                    HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })
                     if (names.size > 1) {
                         com.hermes.client.ui.components.ProfileChips(
                             names = names.filterNotNull(),
@@ -212,6 +212,12 @@ private fun MissionControlContent(
                 }
             }
         }
+        if (state.needsYou.isNotEmpty()) {
+            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size) }
+            items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+                NeedsYouRow(alert, onClick = { onOpen(alert.route) })
+            }
+        }
         when {
             state.loading && state.sections.isEmpty() -> item { LoadingState() }
             state.error != null -> item { ErrorState(message = state.error!!, onRetry = onRetry) }
@@ -257,6 +263,25 @@ private fun SectionHeader(label: String, count: Int) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+@Composable
+private fun NeedsYouRow(alert: CronAlert, onClick: () -> Unit) {
+    ListItem(
+        leadingContent = {
+            Icon(Icons.Rounded.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+        },
+        headlineContent = { Text(alert.name) },
+        supportingContent = {
+            Text(
+                when (alert.reason) {
+                    CronAlertReason.FAILED -> "Last run failed"
+                    CronAlertReason.OVERDUE -> "Overdue"
+                },
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -148,11 +148,13 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     val vm: MissionControlViewModel = hiltViewModel(key = "mc-${profile ?: "_"}")
     val state by vm.state.collectAsStateWithLifecycle()
     val responses by vm.responses.collectAsStateWithLifecycle()
-    val expanded = remember { androidx.compose.runtime.mutableStateMapOf<String, Boolean>() }
+    var expandedIds by androidx.compose.runtime.saveable.rememberSaveable {
+        androidx.compose.runtime.mutableStateOf(emptySet<String>())
+    }
     val onToggle: (ActivityItem) -> Unit = { item ->
-        val open = !(expanded[item.id] ?: false)
-        expanded[item.id] = open
-        if (open) item.sessionId?.let { vm.loadResponse(it) }
+        val nowExpanded = item.id !in expandedIds
+        expandedIds = if (nowExpanded) expandedIds + item.id else expandedIds - item.id
+        if (nowExpanded) item.sessionId?.let { vm.loadResponse(it) }
     }
     val onRetryResponse: (ActivityItem) -> Unit = { item -> item.sessionId?.let { vm.loadResponse(it) } }
     val scope = rememberCoroutineScope()
@@ -178,7 +180,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
         ) {
             MissionControlContent(
                 state = state, nowMs = now, onRetry = { vm.refresh() },
-                responses = responses, expanded = expanded,
+                responses = responses, expandedIds = expandedIds,
                 onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
             )
         }
@@ -191,7 +193,7 @@ private fun MissionControlContent(
     nowMs: Long,
     onRetry: () -> Unit,
     responses: Map<String, MissionControlViewModel.CronResponseUi>,
-    expanded: androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean>,
+    expandedIds: Set<String>,
     onToggle: (ActivityItem) -> Unit,
     onRetryResponse: (ActivityItem) -> Unit,
     onOpen: (String) -> Unit,
@@ -236,7 +238,7 @@ private fun MissionControlContent(
                         item = activity,
                         nowMs = nowMs,
                         expandable = expandable,
-                        isExpanded = expanded[activity.id] == true,
+                        isExpanded = activity.id in expandedIds,
                         response = activity.sessionId?.let { responses[it] },
                         onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
                         onRetry = { onRetryResponse(activity) },

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -18,6 +18,7 @@ data class MissionControlState(
     val loading: Boolean = false,
     val error: String? = null,
     val unauthorized: Boolean = false,
+    val needsYou: List<CronAlert> = emptyList(),
 )
 
 /**
@@ -61,8 +62,12 @@ class MissionControlViewModel @Inject constructor(
             val scoped = if (profile.isNullOrBlank()) all else all.filter { it.profile == profile }
             // A cron failure (e.g. profile without cron) must not blank the whole feed.
             val crons = runCatching { tools.cronJobs(profile) }.getOrDefault(emptyList())
+            val now = System.currentTimeMillis()
             val items = sessionsToActivity(scoped) + cronsToActivity(crons)
-            _state.value = MissionControlState(sections = groupActivity(items, System.currentTimeMillis()))
+            _state.value = MissionControlState(
+                sections = groupActivity(items, now),
+                needsYou = needsAttention(crons, now),
+            )
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = MissionControlState(unauthorized = true)
             else _state.value = MissionControlState(error = e.message ?: "Failed to load")

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -95,15 +96,17 @@ class MissionControlViewModel @Inject constructor(
     fun loadResponse(sessionId: String) {
         val existing = _responses.value[sessionId]
         if (existing != null && (existing.loading || existing.text != null)) return
-        _responses.value = _responses.value + (sessionId to CronResponseUi(loading = true))
+        _responses.update { it + (sessionId to CronResponseUi(loading = true)) }
         viewModelScope.launch {
             val result = runCatching { sessions.history(sessionId, profile) }
-            _responses.value = _responses.value + (
-                sessionId to result.fold(
-                    onSuccess = { CronResponseUi(text = cronResponse(it)) },
-                    onFailure = { CronResponseUi(error = true) },
+            _responses.update {
+                it + (
+                    sessionId to result.fold(
+                        onSuccess = { CronResponseUi(text = cronResponse(it)) },
+                        onFailure = { CronResponseUi(error = true) },
+                    )
                 )
-            )
+            }
         }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -63,10 +63,12 @@ class MissionControlViewModel @Inject constructor(
             // A cron failure (e.g. profile without cron) must not blank the whole feed.
             val crons = runCatching { tools.cronJobs(profile) }.getOrDefault(emptyList())
             val now = System.currentTimeMillis()
-            val items = sessionsToActivity(scoped) + cronsToActivity(crons)
+            val alerts = needsAttention(crons, now)
+            val alertIds = alerts.mapTo(mutableSetOf()) { it.jobId }
+            val items = sessionsToActivity(scoped) + cronsToActivity(crons.filterNot { it.id in alertIds })
             _state.value = MissionControlState(
                 sections = groupActivity(items, now),
-                needsYou = needsAttention(crons, now),
+                needsYou = alerts,
             )
         } catch (e: HermesApiException) {
             if (e.code == 401) _state.value = MissionControlState(unauthorized = true)

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -34,6 +34,12 @@ class MissionControlViewModel @Inject constructor(
     private val _state = MutableStateFlow(MissionControlState())
     val state: StateFlow<MissionControlState> = _state.asStateFlow()
 
+    /** Lazily-loaded cron-run responses, keyed by sessionId. */
+    data class CronResponseUi(val loading: Boolean = false, val text: String? = null, val error: Boolean = false)
+
+    private val _responses = MutableStateFlow<Map<String, CronResponseUi>>(emptyMap())
+    val responses: StateFlow<Map<String, CronResponseUi>> = _responses.asStateFlow()
+
     private var profile: String? = null
     private var loadJob: kotlinx.coroutines.Job? = null
 
@@ -72,6 +78,25 @@ class MissionControlViewModel @Inject constructor(
     suspend fun switchTo(profile: String?) {
         if (!profile.isNullOrBlank() && profile != profileManager.active.value) {
             profileManager.switchTo(profile)
+        }
+    }
+
+    /**
+     * Fetch a cron run's response on demand (one REST history call), caching by sessionId. A loaded
+     * or in-flight entry is not refetched; a prior error IS retryable (call again).
+     */
+    fun loadResponse(sessionId: String) {
+        val existing = _responses.value[sessionId]
+        if (existing != null && (existing.loading || existing.text != null)) return
+        _responses.value = _responses.value + (sessionId to CronResponseUi(loading = true))
+        viewModelScope.launch {
+            val result = runCatching { sessions.history(sessionId, profile) }
+            _responses.value = _responses.value + (
+                sessionId to result.fold(
+                    onSuccess = { CronResponseUi(text = cronResponse(it)) },
+                    onFailure = { CronResponseUi(error = true) },
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt
@@ -1,0 +1,40 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.util.isoToEpochMs
+
+enum class CronAlertReason { FAILED, OVERDUE }
+
+data class CronAlert(
+    val jobId: String,
+    val name: String,
+    val reason: CronAlertReason,
+    val route: String,
+)
+
+/** Default grace before an un-run scheduled job counts as overdue. */
+const val NEEDS_YOU_GRACE_MS = 5 * 60_000L
+
+/**
+ * Cron jobs needing attention. FAILED (last run errored) takes priority — a broken job matters even
+ * if paused/disabled. Else OVERDUE: an enabled, non-paused job whose next run is more than [graceMs]
+ * past due. Pure — [nowMs] passed in so it unit-tests without a clock.
+ */
+fun needsAttention(
+    crons: List<CronJobDto>,
+    nowMs: Long,
+    graceMs: Long = NEEDS_YOU_GRACE_MS,
+): List<CronAlert> = crons.mapNotNull { job ->
+    val name = job.name?.ifBlank { null } ?: job.id
+    val route = "cron_detail/${job.id}"
+    val failed = job.lastStatus.equals("error", ignoreCase = true) ||
+        job.lastStatus.equals("failed", ignoreCase = true)
+    when {
+        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route)
+        job.enabled && !job.isPaused -> {
+            val next = isoToEpochMs(job.nextRunAt)
+            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route) else null
+        }
+        else -> null
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Chat
-import androidx.compose.material.icons.rounded.Bolt
+import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -45,8 +45,8 @@ import com.hermes.client.ui.usage.UsageScreen
 private data class Tab(val route: String, val label: String, val icon: ImageVector)
 
 private val TABS = listOf(
+    Tab("activity", "Home", Icons.Rounded.Home),
     Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
-    Tab("activity", "Agent Activity", Icons.Rounded.Bolt),
     Tab("you", "You", Icons.Rounded.Person),
 )
 
@@ -68,7 +68,7 @@ private val TABS = listOf(
 @Composable
 fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsumed: () -> Unit = {}) {
     val nav = rememberNavController()
-    val start = if (hasConfig) "sessions" else "setup"
+    val start = if (hasConfig) "activity" else "setup"
 
     LaunchedEffect(deepLinkRoute) { deepLinkRoute?.let { nav.navigate(it); onDeepLinkConsumed() } }
 
@@ -123,7 +123,7 @@ fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsu
             composable("setup") {
                 SetupScreen(
                     onSaved = {
-                        nav.navigate("sessions") { popUpTo("setup") { inclusive = true } }
+                        nav.navigate("activity") { popUpTo("setup") { inclusive = true } }
                     },
                 )
             }

--- a/app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt
@@ -94,4 +94,13 @@ class ActivityModelsTest {
         )
         assertEquals(emptyList<ActivityItem>(), cronsToActivity(listOf(job)))
     }
+
+    @Test fun sessionsToActivity_sets_sessionId_to_raw_id() {
+        val s = com.hermes.client.domain.Session(
+            id = "sess-42", title = "Nightly report", model = null, provider = null,
+            messageCount = 3, profile = "default", source = "cron", lastActive = 1_000L,
+        )
+        val item = sessionsToActivity(listOf(s)).single()
+        assertEquals("sess-42", item.sessionId)
+    }
 }

--- a/app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt
@@ -1,0 +1,50 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import com.hermes.client.domain.ToolCall
+import com.hermes.client.domain.ToolStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun msg(role: Role, text: String = "", tools: List<ToolCall> = emptyList()) =
+    ChatMessage(id = "x", role = role, text = text, tools = tools)
+
+class CronResponseTest {
+    @Test fun returns_last_assistant_text() {
+        val out = cronResponse(
+            listOf(msg(Role.USER, "run it"), msg(Role.ASSISTANT, "first"), msg(Role.ASSISTANT, "final answer")),
+        )
+        assertEquals("final answer", out)
+    }
+
+    @Test fun trims_assistant_text() {
+        assertEquals("hi", cronResponse(listOf(msg(Role.ASSISTANT, "  hi  "))))
+    }
+
+    @Test fun falls_back_to_last_tool_output_when_no_assistant_text() {
+        val out = cronResponse(
+            listOf(
+                msg(Role.USER, "go"),
+                msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t1", "search", ToolStatus.DONE, "42 results"))),
+            ),
+        )
+        assertEquals("search: 42 results", out)
+    }
+
+    @Test fun truncates_long_tool_output() {
+        val long = "y".repeat(CRON_RESPONSE_MAX + 50)
+        val out = cronResponse(listOf(msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t", "run", ToolStatus.DONE, long)))))
+        assertEquals(CRON_RESPONSE_MAX + 1, out.length)
+        assertTrue(out.endsWith("…"))
+    }
+
+    @Test fun empty_messages_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(emptyList()))
+    }
+
+    @Test fun blank_assistant_and_no_tools_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(listOf(msg(Role.ASSISTANT, "   "))))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
@@ -1,0 +1,59 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.data.repository.ToolsRepository
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MissionControlViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val sessions = mockk<SessionRepository>()
+    private val tools = mockk<ToolsRepository>(relaxed = true)
+    private val profileManager = mockk<ProfileManager>(relaxed = true)
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private fun vm() = MissionControlViewModel(sessions, tools, profileManager)
+
+    @Test fun loadResponse_sets_text_on_success() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "the answer"))
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertEquals("the answer", vm.responses.value["s1"]?.text)
+    }
+
+    @Test fun loadResponse_sets_error_on_failure() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } throws RuntimeException("boom")
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertTrue(vm.responses.value["s1"]?.error == true)
+    }
+
+    @Test fun loadResponse_caches_and_does_not_refetch() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "x"))
+        val vm = vm()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        coVerify(exactly = 1) { sessions.history("s1", any()) }
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
@@ -1,0 +1,60 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", name: String? = null, enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, name = name, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class NeedsYouTest {
+    @Test fun failed_status_makes_a_FAILED_alert() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "error")), NOW).single().reason)
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "failed")), NOW).single().reason)
+    }
+
+    @Test fun healthy_success_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000))), NOW).isEmpty())
+    }
+
+    @Test fun enabled_past_due_beyond_grace_is_OVERDUE() {
+        assertEquals(CronAlertReason.OVERDUE, needsAttention(listOf(job(nextRunAt = iso(NOW - 10 * 60_000))), NOW).single().reason)
+    }
+
+    @Test fun future_next_run_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW + 60 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun within_grace_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW - 2 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_or_disabled_not_failed_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(enabled = false, nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+        assertTrue(needsAttention(listOf(job(state = "paused", nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_but_failed_still_shows_FAILED() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(state = "paused", lastStatus = "error")), NOW).single().reason)
+    }
+
+    @Test fun failed_and_past_due_is_a_single_FAILED() {
+        val alerts = needsAttention(listOf(job(lastStatus = "error", nextRunAt = iso(NOW - 10 * 60_000))), NOW)
+        assertEquals(1, alerts.size)
+        assertEquals(CronAlertReason.FAILED, alerts.single().reason)
+    }
+
+    @Test fun name_falls_back_to_id_and_route_is_cron_detail() {
+        val a = needsAttention(listOf(job(id = "abc", name = "  ", lastStatus = "error")), NOW).single()
+        assertEquals("abc", a.name)
+        assertEquals("cron_detail/abc", a.route)
+    }
+}

--- a/docs/ideas/activity-home-and-cron-response.md
+++ b/docs/ideas/activity-home-and-cron-response.md
@@ -1,0 +1,53 @@
+# Activity Home + Cron Response-at-a-Glance
+
+## Problem Statement
+**How might we** make opening the app land you on *what's happening and what needs you* (never a stale resumed chat), and let you see *what a scheduled job actually answered* without wading through its full transcript — using only existing endpoints + native APIs?
+
+## Context (grounded in the code)
+- **Launch today:** `HermesNav` sets `start = if (hasConfig) "sessions" else "setup"` — a cold launch opens the **Sessions list**. A notification tap already deep-links to `chat/<id>` via the `extra_route` rail.
+- **Agent Activity today:** the `activity` tab is **Mission Control** — already a "unified activity feed merging conversations + cron for the active profile, time-grouped." Cron runs are stored as real `source="cron"` **sessions**; tapping one opens the *full* transcript. `ActivityItem.status` already carries cron `last_status`; `CronJobDto` carries `lastRunAt`/`nextRunAt`.
+- **Product vs Technical toggle** already exists (`SettingsStore.toolCallTechnical`): Product mode hides tool payloads.
+- **Data reality (verified this session):** the WS stream emits `approval.request/responded`, `run.*`, `tool.*`, `message.*` — but there is **no REST list of pending approvals**, and cron-finished/messaging events are **not** on the app's WS. Cron state and messaging pairing ARE available over REST (`/api/cron/*`, `/api/pairing`).
+
+## Recommended Direction
+
+Two complementary, independently shippable pieces on the **same surface** — the existing Mission Control feed. Ship the small one first.
+
+**Piece 1 (ship first) — Cron response inline in Agent Activity.**
+A cron item in the feed expands **inline** to show the run's **final assistant message** (the "response"), Product-mode-filtered so tool payloads are hidden. Tap-through to the full transcript is preserved. The response is the last `role = assistant` `ChatMessage` in the cron-produced session, fetched **lazily on expand** (one history call for the tapped item — no upfront N calls). For a run with only tool output and no final assistant text, fall back to the **last tool result summary**. Small, clean, no data gaps.
+
+**Piece 2 — Home = Mission Control promoted, with a "Needs you" strip, set as the launch destination.**
+Flip the start destination from `sessions` to the activity home so a cold launch lands on *what's happening* — never a resumed stale chat (this is the real fix for "it remembers the session"). The bottom-nav tab is **relabeled "Home"** (concept: the Situation Room) rather than "Agent Activity". A compact **"Needs you"** strip sits on top of the existing time-grouped feed and **auto-refreshes on resume** via a cheap REST poll of cron + pairing. Notification taps still deep-link to their session unchanged. "New chat" scopes to the **last-used profile**.
+
+**The honest constraint on "Needs you":** it leads with what's **reliable over REST** — **failed / overdue cron** (from `last_status` + `next_run`, already in the feed's data) and **waiting messaging** (`/api/pairing`). *Pending agent approvals* — the thing you'd most want — are WS-only and transient, so they appear **only as a bonus when the foreground service is live** (from its in-memory cache), never as a promised cold-launch count. We do **not** build "Needs you = approvals count"; it would be empty and misleading most of the time.
+
+Rationale: Piece 1 is a painkiller with zero data gaps — it ships this week and makes the cron feature actually useful on a phone. Piece 2 reuses the shipped Mission Control feed rather than duplicating it as a new screen, and is honest about the one weak input (approvals) instead of building the whole thing around it.
+
+## Key Assumptions to Validate
+- [ ] **A cron run has a clean "final answer."** Bet: the last `assistant` message in the `source="cron"` session is the response. Test: expand several real cron runs (single-step and multi-step); confirm the last assistant text reads as "the answer." Fallback: for a tool-only run with no final assistant text, show the **last tool result summary**.
+- [ ] **Failed/overdue cron is derivable without new endpoints.** Bet: `CronJobDto.lastStatus` + `nextRunAt` (already mapped) are enough to flag "failed" and "overdue." Test: force a failing cron + a missed schedule; confirm both surface in "Needs you."
+- [ ] **Landing on the home doesn't fight the notification deep-link.** Bet: start on home, then `deepLinkRoute` navigates on top as today. Test: cold-launch from an approval notification → lands on the session, not the home.
+- [ ] **Last-used profile is safe as the new-chat default.** Bet: reopening the last tenant is what you want. Risk: cross-tenant mis-send. Test: dogfood; if it ever feels risky, fall back to a pinned default or a picker (both already considered).
+
+## MVP Scope
+**In:**
+- **Piece 1:** cron feed items expand to the final assistant message (Product-mode-filtered), lazy-fetched on expand; full-transcript tap preserved.
+- **Piece 2:** start destination → activity home (bottom-nav tab relabeled **"Home"**); a "Needs you" strip = failed/overdue cron (+ messaging-pairing waits) that **auto-refreshes on resume**; "New chat" uses last-used profile; notification deep-link unchanged.
+
+**Out (this MVP):**
+- A separate net-new "Situation Room" screen (we promote Mission Control instead).
+- A guaranteed cold-launch pending-approvals count (WS-only; bonus-when-service-on only).
+- Any new gateway endpoint.
+- A profile picker / pinned-default-profile launch flow (revisit only if last-used feels unsafe in daily use).
+
+## Not Doing (and Why)
+- **Duplicate Situation Room screen** — Mission Control already is the unified feed; a second screen would fork the code and the data. Promote, don't duplicate.
+- **"Needs you" built around approvals** — no REST list + transient + service-dependent; it would be blank on cold launch. Cron/messaging lead; approvals are a live-only bonus.
+- **New-chat-on-launch (the original ask)** — superseded: landing on the home already removes the stale-session-resume problem, and gives orientation before you start typing. A one-tap "New" is right there.
+- **Eager-loading every cron response in the feed** — N history calls on every open. Lazy-on-expand instead.
+- **A new Product/Technical control for cron** — reuse the existing toggle; the cron response is just an assistant message with payloads hidden.
+
+## Resolved Decisions
+- **Launch tab is relabeled "Home"** (concept: the Situation Room), not kept as "Agent Activity" — it becomes the start destination with the "Needs you" strip on top.
+- **"Needs you" auto-refreshes on resume** via a cheap REST poll of cron + pairing (not pull/tab-enter only).
+- **Tool-only cron runs** (no final assistant text) show the **last tool result summary** as the "response".

--- a/docs/superpowers/plans/2026-07-04-cron-response-inline.md
+++ b/docs/superpowers/plans/2026-07-04-cron-response-inline.md
@@ -1,0 +1,529 @@
+# Cron Response Inline (Agent Activity) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tapping a cron run in the Agent Activity feed expands its response (the run's final assistant message) inline, with a "View full chat" link to the transcript.
+
+**Architecture:** A pure `cronResponse(messages)` extractor + an `ActivityItem.sessionId` + a lazy per-run loader on `MissionControlViewModel` (`SessionRepository.history()` REST, cached by sessionId) + response-first inline expansion in `MissionControlScreen`. No gateway/bridge changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, MVVM + StateFlow, JUnit + MockK + coroutines-test.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Reuse `SessionRepository.history(sessionId, profile): List<ChatMessage>` (REST `GET /api/sessions/<id>/messages`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Follow patterns: pure unit tests like `ActivityModelsTest`; VM tests with MockK + `runTest`; Material3 `ListItem` rows.
+- **No AI/assistant attribution** in commits, files, or PRs.
+- Only **cron runs** expand (`kind == CRON && sessionId != null && !upcoming`); conversations + upcoming next-runs navigate as today.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt` — pure `cronResponse` + `CRON_RESPONSE_MAX`.
+- Create `app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt` — `ActivityItem.sessionId`.
+- Modify `app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt` — assert `sessionId`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt` — `CronResponseUi`, `responses`, `loadResponse`.
+- Create `app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt` — inline expansion.
+
+---
+
+### Task 1: Pure `cronResponse` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt`
+
+**Interfaces:**
+- Produces: `const val CRON_RESPONSE_MAX = 500`; `fun cronResponse(messages: List<ChatMessage>): String`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import com.hermes.client.domain.ToolCall
+import com.hermes.client.domain.ToolStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun msg(role: Role, text: String = "", tools: List<ToolCall> = emptyList()) =
+    ChatMessage(id = "x", role = role, text = text, tools = tools)
+
+class CronResponseTest {
+    @Test fun returns_last_assistant_text() {
+        val out = cronResponse(
+            listOf(msg(Role.USER, "run it"), msg(Role.ASSISTANT, "first"), msg(Role.ASSISTANT, "final answer")),
+        )
+        assertEquals("final answer", out)
+    }
+
+    @Test fun trims_assistant_text() {
+        assertEquals("hi", cronResponse(listOf(msg(Role.ASSISTANT, "  hi  "))))
+    }
+
+    @Test fun falls_back_to_last_tool_output_when_no_assistant_text() {
+        val out = cronResponse(
+            listOf(
+                msg(Role.USER, "go"),
+                msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t1", "search", ToolStatus.DONE, "42 results"))),
+            ),
+        )
+        assertEquals("search: 42 results", out)
+    }
+
+    @Test fun truncates_long_tool_output() {
+        val long = "y".repeat(CRON_RESPONSE_MAX + 50)
+        val out = cronResponse(listOf(msg(Role.ASSISTANT, "", tools = listOf(ToolCall("t", "run", ToolStatus.DONE, long)))))
+        assertEquals(CRON_RESPONSE_MAX + 1, out.length)
+        assertTrue(out.endsWith("…"))
+    }
+
+    @Test fun empty_messages_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(emptyList()))
+    }
+
+    @Test fun blank_assistant_and_no_tools_returns_placeholder() {
+        assertEquals("No text output.", cronResponse(listOf(msg(Role.ASSISTANT, "   "))))
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronResponseTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `cronResponse`/`CRON_RESPONSE_MAX`.
+
+- [ ] **Step 3: Implement `CronResponse.kt`**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+
+/** Max length of the tool-result fallback summary before truncation. */
+const val CRON_RESPONSE_MAX = 500
+
+/**
+ * A cron run's "response" from its session messages: the last assistant message with text; else
+ * the last tool result summary; else a placeholder. Pure — unit-tested without network or clock.
+ */
+fun cronResponse(messages: List<ChatMessage>): String {
+    messages.lastOrNull { it.role == Role.ASSISTANT && it.text.isNotBlank() }
+        ?.let { return it.text.trim() }
+    messages.lastOrNull { m -> m.tools.any { it.output.isNotBlank() } }
+        ?.let { m ->
+            val tool = m.tools.last { it.output.isNotBlank() }
+            val summary = "${tool.name}: ${tool.output.trim()}"
+            return if (summary.length > CRON_RESPONSE_MAX) summary.take(CRON_RESPONSE_MAX) + "…" else summary
+        }
+    return "No text output."
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronResponseTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt app/src/test/java/com/hermes/client/ui/activity/CronResponseTest.kt
+git commit -m "feat(activity): pure cronResponse extractor with tests"
+```
+
+---
+
+### Task 2: `ActivityItem.sessionId`
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt`
+
+**Interfaces:**
+- Produces: `ActivityItem.sessionId: String?` — the raw session id, set by `sessionsToActivity`, null from `cronsToActivity`.
+
+- [ ] **Step 1: Add the failing test** — append to `ActivityModelsTest`:
+
+```kotlin
+    @Test fun sessionsToActivity_sets_sessionId_to_raw_id() {
+        val s = com.hermes.client.domain.Session(
+            id = "sess-42", title = "Nightly report", model = null, provider = null,
+            messageCount = 3, profile = "default", source = "cron", lastActive = 1_000L,
+        )
+        val item = sessionsToActivity(listOf(s)).single()
+        assertEquals("sess-42", item.sessionId)
+    }
+```
+
+Ensure `import org.junit.Assert.assertEquals` is present in the test file.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ActivityModelsTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — `sessionId` unresolved.
+
+- [ ] **Step 3: Add the field + set it**
+
+In `ActivityModels.kt`, add to the `ActivityItem` data class (after `route`):
+
+```kotlin
+    // Raw session id for a session-backed row (used to lazily load a cron run's response inline).
+    // Null for cron next-run items.
+    val sessionId: String? = null,
+```
+
+In `sessionsToActivity`, add `sessionId = s.id,` to the `ActivityItem(...)` constructor (alongside `route = "chat/${s.id}"`). Leave `cronsToActivity` unchanged (defaults to null).
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ActivityModelsTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt app/src/test/java/com/hermes/client/ui/activity/ActivityModelsTest.kt
+git commit -m "feat(activity): carry sessionId on ActivityItem for inline response loading"
+```
+
+---
+
+### Task 3: `MissionControlViewModel` lazy response loader
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: `cronResponse` (Task 1); `SessionRepository.history(sessionId, profile)`.
+- Produces: `data class CronResponseUi(loading: Boolean = false, text: String? = null, error: Boolean = false)`; `val responses: StateFlow<Map<String, CronResponseUi>>`; `fun loadResponse(sessionId: String)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.data.repository.ToolsRepository
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MissionControlViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val sessions = mockk<SessionRepository>()
+    private val tools = mockk<ToolsRepository>(relaxed = true)
+    private val profileManager = mockk<ProfileManager>(relaxed = true)
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private fun vm() = MissionControlViewModel(sessions, tools, profileManager)
+
+    @Test fun loadResponse_sets_text_on_success() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "the answer"))
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertEquals("the answer", vm.responses.value["s1"]?.text)
+    }
+
+    @Test fun loadResponse_sets_error_on_failure() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } throws RuntimeException("boom")
+        val vm = vm()
+        vm.loadResponse("s1")
+        advanceUntilIdle()
+        assertTrue(vm.responses.value["s1"]?.error == true)
+    }
+
+    @Test fun loadResponse_caches_and_does_not_refetch() = runTest(dispatcher) {
+        coEvery { sessions.history("s1", any()) } returns listOf(ChatMessage("m", Role.ASSISTANT, "x"))
+        val vm = vm()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        vm.loadResponse("s1"); advanceUntilIdle()
+        coVerify(exactly = 1) { sessions.history("s1", any()) }
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MissionControlViewModelTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `responses`/`loadResponse`/`CronResponseUi`.
+
+- [ ] **Step 3: Add the loader to `MissionControlViewModel`**
+
+Add imports if missing: `kotlinx.coroutines.flow.asStateFlow` (already present), `kotlinx.coroutines.launch` (already present).
+
+Add inside the class body (e.g. after the `state` declaration):
+
+```kotlin
+    /** Lazily-loaded cron-run responses, keyed by sessionId. */
+    data class CronResponseUi(val loading: Boolean = false, val text: String? = null, val error: Boolean = false)
+
+    private val _responses = MutableStateFlow<Map<String, CronResponseUi>>(emptyMap())
+    val responses: StateFlow<Map<String, CronResponseUi>> = _responses.asStateFlow()
+
+    /**
+     * Fetch a cron run's response on demand (one REST history call), caching by sessionId. A loaded
+     * or in-flight entry is not refetched; a prior error IS retryable (call again).
+     */
+    fun loadResponse(sessionId: String) {
+        val existing = _responses.value[sessionId]
+        if (existing != null && (existing.loading || existing.text != null)) return
+        _responses.value = _responses.value + (sessionId to CronResponseUi(loading = true))
+        viewModelScope.launch {
+            val result = runCatching { sessions.history(sessionId, profile) }
+            _responses.value = _responses.value + (
+                sessionId to result.fold(
+                    onSuccess = { CronResponseUi(text = cronResponse(it)) },
+                    onFailure = { CronResponseUi(error = true) },
+                )
+            )
+        }
+    }
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MissionControlViewModelTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
+git commit -m "feat(activity): lazy per-run cron response loader on MissionControlViewModel"
+```
+
+---
+
+### Task 4: Inline expansion in `MissionControlScreen`
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+**Interfaces:**
+- Consumes: `ActivityItem.sessionId` (Task 2); `MissionControlViewModel.responses`/`loadResponse`/`CronResponseUi` (Task 3).
+
+- [ ] **Step 1: Thread response state through `MissionControlPage`**
+
+In `MissionControlPage`, after `val state by vm.state.collectAsStateWithLifecycle()` add:
+
+```kotlin
+    val responses by vm.responses.collectAsStateWithLifecycle()
+    val expanded = remember { androidx.compose.runtime.mutableStateMapOf<String, Boolean>() }
+    val onToggle: (ActivityItem) -> Unit = { item ->
+        val open = !(expanded[item.id] ?: false)
+        expanded[item.id] = open
+        if (open) item.sessionId?.let { vm.loadResponse(it) }
+    }
+    val onRetryResponse: (ActivityItem) -> Unit = { item -> item.sessionId?.let { vm.loadResponse(it) } }
+```
+
+Update the `MissionControlContent(...)` call to pass them:
+
+```kotlin
+            MissionControlContent(
+                state = state, nowMs = now, onRetry = { vm.refresh() },
+                responses = responses, expanded = expanded,
+                onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
+            )
+```
+
+- [ ] **Step 2: Update `MissionControlContent` signature + the item row**
+
+Change the signature to:
+
+```kotlin
+@Composable
+private fun MissionControlContent(
+    state: MissionControlState,
+    nowMs: Long,
+    onRetry: () -> Unit,
+    responses: Map<String, MissionControlViewModel.CronResponseUi>,
+    expanded: androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean>,
+    onToggle: (ActivityItem) -> Unit,
+    onRetryResponse: (ActivityItem) -> Unit,
+    onOpen: (String) -> Unit,
+) {
+```
+
+Replace the `items(section.items, …)` block with:
+
+```kotlin
+                items(section.items, key = { it.id }) { activity ->
+                    val expandable = activity.kind == ActivityKind.CRON &&
+                        activity.sessionId != null && !activity.upcoming
+                    ActivityRow(
+                        item = activity,
+                        nowMs = nowMs,
+                        expandable = expandable,
+                        isExpanded = expanded[activity.id] == true,
+                        response = activity.sessionId?.let { responses[it] },
+                        onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
+                        onRetry = { onRetryResponse(activity) },
+                        onOpenFull = { onOpen(activity.route) },
+                    )
+                }
+```
+
+- [ ] **Step 3: Rewrite `ActivityRow` + add `CronResponseCard`**
+
+Replace the existing `ActivityRow` composable with:
+
+```kotlin
+@Composable
+private fun ActivityRow(
+    item: ActivityItem,
+    nowMs: Long,
+    expandable: Boolean = false,
+    isExpanded: Boolean = false,
+    response: MissionControlViewModel.CronResponseUi? = null,
+    onClick: () -> Unit,
+    onRetry: () -> Unit = {},
+    onOpenFull: () -> Unit = {},
+) {
+    val icon: ImageVector = when {
+        item.kind == ActivityKind.CONVERSATION -> Icons.AutoMirrored.Rounded.Chat
+        item.upcoming -> Icons.Rounded.Schedule
+        item.status.equals("success", ignoreCase = true) -> Icons.Rounded.CheckCircle
+        item.status.equals("error", ignoreCase = true) ||
+            item.status.equals("failed", ignoreCase = true) -> Icons.Rounded.ErrorOutline
+        else -> Icons.Rounded.History
+    }
+    val tint = when {
+        item.status.equals("error", ignoreCase = true) ||
+            item.status.equals("failed", ignoreCase = true) -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.primary
+    }
+    val time = relativeTime(item.timestampMs, nowMs)
+    Column {
+        ListItem(
+            leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
+            headlineContent = { Text(item.title) },
+            supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
+            trailingContent = if (expandable) {
+                {
+                    Icon(
+                        if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        contentDescription = if (isExpanded) "Collapse response" else "Show response",
+                    )
+                }
+            } else {
+                null
+            },
+            modifier = Modifier.clickable(onClick = onClick),
+        )
+        if (expandable && isExpanded) {
+            CronResponseCard(response = response, onRetry = onRetry, onOpenFull = onOpenFull)
+        }
+    }
+}
+
+@Composable
+private fun CronResponseCard(
+    response: MissionControlViewModel.CronResponseUi?,
+    onRetry: () -> Unit,
+    onOpenFull: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.medium,
+        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            when {
+                response == null || response.loading ->
+                    CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+                response.error -> {
+                    Text("Couldn't load response", color = MaterialTheme.colorScheme.error)
+                    TextButton(onClick = onRetry) { Text("Retry") }
+                }
+                else -> {
+                    Text(
+                        response.text ?: "No text output.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.heightIn(max = 220.dp).verticalScroll(rememberScrollState()),
+                    )
+                    TextButton(onClick = onOpenFull) { Text("View full chat") }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add missing imports + build**
+
+Add any imports the compiler reports as missing (candidates, verify against the file's existing imports):
+`androidx.compose.foundation.layout.Column`, `androidx.compose.foundation.rememberScrollState`, `androidx.compose.foundation.verticalScroll`, `androidx.compose.foundation.layout.heightIn`, `androidx.compose.foundation.layout.size`, `androidx.compose.material.icons.rounded.ExpandLess`, `androidx.compose.material.icons.rounded.ExpandMore`, `androidx.compose.material3.CircularProgressIndicator`, `androidx.compose.material3.Surface`, `androidx.compose.material3.TextButton`, `androidx.compose.runtime.remember`.
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`. Iterate on any `^e:` import/type error until clean.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(activity): response-first inline expansion for cron runs"
+```
+
+---
+
+### Task 5: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point it at a gateway that has at least one completed cron run (a `source="cron"` session).
+
+- [ ] **Step 2: Verify**
+
+- Open **Agent Activity**. A completed cron run shows a chevron; tap the row → it expands, shows a spinner, then the run's **response** text; a **"View full chat"** button opens the full transcript.
+- Tap again → collapses. Re-expand → no refetch (instant).
+- A **conversation** row and an **upcoming** cron next-run still navigate (no expansion).
+- Force a history failure (airplane mode mid-expand) → "Couldn't load response" + **Retry**; Retry re-loads.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(activity): cron-response verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure `cronResponse` (last assistant text → tool-result summary → placeholder, `MAX=500` truncation), unit-tested (Task 1) ✓; `ActivityItem.sessionId` set by `sessionsToActivity` (Task 2) ✓; lazy `loadResponse` with `CronResponseUi` loading/text/error, cached by sessionId, retry-on-error, one-history-call guard, VM-tested (Task 3) ✓; response-first inline expansion — tap cron run toggles + loads, spinner/error+Retry/text, "View full chat", only `kind==CRON && sessionId!=null && !upcoming` expand, others navigate (Task 4) ✓; states + on-device incl. failure path (Task 5) ✓; no Product-toggle threading (response is text) ✓; no bridge changes (reuses `history`) ✓.
+- **Placeholder scan:** every code step has full code; the only conditional is the Task 5 verification-only commit and the "add missing imports" step (candidate list given).
+- **Type consistency:** `cronResponse(messages)`/`CRON_RESPONSE_MAX`, `ActivityItem.sessionId`, `MissionControlViewModel.CronResponseUi(loading/text/error)`, `responses`/`loadResponse(sessionId)`, and the `ActivityRow(expandable/isExpanded/response/onClick/onRetry/onOpenFull)` params are consistent across Tasks 1–4. `ToolStatus.DONE`, `Role.ASSISTANT`, `ToolCall(id,name,status,output)`, `Session(...)` match the domain models.
+
+**Ordering note:** Task 1 (pure) and Task 2 (data field) are independent and each green. Task 3 depends on Task 1 (`cronResponse`). Task 4 depends on Tasks 2 + 3. Task 5 verifies on-device.

--- a/docs/superpowers/plans/2026-07-04-home-landing.md
+++ b/docs/superpowers/plans/2026-07-04-home-landing.md
@@ -1,0 +1,132 @@
+# Home Landing (2a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The app opens to the Home tab (Mission Control activity feed) instead of the Sessions list, with the bottom nav leading with Home.
+
+**Architecture:** A navigation-config change entirely in `HermesNav.kt` — reorder/relabel the `TABS` list, flip the start destination to `"activity"`, and point the post-setup jump at `"activity"`. The `"activity"` route id is unchanged (only its visible label changes).
+
+**Tech Stack:** Kotlin, Jetpack Compose, Navigation Compose.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Pure navigation config.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Full suite: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Do **not** touch `MissionControlScreen`, the deep-link rail, `SessionsScreen`, or any repository. Keep the `"activity"` route id.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## File Structure
+
+- Modify `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt` — `TABS`, `start`, post-setup nav, imports.
+
+---
+
+### Task 1: Home landing nav change
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt`
+
+**Interfaces:** none exported (internal nav config).
+
+- [ ] **Step 1: Reorder + relabel `TABS`**
+
+Replace the existing `TABS` list:
+
+```kotlin
+private val TABS = listOf(
+    Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
+    Tab("activity", "Agent Activity", Icons.Rounded.Bolt),
+    Tab("you", "You", Icons.Rounded.Person),
+)
+```
+
+with (Home first, relabeled, Home icon):
+
+```kotlin
+private val TABS = listOf(
+    Tab("activity", "Home", Icons.Rounded.Home),
+    Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
+    Tab("you", "You", Icons.Rounded.Person),
+)
+```
+
+- [ ] **Step 2: Fix icon imports**
+
+Add `import androidx.compose.material.icons.rounded.Home`. If `Icons.Rounded.Bolt` is now unused elsewhere in the file, remove `import androidx.compose.material.icons.rounded.Bolt` (verify with a search before removing).
+
+- [ ] **Step 3: Flip the start destination**
+
+Change:
+
+```kotlin
+val start = if (hasConfig) "sessions" else "setup"
+```
+
+to:
+
+```kotlin
+val start = if (hasConfig) "activity" else "setup"
+```
+
+- [ ] **Step 4: Point the post-setup jump at Home**
+
+Change (around line 126):
+
+```kotlin
+                        nav.navigate("sessions") { popUpTo("setup") { inclusive = true } }
+```
+
+to:
+
+```kotlin
+                        nav.navigate("activity") { popUpTo("setup") { inclusive = true } }
+```
+
+- [ ] **Step 5: Compile + full unit suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`. (No tests change; this confirms nothing regressed and the icon import resolves.)
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+git commit -m "feat(nav): land on Home tab; bottom nav leads with Home"
+```
+
+---
+
+### Task 2: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Use a build already configured with a gateway (or complete setup against the mock at `http://10.0.2.2:8899`).
+
+- [ ] **Step 2: Verify**
+
+- **Cold launch (configured):** the app opens on **Home** — the Mission Control activity feed (LIVE NOW / UPCOMING / RECENT) — not the Sessions list. The bottom nav reads **Home · Chats · You** with **Home** selected.
+- **Chats tab:** tapping Chats shows the Sessions list; its **New** button still creates + opens a session.
+- **Notification deep-link:** launching from a notification (or `adb shell am start ... --es extra_route "chat/<id>"`) still opens that session, not Home.
+- **Fresh setup:** clear data, complete setup → lands on **Home** (not Sessions).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(nav): home-landing verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** `TABS` reorder + relabel + Home icon (Task 1 Steps 1–2) ✓; `start = "activity"` (Step 3) ✓; post-setup jump → `"activity"` (Step 4) ✓; route id `"activity"` kept (only label changes) ✓; no touch to MissionControlScreen/deep-link/SessionsScreen/repos ✓; on-device incl. notification deep-link + fresh-setup + Chats/New regression (Task 2) ✓; no bridge changes ✓; "Needs you"/approvals/messaging excluded ✓.
+- **Placeholder scan:** every code step shows the exact before/after; the only conditional is the "remove Bolt import if now unused" (guarded by a search) and the Task 2 verification-only commit.
+- **Type consistency:** `Tab(route, label, icon)`, the `"activity"`/`"sessions"`/`"you"` route ids, and `Icons.Rounded.Home` are consistent with the existing `HermesNav` structure.
+
+**Ordering note:** Task 1 is the whole change (one file, compiles + suite green). Task 2 verifies on-device.

--- a/docs/superpowers/plans/2026-07-04-needs-you.md
+++ b/docs/superpowers/plans/2026-07-04-needs-you.md
@@ -1,0 +1,332 @@
+# "Needs you" strip (2b) + Home header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a "Needs you" strip (failed/overdue cron) atop the per-profile Home feed, and rename the Home header from "Agent Activity" to "Home".
+
+**Architecture:** A pure `needsAttention(crons, now)` deriver → `MissionControlState.needsYou` (computed from the cron list `loadInner` already fetches) → a top section in `MissionControlContent`; plus a one-line header rename. No gateway/bridge changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, MVVM + StateFlow, JUnit.
+
+## Global Constraints
+
+- **No bridge/gateway API changes.** Reuse `ToolsRepository.cronJobs(profile)` (already called in `loadInner`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36, minSdk 26.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- Follow patterns: pure unit tests like `CronResponseTest`/`ActivityModelsTest`; Material3 `ListItem` rows; the existing `SectionHeader`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+- "Needs you" is **cron-only**, **per-profile**; FAILED takes priority over OVERDUE.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt` — `CronAlertReason`, `CronAlert`, `needsAttention`.
+- Create `app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt` — `MissionControlState.needsYou` + compute in `loadInner`.
+- Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt` — top "Needs you" section + `NeedsYouRow` + header rename.
+
+---
+
+### Task 1: Pure `needsAttention` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt`
+
+**Interfaces:**
+- Produces: `enum class CronAlertReason { FAILED, OVERDUE }`; `data class CronAlert(jobId, name, reason, route)`; `const val NEEDS_YOU_GRACE_MS`; `fun needsAttention(crons: List<CronJobDto>, nowMs: Long, graceMs: Long = NEEDS_YOU_GRACE_MS): List<CronAlert>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", name: String? = null, enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, name = name, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class NeedsYouTest {
+    @Test fun failed_status_makes_a_FAILED_alert() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "error")), NOW).single().reason)
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(lastStatus = "failed")), NOW).single().reason)
+    }
+
+    @Test fun healthy_success_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000))), NOW).isEmpty())
+    }
+
+    @Test fun enabled_past_due_beyond_grace_is_OVERDUE() {
+        assertEquals(CronAlertReason.OVERDUE, needsAttention(listOf(job(nextRunAt = iso(NOW - 10 * 60_000))), NOW).single().reason)
+    }
+
+    @Test fun future_next_run_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW + 60 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun within_grace_is_not_overdue() {
+        assertTrue(needsAttention(listOf(job(nextRunAt = iso(NOW - 2 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_or_disabled_not_failed_has_no_alert() {
+        assertTrue(needsAttention(listOf(job(enabled = false, nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+        assertTrue(needsAttention(listOf(job(state = "paused", nextRunAt = iso(NOW - 10 * 60_000))), NOW).isEmpty())
+    }
+
+    @Test fun paused_but_failed_still_shows_FAILED() {
+        assertEquals(CronAlertReason.FAILED, needsAttention(listOf(job(state = "paused", lastStatus = "error")), NOW).single().reason)
+    }
+
+    @Test fun failed_and_past_due_is_a_single_FAILED() {
+        val alerts = needsAttention(listOf(job(lastStatus = "error", nextRunAt = iso(NOW - 10 * 60_000))), NOW)
+        assertEquals(1, alerts.size)
+        assertEquals(CronAlertReason.FAILED, alerts.single().reason)
+    }
+
+    @Test fun name_falls_back_to_id_and_route_is_cron_detail() {
+        val a = needsAttention(listOf(job(id = "abc", name = "  ", lastStatus = "error")), NOW).single()
+        assertEquals("abc", a.name)
+        assertEquals("cron_detail/abc", a.route)
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NeedsYouTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `needsAttention`/`CronAlert`/`CronAlertReason`.
+
+- [ ] **Step 3: Implement `NeedsYou.kt`**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.util.isoToEpochMs
+
+enum class CronAlertReason { FAILED, OVERDUE }
+
+data class CronAlert(
+    val jobId: String,
+    val name: String,
+    val reason: CronAlertReason,
+    val route: String,
+)
+
+/** Default grace before an un-run scheduled job counts as overdue. */
+const val NEEDS_YOU_GRACE_MS = 5 * 60_000L
+
+/**
+ * Cron jobs needing attention. FAILED (last run errored) takes priority — a broken job matters even
+ * if paused/disabled. Else OVERDUE: an enabled, non-paused job whose next run is more than [graceMs]
+ * past due. Pure — [nowMs] passed in so it unit-tests without a clock.
+ */
+fun needsAttention(
+    crons: List<CronJobDto>,
+    nowMs: Long,
+    graceMs: Long = NEEDS_YOU_GRACE_MS,
+): List<CronAlert> = crons.mapNotNull { job ->
+    val name = job.name?.ifBlank { null } ?: job.id
+    val route = "cron_detail/${job.id}"
+    val failed = job.lastStatus.equals("error", ignoreCase = true) ||
+        job.lastStatus.equals("failed", ignoreCase = true)
+    when {
+        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route)
+        job.enabled && !job.isPaused -> {
+            val next = isoToEpochMs(job.nextRunAt)
+            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route) else null
+        }
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NeedsYouTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
+git commit -m "feat(activity): pure needsAttention (failed/overdue cron) with tests"
+```
+
+---
+
+### Task 2: Surface `needsYou` on the ViewModel state
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt`
+
+**Interfaces:**
+- Consumes: `needsAttention` / `CronAlert` (Task 1).
+- Produces: `MissionControlState.needsYou: List<CronAlert>`.
+
+- [ ] **Step 1: Add `needsYou` to `MissionControlState`**
+
+```kotlin
+data class MissionControlState(
+    val sections: List<ActivitySection> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val unauthorized: Boolean = false,
+    val needsYou: List<CronAlert> = emptyList(),
+)
+```
+
+- [ ] **Step 2: Compute it in `loadInner`'s success branch**
+
+In `loadInner`, the success path currently reads:
+
+```kotlin
+            val items = sessionsToActivity(scoped) + cronsToActivity(crons)
+            _state.value = MissionControlState(sections = groupActivity(items, System.currentTimeMillis()))
+```
+
+Replace with (compute `now` once; derive `needsYou` from the already-fetched `crons`):
+
+```kotlin
+            val now = System.currentTimeMillis()
+            val items = sessionsToActivity(scoped) + cronsToActivity(crons)
+            _state.value = MissionControlState(
+                sections = groupActivity(items, now),
+                needsYou = needsAttention(crons, now),
+            )
+```
+
+Leave the `catch (HermesApiException)` / `catch (Exception)` branches unchanged (they build a `MissionControlState` without `needsYou`, so it defaults to empty).
+
+- [ ] **Step 3: Compile + full unit suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+git commit -m "feat(activity): expose needsYou cron alerts on MissionControl state"
+```
+
+---
+
+### Task 3: Render the "Needs you" section + rename header
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+**Interfaces:**
+- Consumes: `MissionControlState.needsYou` (Task 2); `CronAlert`/`CronAlertReason` (Task 1); existing `SectionHeader`, `onOpen`.
+
+- [ ] **Step 1: Rename the header**
+
+Change (line ~119):
+
+```kotlin
+                    HermesTopBar(title = "Agent Activity", subtitle = currentProfile?.let { "Profile: $it" })
+```
+
+to:
+
+```kotlin
+                    HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })
+```
+
+- [ ] **Step 2: Add the "Needs you" section to `MissionControlContent`**
+
+In `MissionControlContent`'s `LazyColumn`, immediately **after** the `item(key = "quicklinks") { … }` block and **before** the `when { … }`, add:
+
+```kotlin
+        if (state.needsYou.isNotEmpty()) {
+            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size) }
+            items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+                NeedsYouRow(alert, onClick = { onOpen(alert.route) })
+            }
+        }
+```
+
+- [ ] **Step 3: Add the `NeedsYouRow` composable**
+
+Add near `ActivityRow`:
+
+```kotlin
+@Composable
+private fun NeedsYouRow(alert: CronAlert, onClick: () -> Unit) {
+    ListItem(
+        leadingContent = {
+            Icon(Icons.Rounded.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+        },
+        headlineContent = { Text(alert.name) },
+        supportingContent = {
+            Text(
+                when (alert.reason) {
+                    CronAlertReason.FAILED -> "Last run failed"
+                    CronAlertReason.OVERDUE -> "Overdue"
+                },
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
+```
+
+`Icons.Rounded.ErrorOutline`, `ListItem`, `Icon`, `Text`, `MaterialTheme`, `Modifier.clickable` are already imported/used by `ActivityRow` in this file — add any that the compiler reports missing.
+
+- [ ] **Step 4: Compile + full unit suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(activity): Needs-you strip on Home; rename header to Home"
+```
+
+---
+
+### Task 4: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install the beta**
+
+Run `./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point it at a gateway with a **failed** cron job (`last_status` = error) or an **overdue** one (enabled, `next_run_at` in the past). The mock at `http://10.0.2.2:8899` can be given such a job.
+
+- [ ] **Step 2: Verify**
+
+- Home header reads **"Home"** (not "Agent Activity").
+- A profile with a failed/overdue cron shows a red **"Needs you"** section at the **top** of the feed; each row shows the job name + "Last run failed"/"Overdue"; tapping opens **cron detail**.
+- A profile with only healthy cron shows **no** "Needs you" section.
+- Background the app + resume → the strip refreshes (via the existing `ON_RESUME` reload).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(activity): needs-you verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure `needsAttention` — FAILED (error/failed, priority, even paused/disabled), OVERDUE (enabled + !paused + past-grace), name fallback, route, `graceMs=5min`, unit-tested (Task 1) ✓; `MissionControlState.needsYou` computed from the fetched `crons` on the success branch, empty on error/unauthorized (Task 2) ✓; top "Needs you" section (only when non-empty) with `SectionHeader` + `NeedsYouRow` (error-tinted, name, reason text, tap → cron_detail) (Task 3) ✓; header rename → "Home" (Task 3 Step 1) ✓; auto-refresh via existing `ON_RESUME` (unchanged) ✓; on-device incl. healthy-profile-no-strip + resume (Task 4) ✓; cron-only/per-profile, no new endpoint ✓.
+- **Placeholder scan:** every code step has full before/after; the only conditional is the Task 4 verification-only commit and "add any imports the compiler reports missing."
+- **Type consistency:** `needsAttention(crons, nowMs, graceMs)`, `CronAlert(jobId, name, reason, route)`, `CronAlertReason.{FAILED,OVERDUE}`, `MissionControlState.needsYou`, and `NeedsYouRow(alert, onClick)` are consistent across Tasks 1–3. `CronJobDto(id, name, enabled, state, pausedAt, nextRunAt, lastStatus)` + `isPaused` + `isoToEpochMs` match the app.
+
+**Ordering note:** Task 1 (pure) stands alone. Task 2 depends on Task 1. Task 3 depends on Tasks 1 + 2. Task 4 verifies on-device.

--- a/docs/superpowers/specs/2026-07-04-cron-response-inline-design.md
+++ b/docs/superpowers/specs/2026-07-04-cron-response-inline-design.md
@@ -1,0 +1,91 @@
+# Cron Response Inline (Agent Activity) — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/cron-response-inline`
+**Parent idea:** `docs/ideas/activity-home-and-cron-response.md` (Piece 1 — ship first)
+
+## Goal
+
+In the Agent Activity (Mission Control) feed, tapping a **cron run** expands its **response** — the run's final assistant message — **inline**, so you see what the scheduled job answered without opening the full transcript. A "View full chat" link inside the expanded card still opens the complete session. **No gateway/bridge changes.**
+
+## Interaction (decided: response-first)
+
+- Tapping a **cron-run row** expands/collapses its response inline (response-first — the response is the primary thing).
+- The expanded card carries a **"View full chat"** affordance that navigates to the full transcript (`chat/<id>`, today's behavior).
+- **Only cron runs expand.** Conversation rows and **upcoming** cron next-runs keep today's behavior (tap → navigate to their `route`).
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Reuse `SessionRepository.history(sessionId, profile)` (REST `GET /api/sessions/<id>/messages`).
+- Follow existing patterns: pure unit-tested logic (like `ActivityModels`/`sessionsToActivity`), Hilt VM, Material3 `ListItem` feed rows.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `MissionControlViewModel` (Hilt): injects `SessionRepository sessions`, `ToolsRepository tools`, `ProfileManager`; exposes `state: StateFlow<MissionControlState>` of `ActivitySection`/`ActivityItem`; `load/refresh`, and `switchTo(profile)`.
+- `ActivityItem(id, kind: CONVERSATION|CRON, title, subtitle, timestampMs, upcoming, status, route)`. Cron **runs** come from `sessionsToActivity` (source="cron" sessions → `kind=CRON`, `route="chat/<id>"`, `upcoming=false`); cron **next-runs** come from `cronsToActivity` (`upcoming=true`, `route="cron_detail/<id>"`).
+- `SessionRepository.history(sessionId, profile): List<ChatMessage>` — REST, no socket.
+- `ChatMessage(id, role: USER|ASSISTANT|SYSTEM, text, tools: List<ToolCall>, thinking, …)`; `ToolCall(id, name, status, output)`.
+- `MissionControlScreen`: `LazyColumn` → `items(section.items){ ActivityRow(item, nowMs, onClick = { onOpen(item.route) }) }`; `onOpen(route)` awaits `vm.switchTo(profile)` then `onNavigate(route)`. `ActivityRow` is a Material3 `ListItem`.
+
+## Architecture
+
+Add a small pure extractor, a lazy per-run response loader on the VM, an `ActivityItem.sessionId`, and inline expansion in the feed row. Each unit is independently testable.
+
+### Components
+
+1. **Pure `cronResponse(messages: List<ChatMessage>): String`** — `app/src/main/java/com/hermes/client/ui/activity/CronResponse.kt`. The unit-tested core.
+   - Last message with `role == Role.ASSISTANT && text.isNotBlank()` → its `text.trim()`.
+   - Else the last message that has a tool with non-blank `output` → `"${tool.name}: ${tool.output.trim()}"` truncated to a summary length (`MAX = 500` chars, ellipsis if longer).
+   - Else `"No text output."`.
+
+2. **`ActivityItem.sessionId: String? = null`** — `ActivityModels.kt`. Set to the raw session id in `sessionsToActivity` (`sessionId = s.id`). Left null by `cronsToActivity`. Expansion is offered only when `kind == ActivityKind.CRON && sessionId != null && !upcoming`.
+
+3. **`MissionControlViewModel` — lazy response loader.**
+   - `data class CronResponseUi(val loading: Boolean = false, val text: String? = null, val error: Boolean = false)`.
+   - `private val _responses = MutableStateFlow<Map<String, CronResponseUi>>(emptyMap())`; `val responses: StateFlow<Map<String, CronResponseUi>>` keyed by **sessionId**.
+   - `fun loadResponse(sessionId: String)`: if the map already has a non-loading success/entry for it, return (cache). Else set `loading=true`; `viewModelScope.launch { runCatching { sessions.history(sessionId, profile) }.onSuccess { put(sessionId, CronResponseUi(text = cronResponse(it))) }.onFailure { put(sessionId, CronResponseUi(error = true)) } }`. A retry clears the errored entry and re-calls.
+   - Uses the VM's existing `profile` field; no profile switch needed to *read* history (the REST call takes the profile param), but the "View full chat" navigation reuses the existing `onOpen`/`switchTo` path.
+
+4. **`MissionControlScreen` — inline expansion.**
+   - Expansion state: `val expanded = remember { mutableStateMapOf<String, Boolean>() }` in `MissionControlPage`, keyed by `ActivityItem.id`. Collect `vm.responses` as state.
+   - `ActivityRow` gains: `expandable: Boolean`, `isExpanded: Boolean`, `response: CronResponseUi?`, `onToggle: () -> Unit`, `onOpenFull: () -> Unit`. For an expandable item, the row's `onClick` calls `onToggle` (and on first expand, `vm.loadResponse(sessionId)`); a trailing chevron rotates with state. Non-expandable rows keep `onClick = onOpen(route)`.
+   - Expanded content (below the row): `loading` → a small `CircularProgressIndicator`; `error` → "Couldn't load response" + a "Retry" text button; else the response `text` in a card (selectable, capped height with internal scroll), followed by a **"View full chat"** text button → `onOpen(item.route)`.
+
+### Data flow
+
+```
+tap cron-run row → toggle expanded[item.id]
+   on first expand → vm.loadResponse(sessionId)
+      → sessions.history(sessionId, profile)  [REST]
+      → cronResponse(messages)  [pure]
+      → _responses[sessionId] = CronResponseUi(text=…)   (or error=true)
+   screen renders responses[sessionId]: spinner | error+retry | text
+"View full chat" → onOpen("chat/<id>")  → switchTo(profile) + navigate  (unchanged)
+```
+
+## Error handling
+
+- **History fetch fails:** `CronResponseUi(error = true)` → inline "Couldn't load response" + Retry (clears the entry and re-calls). The feed itself is unaffected.
+- **Empty / non-text run:** the fallback chain yields the tool-result summary or "No text output." — never a blank card.
+- **Rapid expand/collapse:** the response is cached by sessionId, so re-expanding doesn't refetch; an in-flight load isn't re-launched (guard on `loading`).
+- **Profile:** history is read with the VM's `profile` param; opening the full chat still routes through the existing `switchTo` so the chat screen acts on the right per-profile DB.
+
+## Testing
+
+- **Unit (pure), TDD — `CronResponseTest`:** assistant-text case (picks the **last** assistant message when several); tool-only fallback (`"name: output"`, and truncation past `MAX`); empty list → "No text output."; a run whose only assistant messages are blank → falls through to tool/none.
+- **Unit — `MissionControlViewModel` response loader:** `loadResponse` sets `loading` then `text` on success and `error` on failure (mock `SessionRepository.history`); a second `loadResponse` for the same sessionId does **not** refetch (verify one `history` call).
+- **On-device:** in Agent Activity, tap a cron run → response expands inline (spinner → text); "View full chat" opens the transcript; tapping a conversation or an upcoming cron next-run navigates as before; a failing history fetch shows the error + Retry.
+
+## Not doing (YAGNI)
+
+- Expanding **conversation** rows or **upcoming** cron next-runs (cron runs only).
+- Threading the Product/Technical toggle through this view — the response is the assistant's **text**, inherently payload-free; the toggle still governs the full transcript.
+- Pre-fetching responses for the whole feed (lazy on expand only).
+- Streaming/live updates of a running cron's partial output (show the stored final message).
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Exact truncation length for the tool-result fallback (`MAX = 500` proposed) and response card max height before internal scroll.

--- a/docs/superpowers/specs/2026-07-04-home-landing-design.md
+++ b/docs/superpowers/specs/2026-07-04-home-landing-design.md
@@ -1,0 +1,76 @@
+# Home Landing (2a) — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/home-landing`
+**Parent idea:** `docs/ideas/activity-home-and-cron-response.md` (Piece 2, sub-piece 2a — ship first)
+
+## Goal
+
+Open the app to the **Home** tab (today's Mission Control activity feed) instead of the Sessions list, and lead the bottom nav with Home — so a cold launch lands on *what's happening*, never a resumed stale surface. The "Needs you" strip is a later sub-piece (2b).
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Pure navigation-config change.
+- Follow existing patterns (the `HermesNav` `TABS` list + `NavHost`).
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `HermesNav.kt`: `private data class Tab(route, label, icon)`; `TABS = [Tab("sessions","Chats",Chat), Tab("activity","Agent Activity",Bolt), Tab("you","You",Person)]`; `val start = if (hasConfig) "sessions" else "setup"`; a bottom `NavigationBar` rendering `TABS`; `composable("activity") { MissionControlScreen(...) }`.
+- Post-setup jump (line ~126): `nav.navigate("sessions") { popUpTo("setup") { inclusive = true } }`.
+- Notification deep-link: `MainActivity` reads `extra_route` → `pendingRoute` → `HermesNav`'s `LaunchedEffect(deepLinkRoute) { nav.navigate(it) }` — navigates **on top of** the start destination.
+- The "New" FAB (`SessionsScreen`) uses `vm.createSession()`, already scoped to the active/selected profile — decision (f) ("New chat → last-used profile") needs no change and is out of scope here.
+
+## Architecture / changes (all in `HermesNav.kt`)
+
+1. **Reorder + relabel `TABS`** to lead with Home:
+   ```kotlin
+   private val TABS = listOf(
+       Tab("activity", "Home", Icons.Rounded.Home),
+       Tab("sessions", "Chats", Icons.AutoMirrored.Rounded.Chat),
+       Tab("you", "You", Icons.Rounded.Person),
+   )
+   ```
+   (Relabel `"Agent Activity"` → `"Home"`; swap the tab's `Icons.Rounded.Bolt` for `Icons.Rounded.Home`. Add the `Home` icon import.)
+
+2. **Start destination** → land on Home when configured:
+   ```kotlin
+   val start = if (hasConfig) "activity" else "setup"
+   ```
+
+3. **Post-setup nav** → also land on Home after fresh setup:
+   ```kotlin
+   nav.navigate("activity") { popUpTo("setup") { inclusive = true } }
+   ```
+
+No change to the `MissionControlScreen` composable, the deep-link rail, `SessionsScreen`, or any repository.
+
+## Data flow
+
+```
+cold launch (configured) → start = "activity" → Home (Mission Control feed)
+notification tap → extra_route="chat/<id>" → pendingRoute → navigate on top → the session (unchanged)
+setup complete → navigate("activity") → Home
+bottom nav order → Home · Chats · You  (Home selected at launch)
+```
+
+## Error handling
+
+- Not configured → `start = "setup"` (unchanged).
+- The `MissionControlScreen` already handles its own loading/empty/error states for the feed; landing there adds no new failure mode.
+
+## Testing
+
+Navigation-config change with no new pure logic. Verified **on-device**:
+- Cold launch (configured) lands on **Home** (the activity feed), with the bottom nav reading **Home · Chats · You** and **Home** selected.
+- A notification tap still opens its `chat/<id>` (deep-link on top of Home).
+- **Chats** tab still shows the Sessions list; its **New** FAB still creates + opens a session.
+- Fresh setup completes onto **Home** (not the Sessions list).
+
+## Not doing (YAGNI)
+
+- The "Needs you" strip (sub-piece 2b).
+- Approvals / messaging-pairing data, or any new endpoint.
+- Any change to the "New" FAB / new-chat profile logic (existing behavior already satisfies decision (f)).
+- Renaming the `"activity"` route id (only the visible label changes; keeping the route id avoids churn in the deep-link/nav wiring).

--- a/docs/superpowers/specs/2026-07-04-needs-you-design.md
+++ b/docs/superpowers/specs/2026-07-04-needs-you-design.md
@@ -1,0 +1,95 @@
+# "Needs you" strip (2b) + Home header — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/needs-you`
+**Parent idea:** `docs/ideas/activity-home-and-cron-response.md` (Piece 2, sub-piece 2b)
+
+## Goal
+
+Add a compact **"Needs you"** strip to the top of the Home (Mission Control) feed that surfaces cron jobs needing attention — **failed** or **overdue** — for the current profile, and rename the Home screen's header from "Agent Activity" to **"Home"**. **No gateway/bridge changes** (reuses the cron list the feed already fetches).
+
+## Decided
+
+- "Needs you" flags **failed + overdue** cron (per the user): failed = last run errored; overdue = an enabled, non-paused job whose next run is >5 min past due.
+- **Cron-only** (messaging `/api/pairing` isn't wired in the app; approvals are WS-only) — established in the idea doc.
+- **Per-profile** (matches the existing per-profile feed pager).
+- Auto-refresh on resume is **already provided** by the feed's `LifecycleEventEffect(ON_RESUME) { vm.refresh() }`.
+
+## Hard constraints
+
+- **No bridge/gateway API changes.** Reuse `ToolsRepository.cronJobs(profile)` (already called in `loadInner`).
+- Follow existing patterns: pure unit-tested logic (like `cronsToActivity`), `MissionControlState`, Material3 rows.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## What the app already provides (grounding)
+
+- `MissionControlViewModel.loadInner`: fetches `val crons = runCatching { tools.cronJobs(profile) }.getOrDefault(emptyList())`, builds `sessionsToActivity(scoped) + cronsToActivity(crons)`, then `_state.value = MissionControlState(sections = groupActivity(items, now))`.
+- `MissionControlState(sections, loading, error, unauthorized)`.
+- `CronJobDto(id, name, enabled, state, pausedAt, nextRunAt, lastRunAt, lastStatus, lastError, …)`; computed `val isPaused = pausedAt != null || state == "paused"`; `val scheduleText`.
+- `isoToEpochMs(iso: String?): Long?` (`com.hermes.client.ui.util`).
+- `MissionControlScreen`: per-profile pager; top bar `HermesTopBar(title = "Agent Activity", subtitle = currentProfile?.let { "Profile: $it" })` (line ~119); `MissionControlContent` renders a `LazyColumn` (quicklinks item, then sections); `onOpen(route)` awaits `switchTo(profile)` + `onNavigate(route)`.
+- `cron_detail/<id>` is a registered route.
+
+## Architecture
+
+Add a pure alert-deriver, surface its result on the VM state, render a top section on the feed, and rename the header. Each unit is small + independently testable.
+
+### Components
+
+1. **Pure `needsAttention(crons: List<CronJobDto>, nowMs: Long, graceMs: Long = 5 * 60_000L): List<CronAlert>`** — `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt`. The unit-tested core.
+   - `enum class CronAlertReason { FAILED, OVERDUE }`.
+   - `data class CronAlert(val jobId: String, val name: String, val reason: CronAlertReason, val route: String)`.
+   - For each job:
+     - **FAILED** if `lastStatus.equals("error", true) || lastStatus.equals("failed", true)`.
+     - else **OVERDUE** if `enabled && !isPaused && nextRunAt != null && isoToEpochMs(nextRunAt)` is non-null and `< nowMs - graceMs`.
+     - else no alert.
+   - Failed takes priority (a job is at most one alert). Skip paused/disabled jobs for OVERDUE (but a **disabled/paused** job that *failed* still shows FAILED — a broken job matters regardless of whether it's scheduled again; matches "last run errored").
+   - `name = job.name?.ifBlank { null } ?: job.id` (same as `cronsToActivity`); `route = "cron_detail/${job.id}"`.
+
+2. **`MissionControlState.needsYou: List<CronAlert> = emptyList()`** — computed in `loadInner`:
+   `_state.value = MissionControlState(sections = groupActivity(items, now), needsYou = needsAttention(crons, now))`. (The error/unauthorized branches leave `needsYou` empty, as today.)
+
+3. **`MissionControlContent` — "Needs you" section** at the top of the `LazyColumn`, **after** the quicklinks item and **before** the `when { … sections … }`, rendered only when `state.needsYou.isNotEmpty()`:
+   - A `SectionHeader("Needs you", state.needsYou.size)` (reuse the existing header composable).
+   - `items(state.needsYou, key = { "needs-${it.jobId}" }) { alert -> NeedsYouRow(alert, onClick = { onOpen(alert.route) }) }`.
+   - **`NeedsYouRow`:** a Material3 `ListItem` — leading `Icons.Rounded.ErrorOutline` tinted `colorScheme.error`; headline `alert.name`; supporting `when (alert.reason) { FAILED -> "Last run failed"; OVERDUE -> "Overdue" }`; `Modifier.clickable(onClick)`.
+
+4. **Header rename** — `HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })`.
+
+### Data flow
+
+```
+feed load / ON_RESUME refresh → loadInner → tools.cronJobs(profile)
+  → needsAttention(crons, now) → MissionControlState.needsYou
+  → MissionControlContent renders "Needs you" section on top (when non-empty)
+  → tap an alert → onOpen("cron_detail/<id>") → switchTo(profile) + navigate  (existing)
+top bar → "Home"
+```
+
+## Error handling
+
+- A cron fetch failure already degrades gracefully (`getOrDefault(emptyList())`) → `needsAttention([]) = []` → no strip; the conversation feed still renders.
+- `isoToEpochMs` returns null for unparseable/absent `nextRunAt` → that job is simply not OVERDUE.
+- The feed's own loading/error/empty states are unchanged; the strip is additive.
+
+## Testing
+
+- **Unit (pure), TDD — `NeedsYouTest`:**
+  - failed (`lastStatus="error"` and `"failed"`) → FAILED alert; healthy (`"success"`) → none.
+  - overdue: enabled, not paused, `nextRunAt` 10 min in the past → OVERDUE; `nextRunAt` in the future → none; within grace (2 min past) → none.
+  - paused/disabled job that is NOT failed → no alert (not OVERDUE); paused/disabled job that **failed** → FAILED.
+  - failed **and** past-due → a single FAILED alert (priority), not two.
+  - `name` falls back to `jobId` when name blank/null; `route == "cron_detail/<id>"`.
+- **On-device:** a profile with a failed cron shows a red "Needs you" strip at the top; tapping it opens the job detail; a healthy profile shows no strip; the header reads **"Home"**; backgrounding + resuming refreshes the strip.
+
+## Not doing (YAGNI)
+
+- Messaging-pairing or approvals in "Needs you" (unavailable; see idea doc).
+- A cross-profile aggregated strip (stays per-profile with the pager).
+- Dismiss/snooze/ack of alerts, or a badge on the Home tab.
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Grace window for OVERDUE (`5 min` proposed) — a pure `graceMs` param, trivially tunable.


### PR DESCRIPTION
## Promote develop → main (production 0.1.31)

Promotes three beta-channel releases to production. main was last at 0.1.28 (#49).

### What ships to production
- **0.1.29** — Cron response inline: tap a cron run in the Home feed to expand its final response inline (no full transcript needed).
- **0.1.30** — Home landing: the app opens to the **Home** tab (Home · Chats · You); notification taps still deep-link. **Includes a launch-crash fix** — the MissionControl profile pager's unsafe `names[page]` indexing during the async profile load (latent since 0.1.28) is hardened to `getOrNull`.
- **0.1.31** — "Needs you" strip + header: a red section pins failed/overdue cron to the top of Home, deduped from the feed; the Home header reads "Home".

All built via spec → plan → subagent-driven development with per-task and opus final whole-branch reviews, shipped/verified on the beta channel. No bridge/gateway API changes across the set.
