### PR TITLE
UX quick wins: styled error states, per-tenant accent, model chip, cron status, composer token

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -256,7 +256,7 @@ private fun SectionHeader(label: String, count: Int) {
         Text(
             label.uppercase(),
             style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.primary,
+            color = LocalProfileAccent.current.accent,
             modifier = Modifier.weight(1f),
         )
         Text(
@@ -308,7 +308,7 @@ private fun ActivityRow(
     val tint = when {
         item.status.equals("error", ignoreCase = true) ||
             item.status.equals("failed", ignoreCase = true) -> MaterialTheme.colorScheme.error
-        else -> MaterialTheme.colorScheme.primary
+        else -> LocalProfileAccent.current.accent
     }
     val time = relativeTime(item.timestampMs, nowMs)
     Column {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -351,7 +352,7 @@ private fun ToolCard(tool: ToolCall) {
                     if (tool.status == ToolStatus.RUNNING) Icons.Rounded.PlayArrow else Icons.Rounded.Check,
                     contentDescription = null,
                     modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = LocalProfileAccent.current.accent,
                 )
                 Text(
                     text = if (tool.status == ToolStatus.RUNNING) "${tool.name}…" else tool.name,

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -165,6 +165,8 @@ fun ChatScreen(
                     .padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                com.hermes.client.ui.components.ProfileAvatar(activeProfile)
+                Spacer(Modifier.width(4.dp))
                 IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) {
                     Icon(Icons.Rounded.AttachFile, contentDescription = "Attach image")
                 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -22,9 +23,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
+import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.AttachFile
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -135,11 +138,17 @@ fun ChatScreen(
                     }
                 },
                 actions = {
-                    if (providers.isNotEmpty()) {
-                        androidx.compose.material3.TextButton(onClick = { modelSheetOpen = true }) {
-                            Text(currentModel ?: "Model", maxLines = 1)
-                        }
-                    }
+                    AssistChip(
+                        onClick = { modelSheetOpen = true },
+                        label = { Text(currentModel ?: "Model", maxLines = 1) },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Rounded.ArrowDropDown,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        },
+                    )
                     StatusDot(connState)
                 },
             )

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.material3.OutlinedTextField
@@ -194,7 +195,7 @@ fun ChatScreen(
                 Text(
                     "COMMANDS",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = LocalProfileAccent.current.accent,
                     modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
                 )
                 LazyColumn(Modifier.weight(1f).fillMaxWidth()) {
@@ -211,7 +212,7 @@ fun ChatScreen(
                 Text(
                     "ATTACH / MENTION",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = LocalProfileAccent.current.accent,
                     modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
                 )
                 LazyColumn(Modifier.weight(1f).fillMaxWidth()) {

--- a/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
@@ -23,6 +23,10 @@ fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp
         modifier.size(size).clip(CircleShape).background(accent.accent),
         contentAlignment = Alignment.Center,
     ) {
-        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+        Text(
+            (name ?: "·").take(1).uppercase(),
+            color = accent.onAccent,
+            style = if (size >= 40.dp) MaterialTheme.typography.titleMedium else MaterialTheme.typography.labelLarge,
+        )
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
@@ -1,0 +1,28 @@
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.rememberProfileAccent
+
+/** A lettered, per-tenant-coloured avatar token (the profile's initial in its accent). */
+@Composable
+fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
+    val accent = rememberProfileAccent(name, isSystemInDarkTheme())
+    Box(
+        modifier.size(size).clip(CircleShape).background(accent.accent),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -116,7 +117,7 @@ fun CronDetailScreen(
                             job.prompt?.takeIf { it.isNotBlank() }?.let {
                                 Spacer(Modifier.padding(top = 12.dp))
                                 Text("PROMPT", style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.primary)
+                                    color = LocalProfileAccent.current.accent)
                                 Text(it, style = MaterialTheme.typography.bodySmall, maxLines = 8,
                                     overflow = TextOverflow.Ellipsis)
                             }
@@ -124,7 +125,7 @@ fun CronDetailScreen(
                         Text(
                             "RUN HISTORY (${state.runs.size})",
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = LocalProfileAccent.current.accent,
                             modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
                         )
                     }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -74,7 +74,11 @@ fun CronDetailScreen(
     ) { padding ->
         when {
             state.loading -> com.hermes.client.ui.components.LoadingState()
-            state.job == null -> Text(state.error ?: "Not found", Modifier.padding(padding).padding(24.dp))
+            state.job == null -> com.hermes.client.ui.components.ErrorState(
+                message = state.error ?: "Couldn't load this cron job",
+                modifier = Modifier.padding(padding).fillMaxSize(),
+                onRetry = { vm.load(jobId) },
+            )
             else -> {
                 val job = state.job!!
                 LazyColumn(Modifier.padding(padding).fillMaxSize()) {

--- a/app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt
@@ -1,0 +1,19 @@
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.activity.CronAlertReason
+import com.hermes.client.ui.activity.needsAttention
+
+enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }
+
+/** Pure: a cron job's at-a-glance status for the list. FAILED (last run errored) takes priority,
+ *  then OVERDUE, then PAUSED (disabled/paused), else OK. Reuses [needsAttention]. */
+fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus {
+    val alert = needsAttention(listOf(job), nowMs).firstOrNull()
+    return when {
+        alert?.reason == CronAlertReason.FAILED -> CronRowStatus.FAILED
+        alert?.reason == CronAlertReason.OVERDUE -> CronRowStatus.OVERDUE
+        !job.enabled || job.isPaused -> CronRowStatus.PAUSED
+        else -> CronRowStatus.OK
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -51,11 +50,12 @@ fun CronScreen(
         Box(Modifier.padding(padding).fillMaxSize()) {
             when {
                 state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
-                state.jobs.isEmpty() -> Text(
-                    "No cron jobs for this profile.",
-                    Modifier.align(Alignment.Center),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+                state.jobs.isEmpty() -> com.hermes.client.ui.components.EmptyState(
+                    title = "No cron jobs",
+                    subtitle = "Scheduled jobs for this profile will show up here.",
                 )
                 else -> LazyColumn(Modifier.fillMaxSize()) {
                     items(state.jobs, key = { it.id }) { job ->

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -67,7 +68,7 @@ fun CronScreen(
                                         !job.enabled -> "  · disabled"
                                         else -> ""
                                     },
-                                    color = if (job.enabled && !job.isPaused) MaterialTheme.colorScheme.primary
+                                    color = if (job.enabled && !job.isPaused) LocalProfileAccent.current.accent
                                     else MaterialTheme.colorScheme.error,
                                 )
                             },

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -7,8 +7,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.PauseCircleOutline
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -17,6 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -58,28 +64,42 @@ fun CronScreen(
                     title = "No cron jobs",
                     subtitle = "Scheduled jobs for this profile will show up here.",
                 )
-                else -> LazyColumn(Modifier.fillMaxSize()) {
-                    items(state.jobs, key = { it.id }) { job ->
-                        ListItem(
-                            overlineContent = {
-                                Text(
-                                    job.scheduleText + when {
-                                        job.isPaused -> "  · paused"
-                                        !job.enabled -> "  · disabled"
-                                        else -> ""
-                                    },
-                                    color = if (job.enabled && !job.isPaused) LocalProfileAccent.current.accent
-                                    else MaterialTheme.colorScheme.error,
-                                )
-                            },
-                            headlineContent = { Text(job.name ?: job.id) },
-                            supportingContent = {
-                                val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
-                                Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())
-                            },
-                            modifier = Modifier.clickable { onOpen(job.id) },
-                        )
-                        HorizontalDivider()
+                else -> {
+                    val nowMs = remember(state.jobs) { System.currentTimeMillis() }
+                    LazyColumn(Modifier.fillMaxSize()) {
+                        items(state.jobs, key = { it.id }) { job ->
+                            ListItem(
+                                leadingContent = {
+                                    val (icon, tint) = when (cronRowStatus(job, nowMs)) {
+                                        CronRowStatus.FAILED, CronRowStatus.OVERDUE ->
+                                            Icons.Rounded.ErrorOutline to MaterialTheme.colorScheme.error
+                                        CronRowStatus.PAUSED ->
+                                            Icons.Rounded.PauseCircleOutline to MaterialTheme.colorScheme.onSurfaceVariant
+                                        CronRowStatus.OK ->
+                                            Icons.Rounded.CheckCircle to com.hermes.client.ui.theme.LocalProfileAccent.current.accent
+                                    }
+                                    Icon(icon, contentDescription = null, tint = tint)
+                                },
+                                overlineContent = {
+                                    Text(
+                                        job.scheduleText + when {
+                                            job.isPaused -> "  · paused"
+                                            !job.enabled -> "  · disabled"
+                                            else -> ""
+                                        },
+                                        color = if (job.enabled && !job.isPaused) LocalProfileAccent.current.accent
+                                        else MaterialTheme.colorScheme.error,
+                                    )
+                                },
+                                headlineContent = { Text(job.name ?: job.id) },
+                                supportingContent = {
+                                    val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
+                                    Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())
+                                },
+                                modifier = Modifier.clickable { onOpen(job.id) },
+                            )
+                            HorizontalDivider()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/hermes/client/ui/models/ModelSelector.kt
+++ b/app/src/main/java/com/hermes/client/ui/models/ModelSelector.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
@@ -145,7 +146,7 @@ fun ModelSelectorContent(
                     is ModelListItem.Header -> Text(
                         text = item.title + if (item.isCurrent) "  (current)" else "",
                         style = MaterialTheme.typography.titleSmall,
-                        color = if (item.isCurrent) MaterialTheme.colorScheme.primary
+                        color = if (item.isCurrent) LocalProfileAccent.current.accent
                         else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(start = 4.dp, top = 14.dp, bottom = 4.dp),
                     )
@@ -188,7 +189,7 @@ private fun ModelRowItem(
             Icon(
                 imageVector = if (row.isFavorite) Icons.Rounded.Star else Icons.Rounded.StarBorder,
                 contentDescription = if (row.isFavorite) "Unfavorite" else "Favorite",
-                tint = if (row.isFavorite) MaterialTheme.colorScheme.primary
+                tint = if (row.isFavorite) LocalProfileAccent.current.accent
                 else MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.HubRow
 import com.hermes.client.ui.theme.ACCENT_SWATCHES
+import com.hermes.client.ui.theme.LocalProfileAccent
 import com.hermes.client.ui.theme.accentFromHsl
 import com.hermes.client.ui.theme.colorArgbToHsl
 import com.hermes.client.ui.theme.hslToColorArgb
@@ -71,7 +72,7 @@ fun YouHubScreen(
             Text(
                 "PROFILES",
                 style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.primary,
+                color = LocalProfileAccent.current.accent,
                 modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
             )
             ProfileAvatarRow(
@@ -227,7 +228,7 @@ private fun ProfileAvatarRow(profiles: List<String>, active: String?, onSwitch: 
                 Text(
                     name,
                     style = MaterialTheme.typography.labelSmall,
-                    color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (selected) LocalProfileAccent.current.accent else MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                 )
             }

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -51,7 +51,6 @@ import com.hermes.client.ui.theme.LocalProfileAccent
 import com.hermes.client.ui.theme.accentFromHsl
 import com.hermes.client.ui.theme.colorArgbToHsl
 import com.hermes.client.ui.theme.hslToColorArgb
-import com.hermes.client.ui.theme.rememberProfileAccent
 
 /**
  * "You" tab — profile identity + everything about the account/app: the profile quick-switch
@@ -202,29 +201,22 @@ private fun SliderRow(
 /** Quick-switch avatar row: each profile's initial in a chip tinted to that profile's own accent. */
 @Composable
 private fun ProfileAvatarRow(profiles: List<String>, active: String?, onSwitch: (String) -> Unit) {
-    val dark = androidx.compose.foundation.isSystemInDarkTheme()
     Row(
         Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 12.dp, vertical = 4.dp),
     ) {
         profiles.forEach { name ->
             val selected = name == active
-            // Each avatar previews that profile's own accent hue, so the switcher itself teaches
-            // the color mapping.
-            val accent = rememberProfileAccent(name, dark)
+            // Each avatar previews that profile's own accent hue (via ProfileAvatar), so the
+            // switcher itself teaches the color mapping.
             Column(
                 Modifier.padding(end = 12.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Box(
-                    Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                        .background(accent.accent)
-                        .clickable { onSwitch(name) },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(name.take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.titleMedium)
-                }
+                com.hermes.client.ui.components.ProfileAvatar(
+                    name,
+                    modifier = Modifier.clickable { onSwitch(name) },
+                    size = 48.dp,
+                )
                 Text(
                     name,
                     style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
@@ -305,14 +306,14 @@ private fun CollapsibleHeader(
             if (collapsed) Icons.Rounded.ChevronRight else Icons.Rounded.ExpandMore,
             contentDescription = if (collapsed) "Expand" else "Collapse",
             tint = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
-            else MaterialTheme.colorScheme.primary,
+            else LocalProfileAccent.current.accent,
             modifier = Modifier.padding(end = 8.dp).size(18.dp),
         )
         Text(
             if (indent) label else label.uppercase(),
             style = MaterialTheme.typography.labelMedium,
             color = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
-            else MaterialTheme.colorScheme.primary,
+            else LocalProfileAccent.current.accent,
             modifier = Modifier.weight(1f),
         )
         Text(
@@ -332,7 +333,7 @@ private fun SectionHeader(label: String, count: Int, note: String? = null) {
         Text(
             label.uppercase(),
             style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            color = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+            color = LocalProfileAccent.current.accent,
         )
         note?.let {
             Text(
@@ -408,7 +409,7 @@ private fun SessionRow(
                         Icons.Rounded.PushPin,
                         contentDescription = "Pinned",
                         modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = LocalProfileAccent.current.accent,
                     )
                 }
             } else null,

--- a/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -40,7 +39,12 @@ fun AgentsToolsScreen(
         Box(Modifier.padding(padding).fillMaxSize()) {
             when {
                 state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+                state.skills.isEmpty() && state.toolsets.isEmpty() -> com.hermes.client.ui.components.EmptyState(
+                    title = "No agents or tools",
+                )
                 else -> LazyColumn(Modifier.fillMaxSize()) {
                     item { SectionHeader("Skills (${state.skills.size})") }
                     items(state.skills, key = { it.name }) { skill ->

--- a/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hermes.client.ui.theme.LocalProfileAccent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,7 +87,7 @@ private fun SectionHeader(text: String) {
     Text(
         text,
         style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
+        color = LocalProfileAccent.current.accent,
         modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
     )
 }

--- a/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -109,7 +108,9 @@ fun UsageScreen(
         Box(Modifier.padding(padding).fillMaxSize()) {
             when {
                 state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
                 else -> LazyColumn(Modifier.fillMaxSize()) {
                     item {
                         Column(Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -126,13 +127,13 @@ fun UsageScreen(
                             }
                             if (state.daily.isNotEmpty()) {
                                 Text("DAILY TOKENS", style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.primary,
+                                    color = LocalProfileAccent.current.accent,
                                     modifier = Modifier.padding(top = 20.dp, bottom = 8.dp))
                                 DailyTokensChart(state.daily)
                             }
                         }
                         Text("TOP MODELS", style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = LocalProfileAccent.current.accent,
                             modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp))
                     }
                     // No key: model names can repeat across providers (e.g. two "gemma"),

--- a/app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt
@@ -1,0 +1,34 @@
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class CronRowStatusTest {
+    @Test fun failed_last_run_is_FAILED() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(lastStatus = "error"), NOW))
+    }
+    @Test fun overdue_is_OVERDUE() {
+        assertEquals(CronRowStatus.OVERDUE, cronRowStatus(job(nextRunAt = iso(NOW - 10 * 60_000)), NOW))
+    }
+    @Test fun paused_or_disabled_not_failed_is_PAUSED() {
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(state = "paused"), NOW))
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(enabled = false), NOW))
+    }
+    @Test fun healthy_future_is_OK() {
+        assertEquals(CronRowStatus.OK, cronRowStatus(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000)), NOW))
+    }
+    @Test fun failed_takes_priority_over_paused() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(state = "paused", lastStatus = "error"), NOW))
+    }
+}

--- a/docs/superpowers/plans/2026-07-05-ux-quick-wins.md
+++ b/docs/superpowers/plans/2026-07-05-ux-quick-wins.md
@@ -1,0 +1,424 @@
+# UX Quick Wins (batch) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Top-5 UX quick wins — styled error/empty states, full per-tenant accent wiring, a visible model chip, cron status in the list, and a chat-composer tenant token.
+
+**Architecture:** Five independent Compose-only changes over existing infrastructure (`ScreenStates`, `LocalProfileAccent`, `needsAttention`, `ModelSelectorSheet`). One pure helper (`cronRowStatus`) is unit-tested; the rest is verified on-device.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing state/data only. Material 3.
+- Multi-tenant isolation preserved; no unrelated refactors.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt` + test (Task 1).
+- Modify `ui/cron/CronDetailScreen.kt`, `ui/cron/CronScreen.kt`, `ui/tools/AgentsToolsScreen.kt`, `ui/usage/UsageScreen.kt` (Task 2).
+- Modify ~8 screens: `colorScheme.primary` → accent (Task 3).
+- Modify `ui/chat/ChatScreen.kt` (Task 4).
+- Modify `ui/cron/CronScreen.kt` (Task 5).
+- Create `app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt`; modify `ui/chat/ChatScreen.kt`, `ui/nav/YouHubScreen.kt` (Task 6).
+
+---
+
+### Task 1: Pure `cronRowStatus` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt`
+
+**Interfaces:**
+- Consumes: `needsAttention(listOf(job), now)` / `CronAlertReason` from `com.hermes.client.ui.activity` (`ui/activity/NeedsYou.kt`).
+- Produces: `enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }`; `fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class CronRowStatusTest {
+    @Test fun failed_last_run_is_FAILED() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(lastStatus = "error"), NOW))
+    }
+    @Test fun overdue_is_OVERDUE() {
+        assertEquals(CronRowStatus.OVERDUE, cronRowStatus(job(nextRunAt = iso(NOW - 10 * 60_000)), NOW))
+    }
+    @Test fun paused_or_disabled_not_failed_is_PAUSED() {
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(state = "paused"), NOW))
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(enabled = false), NOW))
+    }
+    @Test fun healthy_future_is_OK() {
+        assertEquals(CronRowStatus.OK, cronRowStatus(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000)), NOW))
+    }
+    @Test fun failed_takes_priority_over_paused() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(state = "paused", lastStatus = "error"), NOW))
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronRowStatusTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `cronRowStatus`/`CronRowStatus`.
+
+- [ ] **Step 3: Implement `CronRowStatus.kt`**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.activity.CronAlertReason
+import com.hermes.client.ui.activity.needsAttention
+
+enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }
+
+/** Pure: a cron job's at-a-glance status for the list. FAILED (last run errored) takes priority,
+ *  then OVERDUE, then PAUSED (disabled/paused), else OK. Reuses [needsAttention]. */
+fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus {
+    val alert = needsAttention(listOf(job), nowMs).firstOrNull()
+    return when {
+        alert?.reason == CronAlertReason.FAILED -> CronRowStatus.FAILED
+        alert?.reason == CronAlertReason.OVERDUE -> CronRowStatus.OVERDUE
+        !job.enabled || job.isPaused -> CronRowStatus.PAUSED
+        else -> CronRowStatus.OK
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronRowStatusTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt
+git commit -m "feat(cron): pure cronRowStatus for list status icons"
+```
+
+---
+
+### Task 2: Styled error/empty states (Item 1)
+
+**Files:** Modify `ui/cron/CronDetailScreen.kt`, `ui/cron/CronScreen.kt`, `ui/tools/AgentsToolsScreen.kt`, `ui/usage/UsageScreen.kt`
+
+**Interfaces:** Consumes existing `com.hermes.client.ui.components.{ErrorState, EmptyState}` — `ErrorState(message: String, modifier = Modifier.fillMaxSize(), onRetry: (() -> Unit)? = null)`, `EmptyState(title: String, modifier = …, subtitle: String? = null, …)`.
+
+- [ ] **Step 1: CronDetailScreen** — replace the bare error `Text`
+
+Find `state.job == null -> Text(state.error ?: "Not found", …)` (~line 77) and replace with:
+```kotlin
+                state.job == null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error ?: "Couldn't load this cron job",
+                    onRetry = { vm.load(jobId) },
+                )
+```
+(`jobId` is the composable's nav-arg param, already used in `LaunchedEffect(jobId) { vm.load(jobId) }`.)
+
+- [ ] **Step 2: CronScreen** — error + empty
+
+Replace the `state.error != null -> Text(...)` and `state.jobs.isEmpty() -> Text(...)` branches (~lines 52-59) with:
+```kotlin
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+                state.jobs.isEmpty() -> com.hermes.client.ui.components.EmptyState(
+                    title = "No cron jobs",
+                    subtitle = "Scheduled jobs for this profile will show up here.",
+                )
+```
+
+- [ ] **Step 3: AgentsToolsScreen** — error + empty
+
+Replace `state.error != null -> Text(state.error!!, …)` (~line 42) with:
+```kotlin
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+```
+If there is a "no skills/toolsets" empty case rendered as blank/nothing, add an `EmptyState(title = "No agents or tools")` branch (read the file to place it in the same `when`); if the screen has no empty branch, add one after the error branch guarded on the loaded-but-empty condition it exposes.
+
+- [ ] **Step 4: UsageScreen** — error
+
+Replace `state.error != null -> Text(state.error!!, …)` (~line 111) with:
+```kotlin
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+```
+
+- [ ] **Step 5: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`. (If a bare `Text` sat inside a centering `Box`, the `ErrorState`/`EmptyState` already fill/center themselves — remove any now-redundant `Modifier.align`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+git commit -m "feat(ux): route error/empty screens through shared ScreenStates (icon + Retry)"
+```
+
+---
+
+### Task 3: Wire the per-tenant accent into content (Item 2)
+
+**Files:** Modify (grep each; line numbers are guides): `ui/activity/MissionControlScreen.kt`, `ui/cron/CronScreen.kt`, `ui/cron/CronDetailScreen.kt`, `ui/chat/ChatScreen.kt`, `ui/chat/ChatComponents.kt`, `ui/usage/UsageScreen.kt`, `ui/sessions/SessionsScreen.kt`, `ui/models/ModelSelector.kt`, `ui/nav/YouHubScreen.kt`
+
+**Interfaces:** Consumes `com.hermes.client.ui.theme.LocalProfileAccent` (`.current.accent: Color`, a `@Composable` read). `HermesTheme` provides it app-wide for the active profile; MissionControl re-provides per page.
+
+- [ ] **Step 1: Replace in-content accent colour at each site**
+
+For each file, add `import com.hermes.client.ui.theme.LocalProfileAccent` and replace **in-content accent** uses of `MaterialTheme.colorScheme.primary` with `LocalProfileAccent.current.accent`. The sites (find via `grep -n "colorScheme.primary"` in each file and match the description):
+
+- `MissionControlScreen.kt` — the `SectionHeader` label `color`; the `ActivityRow` non-error icon `tint`.
+- `CronScreen.kt` — the schedule-overline `color` **only in the `job.enabled && !job.isPaused` branch** (keep the `else -> MaterialTheme.colorScheme.error`).
+- `CronDetailScreen.kt` — the "PROMPT" and "RUN HISTORY (…)" label colours.
+- `ChatScreen.kt` — the "COMMANDS" and "ATTACH · MENTION" (or similar) section-label colours.
+- `ChatComponents.kt` — the accent icon `tint = MaterialTheme.colorScheme.primary`.
+- `UsageScreen.kt` — the "DAILY TOKENS" / "TOP MODELS" section-label colours. **Leave the chart `inputColor` as `colorScheme.primary`.**
+- `SessionsScreen.kt` — the group-header chevron `tint`, the group label `color`, the `SectionHeader` label `color`, and the other icon `tint`.
+- `ModelSelector.kt` — the current-model row label `color` and the favourite-star `tint`.
+- `YouHubScreen.kt` — the "PROFILES" section label and the selected-avatar-name label `color`.
+
+Do **NOT** change any `colorScheme.error`, `onSurface`, `onSurfaceVariant`, `surfaceVariant`, etc. — only the enumerated `colorScheme.primary` accent uses.
+
+- [ ] **Step 2: Verify no stray content `colorScheme.primary` remain (beyond the intentionally-left chart)**
+
+Run: `grep -rn "colorScheme.primary" app/src/main/java/com/hermes/client/ui/{activity,cron,chat,usage,sessions,models,nav} 2>/dev/null`
+Expected: only the intentional leave-behinds (Usage chart `inputColor`, and any genuinely-semantic primary you deliberately kept). Note them in the report.
+
+- [ ] **Step 3: Compile + full suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(ux): render in-content accents in the active-tenant colour"
+```
+
+---
+
+### Task 4: Visible model chip in the chat header (Item 3)
+
+**Files:** Modify `ui/chat/ChatScreen.kt`
+
+- [ ] **Step 1: Replace the gated TextButton with an always-visible AssistChip**
+
+In the `HermesTopBar(...)` `actions` slot (~line 136-143), replace:
+```kotlin
+                if (providers.isNotEmpty()) {
+                    androidx.compose.material3.TextButton(onClick = { modelSheetOpen = true }) {
+                        Text(currentModel ?: "Model", maxLines = 1)
+                    }
+                }
+                StatusDot(connState)
+```
+with:
+```kotlin
+                androidx.compose.material3.AssistChip(
+                    onClick = { modelSheetOpen = true },
+                    label = { Text(currentModel ?: "Model", maxLines = 1) },
+                    trailingIcon = {
+                        Icon(
+                            androidx.compose.material.icons.Icons.Rounded.ArrowDropDown,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                )
+                StatusDot(connState)
+```
+Add imports if missing (`androidx.compose.material.icons.rounded.ArrowDropDown`, `androidx.compose.foundation.layout.size`, `androidx.compose.ui.unit.dp`). The chip is always shown (tapping opens the sheet, which loads providers).
+
+- [ ] **Step 2: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): visible model chip in the header (always shown, opens the sheet)"
+```
+
+---
+
+### Task 5: Cron status icon in the list (Item 4 UI)
+
+**Files:** Modify `ui/cron/CronScreen.kt`
+
+**Interfaces:** Consumes `cronRowStatus(job, nowMs): CronRowStatus` (Task 1); `LocalProfileAccent` (Task 3 import may already be present).
+
+- [ ] **Step 1: Add a leading status icon to the cron row**
+
+In the jobs `LazyColumn` (the `else ->` branch), compute a stable now and add `leadingContent` to the `ListItem`:
+```kotlin
+            else -> {
+                val nowMs = remember(state.jobs) { System.currentTimeMillis() }
+                LazyColumn(Modifier.fillMaxSize()) {
+                    items(state.jobs, key = { it.id }) { job ->
+                        ListItem(
+                            leadingContent = {
+                                val (icon, tint) = when (cronRowStatus(job, nowMs)) {
+                                    CronRowStatus.FAILED, CronRowStatus.OVERDUE ->
+                                        Icons.Rounded.ErrorOutline to MaterialTheme.colorScheme.error
+                                    CronRowStatus.PAUSED ->
+                                        Icons.Rounded.PauseCircleOutline to MaterialTheme.colorScheme.onSurfaceVariant
+                                    CronRowStatus.OK ->
+                                        Icons.Rounded.CheckCircle to com.hermes.client.ui.theme.LocalProfileAccent.current.accent
+                                }
+                                Icon(icon, contentDescription = null, tint = tint)
+                            },
+                            overlineContent = { /* unchanged */ },
+                            headlineContent = { Text(job.name ?: job.id) },
+                            supportingContent = { /* unchanged */ },
+                            modifier = Modifier.clickable { onOpen(job.id) },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+```
+Keep the existing `overlineContent`/`supportingContent` bodies as they are (Task 3 already handled the overline colour). Add imports: `androidx.compose.material.icons.rounded.{ErrorOutline, PauseCircleOutline, CheckCircle}`, `androidx.compose.material3.Icon`, `androidx.compose.runtime.remember`.
+
+- [ ] **Step 2: Compile + full suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+git commit -m "feat(cron): leading status icon (failed/overdue/paused/ok) in the cron list"
+```
+
+---
+
+### Task 6: Tenant token near the composer (Item 5)
+
+**Files:** Create `ui/components/ProfileAvatar.kt`; Modify `ui/chat/ChatScreen.kt`, `ui/nav/YouHubScreen.kt`
+
+**Interfaces:** Produces `@Composable fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp)`. Consumes `rememberProfileAccent` (`ui/theme/ProfileAccent.kt`).
+
+- [ ] **Step 1: Create `ProfileAvatar.kt`**
+
+```kotlin
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.rememberProfileAccent
+
+/** A lettered, per-tenant-coloured avatar token (the profile's initial in its accent). */
+@Composable
+fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
+    val accent = rememberProfileAccent(name, isSystemInDarkTheme())
+    Box(
+        modifier.size(size).clip(CircleShape).background(accent.accent),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+    }
+}
+```
+
+- [ ] **Step 2: Place it in the chat composer Row**
+
+In `ChatScreen.kt`'s `bottomBar` composer `Row` (~line 146-186), add as the **first** child (before the paperclip `IconButton`):
+```kotlin
+        com.hermes.client.ui.components.ProfileAvatar(activeProfile)
+        Spacer(Modifier.width(4.dp))
+        IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) { /* unchanged */ }
+```
+(`activeProfile` is already collected in `ChatScreen`; `Spacer`/`Modifier.width` already imported.)
+
+- [ ] **Step 3: Refactor `YouHubScreen.ProfileAvatarRow` to reuse `ProfileAvatar`**
+
+In `YouHubScreen.kt`'s private `ProfileAvatarRow` (~lines 201-236), replace the inline `Box(...48dp...) { Text(initial) }` with `com.hermes.client.ui.components.ProfileAvatar(name, size = 48.dp)` wrapped in the existing `clickable { onSwitch(name) }` (keep the name label `Text` below it). Keep behaviour identical (48 dp avatar + name label).
+
+- [ ] **Step 4: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+git commit -m "feat(ux): reusable ProfileAvatar; tenant token in the chat composer"
+```
+
+---
+
+### Task 7: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Use the mock (`http://10.0.2.2:8899`) which has multiple profiles, a failed + overdue cron (acme), and models.
+
+- [ ] **Step 2: Verify all five**
+
+1. **Error/empty:** open a cron detail with a bad id (or kill the mock mid-load), and the Cron/Agents/Usage screens under error → each shows the **icon + message + Retry** state (not bare text); an empty cron/agents profile shows the styled empty state.
+2. **Accent:** switch profiles (acme/globex/initech) → section headers, list icons, cron overline, chat command labels, sessions group headers render in that tenant's colour, in **both light and dark**.
+3. **Model chip:** the chat header shows a **chip** (model name + caret), visible even on cold-open; tap → the model sheet opens.
+4. **Cron status:** the Cron list shows a leading status icon per row — a failed job red, healthy a check (in the tenant accent), paused a pause glyph.
+5. **Composer token:** the chat composer shows the tenant avatar (correct letter + colour) left of the paperclip; it matches the active profile.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(ux): quick-wins verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Item 1 → Task 2 (route 4 screens through ScreenStates + Retry) ✓; Item 2 → Task 3 (accent at enumerated sites; error/onSurface untouched; chart left) ✓; Item 3 → Task 4 (always-visible AssistChip, un-gated) ✓; Item 4 → Task 1 (pure `cronRowStatus` + test) + Task 5 (leading icon) ✓; Item 5 → Task 6 (`ProfileAvatar` extract + composer token + YouHub reuse) ✓; on-device incl. light+dark, cold-open chip, error/empty, cron icons, composer token → Task 7 ✓; no bridge changes ✓.
+- **Placeholder scan:** every code step has concrete code; the conditional bits are the Task 2 AgentsTools empty-branch placement (guarded read-the-file), Task 3's "find via grep" (line numbers are guides, sites enumerated by description), and the Task 7 verification-only commit.
+- **Type consistency:** `cronRowStatus(job, nowMs): CronRowStatus{FAILED,OVERDUE,OK,PAUSED}` (Task 1) consumed in Task 5; `ErrorState(message,onRetry)`/`EmptyState(title,subtitle)` (existing) in Task 2; `LocalProfileAccent.current.accent` (Task 3) in Tasks 3+5; `ProfileAvatar(name, modifier, size)` (Task 6) used in chat + YouHub. Consistent.
+
+**Ordering:** Task 1 (pure) stands alone. Tasks 2, 4, 6 are independent UI items. Task 3 (accent) is broad but independent. Task 5 depends on Task 1. Task 7 verifies. (Tasks touch mostly disjoint files; `CronScreen.kt` is touched by Tasks 2, 3, 5 and `ChatScreen.kt` by Tasks 3, 4, 6 — execute in order to avoid conflicts.)

--- a/docs/superpowers/specs/2026-07-05-ux-quick-wins-design.md
+++ b/docs/superpowers/specs/2026-07-05-ux-quick-wins-design.md
@@ -1,0 +1,124 @@
+# UX Quick Wins (batch) — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/ux-quick-wins`
+**Source:** Top-5 quick wins in `docs/ideas/ux-review-2026-07-04.md`
+
+## Goal
+
+Five self-contained, no-bridge-change UI improvements, shipped together (one task each): styled error/empty states, full per-tenant accent wiring, a visible model chip, cron status in the list, and a persistent tenant token near the chat composer.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing state/data only. Material 3.
+- Multi-tenant isolation preserved (never blend client data).
+- Follow existing patterns; no unrelated refactors.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Item 1 — Route bare error/empty screens through the shared state composables
+
+`ui/components/ScreenStates.kt` already defines `LoadingState`, `ErrorState(message, modifier, onRetry)` (icon + message + **Retry**), and `EmptyState(title, subtitle, icon, actionLabel, onAction)`. Several screens bypass them with a bare `Text(error!!)`. Route these through the shared composables (retry wired to each VM's `load`):
+
+- `ui/cron/CronDetailScreen.kt:77` — `state.job == null -> Text(state.error ?: "Not found", …)` → `ErrorState(message = state.error ?: "Couldn't load this cron job", onRetry = { vm.load(jobId) })`. (`jobId` is the screen's nav arg, already used at line 53.)
+- `ui/cron/CronScreen.kt:52-59` — error `Text` → `ErrorState(message = state.error!!, onRetry = { vm.load() })`; empty `Text` → `EmptyState(title = "No cron jobs", subtitle = "Scheduled jobs for this profile will show up here.")`.
+- `ui/tools/AgentsToolsScreen.kt:42-43` — error `Text` → `ErrorState(message = state.error!!, onRetry = { vm.load() })` (`ToolsViewModel.load()`); add `EmptyState(title = "No agents or tools")` for the empty case.
+- `ui/usage/UsageScreen.kt:111-112` — error `Text` → `ErrorState(message = state.error!!, onRetry = { vm.load() })`.
+
+Leave `ChatScreen`'s `ConnectionBanner` as-is (already a styled `errorContainer` banner with Retry). Each `ErrorState`/`EmptyState` fills its content area (`Modifier.align(Center)` sites become the state composable centered in the same box/scaffold padding).
+
+## Item 2 — Wire the per-tenant accent through in-content elements
+
+**Verified:** `HermesTheme(profile = activeProfile)` (Theme.kt:36, fed by `MainActivity`) provides `LocalProfileAccent` app-wide as the **active** profile's accent; `MissionControlScreen` re-provides it per pager page. So reading `LocalProfileAccent.current.accent` in content yields the active tenant colour everywhere (and the correct per-page colour on the feed).
+
+Replace `MaterialTheme.colorScheme.primary` with `LocalProfileAccent.current.accent` at these **in-content accent** sites (imports: `com.hermes.client.ui.theme.LocalProfileAccent`):
+
+- `ui/activity/MissionControlScreen.kt` — `SectionHeader` label (`:259`), `ActivityRow` non-error icon tint (`:311`).
+- `ui/cron/CronScreen.kt:70` — the schedule overline colour (enabled/not-paused branch only; keep the `error` colour for the paused/disabled branch).
+- `ui/cron/CronDetailScreen.kt:115,123` — the "PROMPT" / "RUN HISTORY" labels.
+- `ui/chat/ChatScreen.kt:197,214` — the "COMMANDS" / "ATTACH · MENTION" labels.
+- `ui/chat/ChatComponents.kt:354` — the accent icon tint.
+- `ui/usage/UsageScreen.kt:128,134` — the section labels. **Leave `:159` (chart `inputColor`)** as `colorScheme.primary` for now unless it reads cleanly as the accent — the chart colour is a separate concern; changing it is optional and can stay primary.
+- `ui/sessions/SessionsScreen.kt:308,315,335,411` — group-header chevron tint, group label, `SectionHeader` label, and the icon tint.
+- `ui/models/ModelSelector.kt:148,191` — current-model row label and the favourite-star tint.
+- `ui/nav/YouHubScreen.kt:74,230` — "PROFILES" label and the selected-avatar-name label.
+
+Do **not** touch semantic non-accent uses of `colorScheme.error`/`onSurface`/etc. This item is purely `colorScheme.primary` → `LocalProfileAccent.current.accent` at the enumerated call sites. (`LocalProfileAccent.current.accent` is a `@Composable` read — valid at all these sites.)
+
+## Item 3 — Visible model chip in the chat header
+
+`ChatScreen.kt` (~138) currently renders the model control as a `TextButton(Text(currentModel ?: "Model"))` **gated on `providers.isNotEmpty()`** (so it's hidden until providers load, e.g. on cold-open) and reads as flat text. Replace with an always-visible, obviously-tappable chip:
+
+```kotlin
+androidx.compose.material3.AssistChip(
+    onClick = { modelSheetOpen = true },
+    label = { Text(currentModel ?: "Model", maxLines = 1) },
+    trailingIcon = { Icon(Icons.Rounded.ArrowDropDown, contentDescription = null, Modifier.size(18.dp)) },
+)
+```
+
+- Remove the `if (providers.isNotEmpty())` gate — always show the chip (tapping opens the sheet, which loads providers). Keep `StatusDot(connState)` after it.
+- The chip sits in the top-bar `actions` slot; its content inherits the accent-tinted `onBar` content colour as today.
+
+## Item 4 — Cron status indicator in the Cron list
+
+Add a **leading status icon** to each `CronScreen` row so failed/overdue jobs are triage-able from the list (same iconography as Home). Add a pure, unit-tested helper:
+
+`ui/cron/CronRowStatus.kt`:
+```kotlin
+enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }
+
+/** Pure: a cron job's at-a-glance status for the list. Reuses needsAttention for FAILED/OVERDUE. */
+fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus = when {
+    needsAttention(listOf(job), nowMs).firstOrNull()?.reason == CronAlertReason.FAILED -> CronRowStatus.FAILED
+    needsAttention(listOf(job), nowMs).firstOrNull()?.reason == CronAlertReason.OVERDUE -> CronRowStatus.OVERDUE
+    !job.enabled || job.isPaused -> CronRowStatus.PAUSED
+    else -> CronRowStatus.OK
+}
+```
+In `CronScreen.kt`'s `ListItem`, add `leadingContent = { Icon(...) }`:
+- `FAILED`/`OVERDUE` → `Icons.Rounded.ErrorOutline`, tint `MaterialTheme.colorScheme.error`.
+- `PAUSED` → `Icons.Rounded.PauseCircleOutline`, tint `onSurfaceVariant`.
+- `OK` → `Icons.Rounded.CheckCircle`, tint `LocalProfileAccent.current.accent`.
+
+Compute `nowMs = remember(state.jobs) { System.currentTimeMillis() }` in the list scope.
+
+## Item 5 — Persistent tenant token near the chat composer
+
+Extract the lettered, accent-coloured avatar (today private `ProfileAvatarRow` in `YouHubScreen.kt:201-236`) into a reusable composable in `ui/components/ProfileAvatar.kt`:
+
+```kotlin
+@Composable
+fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
+    val dark = isSystemInDarkTheme()
+    val accent = rememberProfileAccent(name, dark)
+    Box(modifier.size(size).clip(CircleShape).background(accent.accent), contentAlignment = Alignment.Center) {
+        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+    }
+}
+```
+- Place a `ProfileAvatar(activeProfile)` as the **leftmost** element of the Chat composer `Row` (`ChatScreen.kt:146-186`), before the paperclip `IconButton`, with a trailing `Spacer(Modifier.width(4.dp))`. It shows the active client's letter in its accent — always visible while typing.
+- Refactor `YouHubScreen`'s `ProfileAvatarRow` to use the new `ProfileAvatar` (drop the duplicated Box/Text; keep its 48 dp size + the name label below).
+
+## Testing
+
+- **Unit (pure), TDD — `CronRowStatusTest`:** failed `lastStatus="error"` → FAILED; overdue → OVERDUE; paused/disabled → PAUSED; healthy future → OK; FAILED priority over OVERDUE.
+- **On-device (per item):**
+  1. CronDetail with a bad id, Cron list load error, Agents error, Usage error → styled icon + message + **Retry** (not bare text); empty cron/agents → styled empty state.
+  2. Switch profiles (acme/globex/initech) → section headers, icons, cron overline, chat command labels, etc. all render in that tenant's accent (both light + dark).
+  3. Chat header shows a model **chip** (name + caret), visible on cold-open, taps → the model sheet.
+  4. Cron list rows show a leading status icon; a failed job is red, healthy shows a check, paused shows a pause.
+  5. The chat composer shows the tenant avatar token (correct letter + colour) next to the paperclip.
+
+## Not doing (YAGNI)
+
+- Any new component beyond `ProfileAvatar` (Item 1 reuses existing `ScreenStates`).
+- Chart-colour accenting (Usage `:159`) unless trivially clean.
+- Changing `ChatScreen`'s `ConnectionBanner` (already styled).
+- The P1/P2 items from the review (this batch is the Top-5 quick wins only).
+- Any gateway/API change.
+
+## Open questions (non-blocking; plan may settle)
+
+- Model chip style (`AssistChip` vs a tonal pill) — `AssistChip` proposed; the plan pins it.
+- Composer token size (28 dp proposed).


### PR DESCRIPTION
## UX quick wins (Top-5 from the design review)

Ships the five quick wins from `docs/ideas/ux-review-2026-07-04.md` — all Compose-only, **no bridge changes**.

1. **Styled error/empty states** — route CronDetail / Cron list / Agents / Usage through the shared `ErrorState`/`EmptyState` (icon + message + **Retry**), replacing the bare "Failed to load…" text (a P0).
2. **Per-tenant accent wired into content** — in-content `colorScheme.primary` (fixed indigo) → `LocalProfileAccent.current.accent` across ~9 screens, so section headers, list icons, cron overlines, chat command labels, etc. render in the active client's colour (acme green ↔ globex gold, verified).
3. **Visible model chip** — the chat header's model control is now an always-visible `AssistChip` (name + caret) that opens the model sheet, instead of a providers-gated invisible text button.
4. **Cron status in the list** — a pure `cronRowStatus(job, now)` drives a leading status icon per Cron row (failed/overdue red, healthy check, paused muted), so you can triage from the list.
5. **Composer tenant token** — a reusable `ProfileAvatar` component; the chat composer now shows the active client's coloured initial next to the paperclip (reduces cross-tenant mistakes). YouHub's avatar row reuses the same component.

### Verification
- New unit tests: `cronRowStatusTest` (5 cases). Full suite + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task reviews + an opus final whole-branch review: "ready to merge"; two batch-introduced minors — a missed AgentsTools accent site and the YouHub avatar initial size — fixed).
- On-device (emulator, acme + globex): all five confirmed; the accent switches per tenant; the P0 error screen is now styled with Retry.

### Deferred follow-ups (Minor, from the review)
YouHub "CUSTOM" picker label + model-chip content colour convention; the "New" FAB on Cron/other screens still uses base indigo (chrome-accent gap, outside this batch's scope).

Spec/plan: `docs/superpowers/specs/2026-07-05-ux-quick-wins-design.md`, `docs/superpowers/plans/2026-07-05-ux-quick-wins.md`.
