### PR TITLE
Promote to production: 0.1.32 (UX quick wins)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 32
-        versionName = "0.1.31"
+        versionCode = 33
+        versionName = "0.1.32"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -256,7 +256,7 @@ private fun SectionHeader(label: String, count: Int) {
         Text(
             label.uppercase(),
             style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colorScheme.primary,
+            color = LocalProfileAccent.current.accent,
             modifier = Modifier.weight(1f),
         )
         Text(
@@ -308,7 +308,7 @@ private fun ActivityRow(
     val tint = when {
         item.status.equals("error", ignoreCase = true) ||
             item.status.equals("failed", ignoreCase = true) -> MaterialTheme.colorScheme.error
-        else -> MaterialTheme.colorScheme.primary
+        else -> LocalProfileAccent.current.accent
     }
     val time = relativeTime(item.timestampMs, nowMs)
     Column {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -351,7 +352,7 @@ private fun ToolCard(tool: ToolCall) {
                     if (tool.status == ToolStatus.RUNNING) Icons.Rounded.PlayArrow else Icons.Rounded.Check,
                     contentDescription = null,
                     modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = LocalProfileAccent.current.accent,
                 )
                 Text(
                     text = if (tool.status == ToolStatus.RUNNING) "${tool.name}…" else tool.name,

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -165,6 +165,8 @@ fun ChatScreen(
                     .padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                com.hermes.client.ui.components.ProfileAvatar(activeProfile)
+                Spacer(Modifier.width(4.dp))
                 IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) {
                     Icon(Icons.Rounded.AttachFile, contentDescription = "Attach image")
                 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -22,9 +23,11 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
+import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.AttachFile
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -135,11 +138,17 @@ fun ChatScreen(
                     }
                 },
                 actions = {
-                    if (providers.isNotEmpty()) {
-                        androidx.compose.material3.TextButton(onClick = { modelSheetOpen = true }) {
-                            Text(currentModel ?: "Model", maxLines = 1)
-                        }
-                    }
+                    AssistChip(
+                        onClick = { modelSheetOpen = true },
+                        label = { Text(currentModel ?: "Model", maxLines = 1) },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Rounded.ArrowDropDown,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        },
+                    )
                     StatusDot(connState)
                 },
             )

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.material3.OutlinedTextField
@@ -194,7 +195,7 @@ fun ChatScreen(
                 Text(
                     "COMMANDS",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = LocalProfileAccent.current.accent,
                     modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
                 )
                 LazyColumn(Modifier.weight(1f).fillMaxWidth()) {
@@ -211,7 +212,7 @@ fun ChatScreen(
                 Text(
                     "ATTACH / MENTION",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = LocalProfileAccent.current.accent,
                     modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
                 )
                 LazyColumn(Modifier.weight(1f).fillMaxWidth()) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -148,6 +148,10 @@ fun ChatScreen(
                                 modifier = Modifier.size(18.dp),
                             )
                         },
+                        colors = androidx.compose.material3.AssistChipDefaults.assistChipColors(
+                            labelColor = com.hermes.client.ui.components.AccentChrome.onBar,
+                            trailingIconContentColor = com.hermes.client.ui.components.AccentChrome.onBar,
+                        ),
                     )
                     StatusDot(connState)
                 },

--- a/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
@@ -23,6 +23,10 @@ fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp
         modifier.size(size).clip(CircleShape).background(accent.accent),
         contentAlignment = Alignment.Center,
     ) {
-        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+        Text(
+            (name ?: "·").take(1).uppercase(),
+            color = accent.onAccent,
+            style = if (size >= 40.dp) MaterialTheme.typography.titleMedium else MaterialTheme.typography.labelLarge,
+        )
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
@@ -1,0 +1,28 @@
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.rememberProfileAccent
+
+/** A lettered, per-tenant-coloured avatar token (the profile's initial in its accent). */
+@Composable
+fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
+    val accent = rememberProfileAccent(name, isSystemInDarkTheme())
+    Box(
+        modifier.size(size).clip(CircleShape).background(accent.accent),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt
@@ -20,11 +20,11 @@ import com.hermes.client.ui.theme.rememberProfileAccent
 fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
     val accent = rememberProfileAccent(name, isSystemInDarkTheme())
     Box(
-        modifier.size(size).clip(CircleShape).background(accent.accent),
+        Modifier.size(size).clip(CircleShape).background(accent.accent).then(modifier),
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            (name ?: "·").take(1).uppercase(),
+            (name?.takeIf { it.isNotBlank() } ?: "·").take(1).uppercase(),
             color = accent.onAccent,
             style = if (size >= 40.dp) MaterialTheme.typography.titleMedium else MaterialTheme.typography.labelLarge,
         )

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -116,7 +117,7 @@ fun CronDetailScreen(
                             job.prompt?.takeIf { it.isNotBlank() }?.let {
                                 Spacer(Modifier.padding(top = 12.dp))
                                 Text("PROMPT", style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.primary)
+                                    color = LocalProfileAccent.current.accent)
                                 Text(it, style = MaterialTheme.typography.bodySmall, maxLines = 8,
                                     overflow = TextOverflow.Ellipsis)
                             }
@@ -124,7 +125,7 @@ fun CronDetailScreen(
                         Text(
                             "RUN HISTORY (${state.runs.size})",
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = LocalProfileAccent.current.accent,
                             modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
                         )
                     }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -74,7 +74,11 @@ fun CronDetailScreen(
     ) { padding ->
         when {
             state.loading -> com.hermes.client.ui.components.LoadingState()
-            state.job == null -> Text(state.error ?: "Not found", Modifier.padding(padding).padding(24.dp))
+            state.job == null -> com.hermes.client.ui.components.ErrorState(
+                message = state.error ?: "Couldn't load this cron job",
+                modifier = Modifier.padding(padding).fillMaxSize(),
+                onRetry = { vm.load(jobId) },
+            )
             else -> {
                 val job = state.job!!
                 LazyColumn(Modifier.padding(padding).fillMaxSize()) {

--- a/app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt
@@ -1,0 +1,19 @@
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.activity.CronAlertReason
+import com.hermes.client.ui.activity.needsAttention
+
+enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }
+
+/** Pure: a cron job's at-a-glance status for the list. FAILED (last run errored) takes priority,
+ *  then OVERDUE, then PAUSED (disabled/paused), else OK. Reuses [needsAttention]. */
+fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus {
+    val alert = needsAttention(listOf(job), nowMs).firstOrNull()
+    return when {
+        alert?.reason == CronAlertReason.FAILED -> CronRowStatus.FAILED
+        alert?.reason == CronAlertReason.OVERDUE -> CronRowStatus.OVERDUE
+        !job.enabled || job.isPaused -> CronRowStatus.PAUSED
+        else -> CronRowStatus.OK
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -51,11 +50,12 @@ fun CronScreen(
         Box(Modifier.padding(padding).fillMaxSize()) {
             when {
                 state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
-                state.jobs.isEmpty() -> Text(
-                    "No cron jobs for this profile.",
-                    Modifier.align(Alignment.Center),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+                state.jobs.isEmpty() -> com.hermes.client.ui.components.EmptyState(
+                    title = "No cron jobs",
+                    subtitle = "Scheduled jobs for this profile will show up here.",
                 )
                 else -> LazyColumn(Modifier.fillMaxSize()) {
                     items(state.jobs, key = { it.id }) { job ->

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -67,7 +68,7 @@ fun CronScreen(
                                         !job.enabled -> "  · disabled"
                                         else -> ""
                                     },
-                                    color = if (job.enabled && !job.isPaused) MaterialTheme.colorScheme.primary
+                                    color = if (job.enabled && !job.isPaused) LocalProfileAccent.current.accent
                                     else MaterialTheme.colorScheme.error,
                                 )
                             },

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -7,8 +7,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.PauseCircleOutline
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -17,6 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -58,28 +64,42 @@ fun CronScreen(
                     title = "No cron jobs",
                     subtitle = "Scheduled jobs for this profile will show up here.",
                 )
-                else -> LazyColumn(Modifier.fillMaxSize()) {
-                    items(state.jobs, key = { it.id }) { job ->
-                        ListItem(
-                            overlineContent = {
-                                Text(
-                                    job.scheduleText + when {
-                                        job.isPaused -> "  · paused"
-                                        !job.enabled -> "  · disabled"
-                                        else -> ""
-                                    },
-                                    color = if (job.enabled && !job.isPaused) LocalProfileAccent.current.accent
-                                    else MaterialTheme.colorScheme.error,
-                                )
-                            },
-                            headlineContent = { Text(job.name ?: job.id) },
-                            supportingContent = {
-                                val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
-                                Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())
-                            },
-                            modifier = Modifier.clickable { onOpen(job.id) },
-                        )
-                        HorizontalDivider()
+                else -> {
+                    val nowMs = remember(state.jobs) { System.currentTimeMillis() }
+                    LazyColumn(Modifier.fillMaxSize()) {
+                        items(state.jobs, key = { it.id }) { job ->
+                            ListItem(
+                                leadingContent = {
+                                    val (icon, tint) = when (cronRowStatus(job, nowMs)) {
+                                        CronRowStatus.FAILED, CronRowStatus.OVERDUE ->
+                                            Icons.Rounded.ErrorOutline to MaterialTheme.colorScheme.error
+                                        CronRowStatus.PAUSED ->
+                                            Icons.Rounded.PauseCircleOutline to MaterialTheme.colorScheme.onSurfaceVariant
+                                        CronRowStatus.OK ->
+                                            Icons.Rounded.CheckCircle to com.hermes.client.ui.theme.LocalProfileAccent.current.accent
+                                    }
+                                    Icon(icon, contentDescription = null, tint = tint)
+                                },
+                                overlineContent = {
+                                    Text(
+                                        job.scheduleText + when {
+                                            job.isPaused -> "  · paused"
+                                            !job.enabled -> "  · disabled"
+                                            else -> ""
+                                        },
+                                        color = if (job.enabled && !job.isPaused) LocalProfileAccent.current.accent
+                                        else MaterialTheme.colorScheme.error,
+                                    )
+                                },
+                                headlineContent = { Text(job.name ?: job.id) },
+                                supportingContent = {
+                                    val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
+                                    Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())
+                                },
+                                modifier = Modifier.clickable { onOpen(job.id) },
+                            )
+                            HorizontalDivider()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/hermes/client/ui/models/ModelSelector.kt
+++ b/app/src/main/java/com/hermes/client/ui/models/ModelSelector.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
@@ -145,7 +146,7 @@ fun ModelSelectorContent(
                     is ModelListItem.Header -> Text(
                         text = item.title + if (item.isCurrent) "  (current)" else "",
                         style = MaterialTheme.typography.titleSmall,
-                        color = if (item.isCurrent) MaterialTheme.colorScheme.primary
+                        color = if (item.isCurrent) LocalProfileAccent.current.accent
                         else MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(start = 4.dp, top = 14.dp, bottom = 4.dp),
                     )
@@ -188,7 +189,7 @@ private fun ModelRowItem(
             Icon(
                 imageVector = if (row.isFavorite) Icons.Rounded.Star else Icons.Rounded.StarBorder,
                 contentDescription = if (row.isFavorite) "Unfavorite" else "Favorite",
-                tint = if (row.isFavorite) MaterialTheme.colorScheme.primary
+                tint = if (row.isFavorite) LocalProfileAccent.current.accent
                 else MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -47,6 +47,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.HubRow
 import com.hermes.client.ui.theme.ACCENT_SWATCHES
+import com.hermes.client.ui.theme.LocalProfileAccent
 import com.hermes.client.ui.theme.accentFromHsl
 import com.hermes.client.ui.theme.colorArgbToHsl
 import com.hermes.client.ui.theme.hslToColorArgb
@@ -71,7 +72,7 @@ fun YouHubScreen(
             Text(
                 "PROFILES",
                 style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.primary,
+                color = LocalProfileAccent.current.accent,
                 modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
             )
             ProfileAvatarRow(
@@ -227,7 +228,7 @@ private fun ProfileAvatarRow(profiles: List<String>, active: String?, onSwitch: 
                 Text(
                     name,
                     style = MaterialTheme.typography.labelSmall,
-                    color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = if (selected) LocalProfileAccent.current.accent else MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                 )
             }

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -51,7 +51,6 @@ import com.hermes.client.ui.theme.LocalProfileAccent
 import com.hermes.client.ui.theme.accentFromHsl
 import com.hermes.client.ui.theme.colorArgbToHsl
 import com.hermes.client.ui.theme.hslToColorArgb
-import com.hermes.client.ui.theme.rememberProfileAccent
 
 /**
  * "You" tab — profile identity + everything about the account/app: the profile quick-switch
@@ -202,29 +201,22 @@ private fun SliderRow(
 /** Quick-switch avatar row: each profile's initial in a chip tinted to that profile's own accent. */
 @Composable
 private fun ProfileAvatarRow(profiles: List<String>, active: String?, onSwitch: (String) -> Unit) {
-    val dark = androidx.compose.foundation.isSystemInDarkTheme()
     Row(
         Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 12.dp, vertical = 4.dp),
     ) {
         profiles.forEach { name ->
             val selected = name == active
-            // Each avatar previews that profile's own accent hue, so the switcher itself teaches
-            // the color mapping.
-            val accent = rememberProfileAccent(name, dark)
+            // Each avatar previews that profile's own accent hue (via ProfileAvatar), so the
+            // switcher itself teaches the color mapping.
             Column(
                 Modifier.padding(end = 12.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Box(
-                    Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                        .background(accent.accent)
-                        .clickable { onSwitch(name) },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(name.take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.titleMedium)
-                }
+                com.hermes.client.ui.components.ProfileAvatar(
+                    name,
+                    modifier = Modifier.clickable { onSwitch(name) },
+                    size = 48.dp,
+                )
                 Text(
                     name,
                     style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
@@ -305,14 +306,14 @@ private fun CollapsibleHeader(
             if (collapsed) Icons.Rounded.ChevronRight else Icons.Rounded.ExpandMore,
             contentDescription = if (collapsed) "Expand" else "Collapse",
             tint = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
-            else MaterialTheme.colorScheme.primary,
+            else LocalProfileAccent.current.accent,
             modifier = Modifier.padding(end = 8.dp).size(18.dp),
         )
         Text(
             if (indent) label else label.uppercase(),
             style = MaterialTheme.typography.labelMedium,
             color = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
-            else MaterialTheme.colorScheme.primary,
+            else LocalProfileAccent.current.accent,
             modifier = Modifier.weight(1f),
         )
         Text(
@@ -332,7 +333,7 @@ private fun SectionHeader(label: String, count: Int, note: String? = null) {
         Text(
             label.uppercase(),
             style = androidx.compose.material3.MaterialTheme.typography.labelMedium,
-            color = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+            color = LocalProfileAccent.current.accent,
         )
         note?.let {
             Text(
@@ -408,7 +409,7 @@ private fun SessionRow(
                         Icons.Rounded.PushPin,
                         contentDescription = "Pinned",
                         modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.primary,
+                        tint = LocalProfileAccent.current.accent,
                     )
                 }
             } else null,

--- a/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -40,7 +39,12 @@ fun AgentsToolsScreen(
         Box(Modifier.padding(padding).fillMaxSize()) {
             when {
                 state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+                state.skills.isEmpty() && state.toolsets.isEmpty() -> com.hermes.client.ui.components.EmptyState(
+                    title = "No agents or tools",
+                )
                 else -> LazyColumn(Modifier.fillMaxSize()) {
                     item { SectionHeader("Skills (${state.skills.size})") }
                     items(state.skills, key = { it.name }) { skill ->

--- a/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hermes.client.ui.theme.LocalProfileAccent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,7 +87,7 @@ private fun SectionHeader(text: String) {
     Text(
         text,
         style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
+        color = LocalProfileAccent.current.accent,
         modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp),
     )
 }

--- a/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -109,7 +108,9 @@ fun UsageScreen(
         Box(Modifier.padding(padding).fillMaxSize()) {
             when {
                 state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> Text(state.error!!, Modifier.align(Alignment.Center))
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
                 else -> LazyColumn(Modifier.fillMaxSize()) {
                     item {
                         Column(Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -126,13 +127,13 @@ fun UsageScreen(
                             }
                             if (state.daily.isNotEmpty()) {
                                 Text("DAILY TOKENS", style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.primary,
+                                    color = LocalProfileAccent.current.accent,
                                     modifier = Modifier.padding(top = 20.dp, bottom = 8.dp))
                                 DailyTokensChart(state.daily)
                             }
                         }
                         Text("TOP MODELS", style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = LocalProfileAccent.current.accent,
                             modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp))
                     }
                     // No key: model names can repeat across providers (e.g. two "gemma"),

--- a/app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt
@@ -1,0 +1,34 @@
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class CronRowStatusTest {
+    @Test fun failed_last_run_is_FAILED() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(lastStatus = "error"), NOW))
+    }
+    @Test fun overdue_is_OVERDUE() {
+        assertEquals(CronRowStatus.OVERDUE, cronRowStatus(job(nextRunAt = iso(NOW - 10 * 60_000)), NOW))
+    }
+    @Test fun paused_or_disabled_not_failed_is_PAUSED() {
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(state = "paused"), NOW))
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(enabled = false), NOW))
+    }
+    @Test fun healthy_future_is_OK() {
+        assertEquals(CronRowStatus.OK, cronRowStatus(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000)), NOW))
+    }
+    @Test fun failed_takes_priority_over_paused() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(state = "paused", lastStatus = "error"), NOW))
+    }
+}

--- a/docs/ideas/activity-home-and-cron-response.md
+++ b/docs/ideas/activity-home-and-cron-response.md
@@ -3,6 +3,15 @@
 ## Problem Statement
 **How might we** make opening the app land you on *what's happening and what needs you* (never a stale resumed chat), and let you see *what a scheduled job actually answered* without wading through its full transcript — using only existing endpoints + native APIs?
 
+## Status — ✅ shipped (production 0.1.31)
+
+- **Piece 1 — Cron response inline:** ✅ **0.1.29.** Tap a cron run in the feed → its final assistant response expands inline (Product-level, last-tool-result fallback), with "View full chat".
+- **Piece 2 — Home:** ✅
+  - **2a — Home landing + tab relabel** (0.1.30): the app opens to the **Home** tab (Home · Chats · You); notification taps still deep-link. Also fixed a latent MissionControl pager launch-crash exposed by landing there.
+  - **2b — "Needs you" strip + header rename** (0.1.31): a red section pins **failed/overdue cron** to the top of Home (deduped from the feed); the header reads "Home".
+
+**Honesty held:** "Needs you" is **cron-only** — messaging-waits (`/api/pairing`) isn't wired in the app and pending approvals are WS-only/transient (no REST list), so both were deliberately excluded. Auto-refresh rides the existing `ON_RESUME` reload. This idea doc is fully delivered.
+
 ## Context (grounded in the code)
 - **Launch today:** `HermesNav` sets `start = if (hasConfig) "sessions" else "setup"` — a cold launch opens the **Sessions list**. A notification tap already deep-links to `chat/<id>` via the `extra_route` rail.
 - **Agent Activity today:** the `activity` tab is **Mission Control** — already a "unified activity feed merging conversations + cron for the active profile, time-grouped." Cron runs are stored as real `source="cron"` **sessions**; tapping one opens the *full* transcript. `ActivityItem.status` already carries cron `last_status`; `CronJobDto` carries `lastRunAt`/`nextRunAt`.

--- a/docs/ideas/interface-modernization.md
+++ b/docs/ideas/interface-modernization.md
@@ -133,3 +133,6 @@ Idea refined 2026-07-02. Direction: **A now / B later**, hybrid chat, chrome-onl
 profile-accent (primary) with optional Material You base. All four open questions
 resolved (above). Build spine: tokens → components → nav → Sessions rebuild → Chat
 rebuild → motion polish, on `feature/design-system` off `develop`.
+
+**✅ Shipped: 0.1.19** ("interface modernization + Mission Control"), with the per-profile
+accent picker following post-0.1.19 (see Deferred features above). This doc is delivered.

--- a/docs/ideas/native-command-surface.md
+++ b/docs/ideas/native-command-surface.md
@@ -3,6 +3,20 @@
 ## Problem Statement
 **How might we** make Hermes for Android a *full-reach, focused-action* remote for self-hosted agents — one that lets you see and unblock any agent from your phone using only the bridge's existing APIs plus native Android capabilities — **without** shipping Hermes core to the device (the official WebView approach) or requiring a single new gateway endpoint?
 
+## Status (as of 2026-07-04, production 0.1.31)
+
+- **Ship 1 — Model sheet:** ✅ **shipped.** Model picker clarity (0.1.22) + the model selection sheet with provider tabs, local favorites, descriptions, and session-vs-default (0.1.23). The switch-failure reason is surfaced in chat; a **Settings** inline-error remains a minor follow-up.
+- **Ship 2 — Native Pager:** mostly shipped.
+  - Share-to-Hermes: text ✅ (0.1.24), images ✅ (0.1.27).
+  - Quick Settings tile ✅ (0.1.26).
+  - **App Widget:** ❌ **shelved** — its headline content (pending approvals) is already covered by the high-priority notification, sits at "0" most of the time, and is only fresh while the foreground service runs. Opt-in only if revisited.
+  - **Voice quick-capture:** ⏸ **deferred** (off-by-default vitamin).
+- **Ship 3 — Situation Room:** ✅ **shipped, reframed as "Home"** (see `activity-home-and-cron-response.md`). Rather than a new screen, we promoted the existing Mission Control feed: cron-response inline (0.1.29), Home landing + tab relabel (0.1.30, plus a pager launch-crash fix), and a "Needs you" strip (0.1.31). Header now reads "Home".
+
+**Key assumptions — resolved.** The WS stream (`/api/ws`) emits `approval.request/responded`, `run.*`, `tool.*`, `message.*` — but **no** cron-finished or messaging events, and **no** REST list of pending approvals. So notifications became **approvals-only**, and "Needs you" is **cron-only** (failed/overdue); pending approvals are best-effort/live-only, and messaging-waits (`/api/pairing`) is not wired in the app. Share-to-Hermes starts a **new** session. The App-Widget freshness bet was never validated (shelved).
+
+**Remaining:** App Widget (opt-in), Voice (deferred), and minor polish (QS-tile `runBlocking`→async, `canStart` dedup, New-FAB last-used-profile, model-sheet Settings inline-error).
+
 ## Context & Constraints (locked)
 - **Architecture:** thin **native** client → existing Hermes bridge (REST at `:9119` + WS). Never wrap the desktop renderer (that's PR #52673's bet; this is the opposite bet).
 - **No bridge/gateway API changes.** Build only against **documented existing endpoints** (see `Hermes API's As of 7-3-2026`) + **native Android APIs**. If a feature seems to need a new endpoint, it's out until it doesn't.

--- a/docs/ideas/ux-review-2026-07-04.md
+++ b/docs/ideas/ux-review-2026-07-04.md
@@ -1,0 +1,225 @@
+# Hermes for Android — Design / UX Review
+
+**Date:** 2026-07-04
+**Reviewer lens:** senior product designer / mobile UX (Material 3, Compose, IA, microcopy, a11y)
+**Product:** native mobile "remote" for a self-hosted multi-tenant AI-agent gateway. Design spine: **"reach everything, act on a few."** Dark-mode-first; per-profile accent colour.
+**Scope constraint honoured:** no gateway/bridge/API changes proposed — everything below is client-side (Compose UI, local state, copy).
+
+Each finding is tagged **P0** (broken/embarrassing), **P1** (clearly worth doing), **P2** (polish), and follows: *what I see → why it matters → specific change*.
+
+---
+
+## 0. Executive read
+
+This does **not** read as a generic chat clone — and that's the win. The Home feed (**Needs You → Live Now → Upcoming → Recent**) is a genuinely confident "agent remote" framing: it leads with *what needs a human*, which is exactly right for a consultant triaging agents across tenants. Sessions grouped by profile→workspace, full-width assistant text vs bubbled user turns, a copy-able code block, and a thoughtful Settings (Diagnostics = shareable debug log) all say "someone who has shipped real tools built this."
+
+The problems are mostly **consistency and finish**, not concept:
+
+1. **The per-tenant accent system is only half-wired.** The top bar, the profile avatar, and *one* FAB take the tenant colour (green for acme); but every in-content accent — section headers, list icons, quick-link chips, the selected profile chip, the Cron FAB — is a fixed purple. The app reads as "a purple app wearing a green hat," which both looks unfinished and **weakens the tenant signal** to a thin strip at the top.
+2. **Error states are unstyled and inconsistent.** Three different patterns across the app; two are bare top-left/centre text ("Failed to load cron job", "Failed to load") with no icon and no Retry. For a beta this is the most embarrassing surface.
+3. **The model selector — a headline feature ("switch models") — is invisible** in the Chat top bar as shipped. If it's the small text button described, it isn't discoverable at all here.
+4. **Cron health doesn't propagate.** Home flags "Nightly DB backup — last run failed" and "Hourly metrics sync — overdue," but the Cron *list* shows zero status; you can't triage from the place you'd manage the jobs.
+
+Fix those four and this jumps from "promising beta" to "confident tool."
+
+---
+
+## 1. First impressions & positioning — does it read as an "agent remote"?
+
+**[01/10 home] Needs You as the hero — keep this. ✅ (already good)**
+Leading the launch screen with failed/overdue work, then live sessions, then upcoming crons, is the single best decision in the app. It matches "act on a few" and immediately differentiates from a chatbot. Don't dilute it.
+
+**[01] The hero is pushed ~560px down the screen — P1.**
+*What:* two full chip rows (profile chips + quick-link chips) sit above "NEEDS YOU," so the most important content starts more than half a screen down.
+*Why:* the confident move is to make the triage list the first thing the eye lands on.
+*Change:* collapse the two rows into one visual band — keep the profile chips as the top row, and demote the four quick-links (Cron/Messaging/Usage/Agents) into a single overflow/"tools" affordance or move them to the bottom of the feed. Target: "NEEDS YOU" visible within the first ~380px under the app bar.
+
+**[all] The giant green app bar spends ~250px on a title + subtitle — P2.**
+*What:* every screen has a tall solid-accent bar containing only e.g. "Home / Profile: acme".
+*Why:* it eats a third of the first viewport on a triage-first app and exaggerates the "colour only lives at the top" problem.
+*Change:* use a standard M3 `TopAppBar` height (medium, not this tall custom band), or a `LargeTopAppBar` that **collapses on scroll**. Move the tenant identity out of the subtitle and into a persistent inline chip (see §8).
+
+---
+
+## 2. Visual design & polish
+
+**[01/02/04/06 + 10] The accent system is inconsistent — P0 (for a colour-differentiated multi-tenant app, this is the core visual defect).**
+*What:* on acme the top bar, the "A" avatar, and the Sessions FAB are green; but "NEEDS YOU/LIVE NOW/…" headers, the clock/chat/chip icons, the selected profile chip fill, and the Cron "New" FAB are all a fixed lavender-purple. Green header + purple body on the same screen.
+*Why:* it looks unfinished, and — more important for this product — it **defeats the tenant-colour concept**: if I switch acme→globex, most of the screen won't change colour, so the colour can't function as a "which client am I in" cue.
+*Change:* pipe the active profile's accent through the Compose `ColorScheme` as `primary` (and derive `primaryContainer`, `onPrimary`, etc.). Section headers, selected chips, list icons, and **both** FABs should all resolve to `MaterialTheme.colorScheme.primary`. Keep red reserved for error only. One accent per tenant, applied everywhere.
+
+**[02/04] Two FABs, two shapes, two colours — P1.**
+*What:* Sessions has a green pill "＋ New"; Cron has a purple rounded-square "New" (no icon).
+*Why:* inconsistency in the most prominent action control on each screen.
+*Change:* one FAB spec — extended FAB, leading "＋" icon, accent-coloured, same corner radius. Label it by context ("New chat" / "New job").
+
+**[03/11 chat] The assistant code block overflows and truncates — P1.**
+*What:* `Result.failure("missing c…` and `stripe.charge(customerId, order.total)` are clipped at the right edge with no scroll affordance.
+*Why:* on an incident-triage screen the code *is* the payload; a silently cut string is a correctness/trust problem.
+*Change:* wrap code in a horizontally scrollable container (`Modifier.horizontalScroll`) with a subtle fade/scrollbar edge, or soft-wrap with a monospace-preserving wrap. Keep the copy button (good) but ensure copy grabs the *full* untruncated text.
+
+**[03/11 chat] Full-width assistant text vs bubbled user turn — keep. ✅**
+Correct pattern for long agent output. The purple user bubble is fine; don't bubble the assistant.
+
+**[08 usage] Stat values float with no container — P2.**
+*What:* Sessions/API calls/Tokens/Est. cost are bare label+number pairs on empty background.
+*Why:* reads as debug output, not a dashboard.
+*Change:* wrap each metric in an M3 `Card`/`OutlinedCard` in a 2-col grid; give "Est. cost" slightly heavier emphasis.
+
+**[10 light] The light-theme app bar loses the tenant colour — P1.**
+*What:* acme's bar becomes a near-white pale mint; the accent is almost imperceptible.
+*Why:* in light mode the tenant signal (already thin, per the P0 above) effectively disappears — raising cross-tenant risk.
+*Change:* in light theme, use the accent as a saturated `primaryContainer` fill or a bold left-edge/underline accent rather than washing it to near-white. The tenant colour must survive both themes at a glance.
+
+---
+
+## 3. Information architecture & navigation
+
+**[bottom nav] Home · Chats · You — solid three-tab spine. ✅**
+Right level of simplicity for one power user. "You" as the profile+config hub is a reasonable home for tenant switching and settings.
+
+**[02] Tab says "Chats," screen title says "Sessions" — P1.**
+*Why:* two names for one destination; "Sessions" is the gateway's word, "Chats" is the user's word. Pick one.
+*Change:* title the screen "Chats" to match the tab (keep "session" only in body text where it's a technical noun).
+
+**[01/06] Profile switching lives in two places with two visual languages — P1.**
+*What:* Home/Chats switch tenants via pill **chips**; the You tab switches via coloured **avatar circles**. Both are "pick a tenant," styled differently.
+*Why:* the most safety-critical control in a multi-tenant app should be one unmistakable, consistent control.
+*Change:* standardise on one tenant-switcher component (I'd use the coloured-avatar treatment — it carries the colour identity — as a compact row, reused on Home/Chats/You). See §8.
+
+**[01] The four quick-link chips are a mini-nav bolted onto Home — P2.**
+*What:* Cron/Messaging/Usage/Agents scroll horizontally (Agents is clipped), duplicating destinations that also live under "You."
+*Why:* they compete with the hero and hide the fact that some (Agents/Usage) are error-prone secondary screens.
+*Change:* keep them, but make each feed section header tappable ("UPCOMING ›" jumps to Cron) so the feed itself is the navigation, and reduce the standalone chip row to the 2–3 you actually reach daily.
+
+**[06/07] "Models" (You) vs "Models & memory" (Settings) overlap — P2.**
+*Why:* two entry points named almost identically; unclear which owns default-model selection.
+*Change:* merge, or rename one ("Model catalog" vs "Model defaults & memory") so the split is obvious.
+
+---
+
+## 4. Interaction design & affordances
+
+**[03/11] Model selector is not discoverable — P1 (arguably the highest-value interaction fix).**
+*What:* the Chat top bar shows back · "Chat / Profile: acme" · Connected/Offline. No visible model control. The current model ("opus") only appears back in the session list.
+*Why:* "switch models" is a stated core job. If the affordance is a small unlabelled text button, users won't find it, and they can't see which model is answering.
+*Change:* put an explicit, always-visible model pill in the top bar or just above the composer: `⌄ opus` styled as an outlined assist-chip. Tapping opens the model bottom sheet. Showing the *current* model persistently also doubles as a "which brain is this" cue.
+
+**[01] "Needs You" rows have no affordance or action — P1.**
+*What:* row = red icon + title + one-line status. No chevron, no timestamp, no inline action.
+*Why:* on an "act on a few" screen, the top-priority rows should telegraph what tapping does and, ideally, offer the fix in place.
+*Change:* add a trailing chevron (or an inline "Retry"/"View" text button) and a relative time ("failed 2h ago"). For a failed cron, a one-tap "Run now" on the row is the money interaction.
+
+**[03/11] Composer send arrow reads as disabled — P2.**
+*What:* the send glyph is low-contrast grey even in the connected state.
+*Change:* when the field is non-empty and connected, tint the send button `primary`; keep grey only for empty/offline. Add the disabled/enabled distinction explicitly.
+
+**[03] Composer placeholder is doing too much — P2.**
+*What:* "Message Hermes… (/ commands · @ attach)" crams three ideas into a two-line placeholder next to a paperclip that already means "attach."
+*Change:* placeholder = "Message Hermes…"; surface "/ for commands" as a subtle helper only on focus; the paperclip already covers attach.
+
+**[02] "Archived" is a bare text button in the app bar — P2.**
+*Change:* make it a standard app-bar action (icon + label, or overflow menu item) with a proper 48dp target.
+
+---
+
+## 5. Empty / loading / error states & resilience
+
+**[05 cron detail] "Failed to load cron job" — bare top-left text — P0.**
+*What:* accent bar, then unstyled body text at top-left. No icon, no explanation, no Retry, no back-to-list guidance.
+*Why:* this is the single most "broken/unfinished" surface in the app; on a beta it reads as a crash.
+*Change:* standard error component — centred column: error icon, "Couldn't load this job," secondary line ("Check your connection to the gateway"), and a filled **Retry** button. See shared spec below.
+
+**[09 agents] "Failed to load" — centred text, still no icon/Retry — P1.**
+Same fix; note it's *centred* here but *top-left* in 05 — proof there's no shared error component.
+
+**[11 chat] Offline banner styling — P1.**
+*What:* full-width flat brick-red bar, "Offline" left, "Retry" right, and a **duplicate** red-dot "Offline" already in the app bar.
+*Why:* (a) flat saturated red isn't M3 error styling and clashes with the accent bar above it; (b) purple "Retry" on dark red is low-contrast; (c) two "Offline" indicators; (d) copy doesn't tell me whether my typed message is queued or lost.
+*Change:* use `errorContainer`/`onErrorContainer` (softer) for the banner; make "Retry" `onErrorContainer` or an outlined button so it passes contrast; drop the redundant app-bar dot **or** the banner (keep the banner — it's more informative); reword to "You're offline — messages will send when reconnected" + Retry.
+
+**[08 usage] All-zero screen with no empty state — P1.**
+*What:* Sessions 0 / API calls 0 / $0.00 / "TOP MODELS" then nothing.
+*Why:* indistinguishable from a broken/unpopulated screen; also no time range, so the number means nothing.
+*Change:* add a range selector (Today/7d/30d) in the bar; under an empty "TOP MODELS," show "No usage in this period yet." If zeros are a load failure, route to the error component instead.
+
+**[shared] Define ONE error/empty/loading component — P1.**
+*Change:* `HermesStatePanel(icon, title, body, primaryAction)` reused by cron detail, agents, usage, chat cold-open, and any list. Loading = centred progress + skeleton rows (not blank). This one component retires findings 05/09/08 at once.
+
+---
+
+## 6. Content & microcopy
+
+- **[05/09] "Failed to load" / "Failed to load cron job" — P1.** Unfriendly, no next step. → "Couldn't load this job. Retry."
+- **[02] "Sessions" vs "Chats" — P1** (see §3). Pick "Chats."
+- **[11] "Offline" (×2, terse) — P1.** → one banner: "You're offline — new messages will send when you reconnect."
+- **[01] "Profile: acme" subtitle duplicates the selected chip AND the avatar — P2.** Drop the subtitle once the tenant chip is persistent (§8); the label is stated 3× on Home.
+- **[02] Every session row repeats "acme · …" while filtered to acme under an ACME group — P2.** Drop the tenant prefix when the list is already tenant-scoped; show workspace/model instead ("acme-web · opus").
+- **[08] "Est. cost $0.00" with no range — P2.** → "Est. cost (7d)".
+- **[06] "Auto colour for \"acme\"" — P2 (already clear, minor).** Fine; consider "Accent — auto (green)" so the value is visible without drilling in.
+
+---
+
+## 7. Accessibility
+
+**[11] "Retry" purple on dark-red banner — P1 (contrast fail).** Purple (~lavender) on brick red is well under 4.5:1. Fix with the errorContainer restyle in §5.
+
+**[10 light] Tenant accent near-invisible in light mode — P1** (also §2). A near-white bar can't carry meaning; colourblind or low-vision users lose the tenant cue entirely.
+
+**[03/11] Grey send arrow & grey secondary text on near-black — P2.** Verify the muted grays ("Next: Jul 5…", "opus · 24 msg", placeholder) clear 4.5:1; several look ~3:1. Bump one step lighter.
+
+**Touch targets — P2.** "Archived," "Retry," the model-selector text button, and the small copy icon should each be ≥48×48dp. Chips and rows look fine.
+
+**Colour-only signalling — mostly good ✅ with one gap.** "Needs You" pairs red with a text status ("Last run failed"/"Overdue") — good, not colour-only. Profile avatars carry a **letter** (A/G/I/D) as well as colour — good, colourblind-safe. *Gap:* the Chat "Connected/Offline" dot leans on green/red; the accompanying word helps, but ensure the offline state also changes shape/icon (it does add the banner — keep that).
+
+---
+
+## 8. Multi-tenant clarity (cross-tenant mistake risk)
+
+**[03/11 chat] While *acting*, the tenant signal is thin — P0/P1.**
+*What:* in Chat — the screen where you approve/redirect/send — the only "which client" cues are the small "Profile: acme" subtitle and the top-bar colour (which, per §2, is the *only* place the accent survives). When you're heads-down replying, it's easy to miss which tenant you're instructing.
+*Why:* cross-tenant leakage (telling acme's agent something meant for globex) is the highest-cost error this app can cause. The signal should be impossible to miss at the moment of action.
+*Change:* add a **persistent tenant token** in/near the composer and app bar: the coloured avatar chip ("🟢 acme") pinned next to the send affordance, so it sits in the user's field of view exactly when they act. Consider a subtle accent hairline on the composer border in the tenant colour. When the accent system is fully wired (§2 P0), this gets much stronger for free.
+
+**[01/02] Redundant tenant labels dilute the signal — P2.**
+Stating "acme" in the bar + subtitle + chip + every row **habituates** the user to ignore it. Say it *once, boldly* (the persistent token) rather than four times quietly — repetition here reduces, not increases, safety.
+
+**[06] Per-tenant avatar colours + letters — good foundation. ✅**
+default=pink D, acme=green A, globex=gold G, initech=purple I. Distinct, letter-backed, colourblind-safe. This is the right primitive — now propagate it everywhere a tenant is referenced (chips, chat token, session rows) so the *same* colour+letter means the *same* client across the whole app.
+
+**[04/08] Screens don't restate scope — P2.**
+Cron list and Usage show data but the "Profile: acme" is easy to lose. If Usage is acme-only, say so ("acme · last 7 days"); if it's all-tenant, that's a **potential isolation concern** to make explicit. Never let a data screen be ambiguous about whose data it is.
+
+---
+
+## What's already good (keep)
+
+- **Needs-You-first Home feed** — the core concept is right and well-sectioned.
+- **Sessions grouped profile→workspace with counts** and a search field — clean IA.
+- **Chat rendering:** full-width assistant text, bubbled user turn, monospace code block with copy.
+- **Settings:** clear, well-scoped subtitles; **Diagnostics = shareable debug log** is exactly what a solo-dev beta needs.
+- **Profile avatars:** colour + letter, distinct per tenant — a strong, accessible identity primitive.
+- **Connected/Offline** status surfaced in the Chat bar.
+
+---
+
+## Top 5 quick wins (cheap, high-impact)
+
+1. **Ship one `HermesStatePanel` for error/empty/loading** (icon + message + Retry), reused on cron-detail, agents, usage, chat cold-open. Kills the two bare "Failed to load" screens (P0/P1) in one change.
+2. **Make the current model a visible pill** in the Chat top bar / above the composer (`⌄ opus`). Restores discoverability of a headline feature (P1).
+3. **Restyle the offline banner** to M3 `errorContainer` + fix the "Retry" contrast + single (not double) offline indicator + clearer copy (P1, a11y).
+4. **Rename the Chats title** from "Sessions" → "Chats" and **drop the redundant "acme ·" prefix** on tenant-scoped session rows (P1/P2).
+5. **Add status to Cron-list rows** (red "Failed"/"Overdue" badge) so Home's "Needs You" and the Cron list agree (P1).
+
+## Top 3 bigger bets
+
+1. **Wire the per-tenant accent through the whole `ColorScheme`** so section headers, chips, icons, and both FABs adopt the active tenant's colour in *both* themes. This is the difference between "purple app with a green hat" and a genuinely tenant-coloured remote — and it directly hardens multi-tenant safety.
+2. **A persistent, unmissable tenant token at the point of action** (composer/app-bar avatar chip + accent composer hairline), plus a single standardised tenant-switcher component reused on Home/Chats/You. Lowers the highest-cost error (cross-tenant instruction).
+3. **Make the Home feed the navigation and compress the chrome:** collapsing top bar, tappable section headers that deep-link (UPCOMING→Cron), and actionable "Needs You" rows (relative time + inline "Run now"/"Retry"). Pushes the app fully into "reach everything, act on a few."
+
+---
+
+### Finding counts
+- **P0:** 3  (accent system half-wired [§2]; bare cron-detail error [§5]; thin tenant signal while acting [§8])
+- **P1:** 14
+- **P2:** 12

--- a/docs/superpowers/plans/2026-07-05-ux-quick-wins.md
+++ b/docs/superpowers/plans/2026-07-05-ux-quick-wins.md
@@ -1,0 +1,424 @@
+# UX Quick Wins (batch) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Top-5 UX quick wins — styled error/empty states, full per-tenant accent wiring, a visible model chip, cron status in the list, and a chat-composer tenant token.
+
+**Architecture:** Five independent Compose-only changes over existing infrastructure (`ScreenStates`, `LocalProfileAccent`, `needsAttention`, `ModelSelectorSheet`). One pure helper (`cronRowStatus`) is unit-tested; the rest is verified on-device.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing state/data only. Material 3.
+- Multi-tenant isolation preserved; no unrelated refactors.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## File Structure
+
+- Create `app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt` + test (Task 1).
+- Modify `ui/cron/CronDetailScreen.kt`, `ui/cron/CronScreen.kt`, `ui/tools/AgentsToolsScreen.kt`, `ui/usage/UsageScreen.kt` (Task 2).
+- Modify ~8 screens: `colorScheme.primary` → accent (Task 3).
+- Modify `ui/chat/ChatScreen.kt` (Task 4).
+- Modify `ui/cron/CronScreen.kt` (Task 5).
+- Create `app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt`; modify `ui/chat/ChatScreen.kt`, `ui/nav/YouHubScreen.kt` (Task 6).
+
+---
+
+### Task 1: Pure `cronRowStatus` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt`
+
+**Interfaces:**
+- Consumes: `needsAttention(listOf(job), now)` / `CronAlertReason` from `com.hermes.client.ui.activity` (`ui/activity/NeedsYou.kt`).
+- Produces: `enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }`; `fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val NOW = 1_700_000_000_000L
+private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.time.ZoneOffset.UTC).toString()
+private fun job(
+    id: String = "j1", enabled: Boolean = true, state: String? = null,
+    pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+) = CronJobDto(
+    id = id, enabled = enabled, state = state, pausedAt = pausedAt,
+    nextRunAt = nextRunAt, lastStatus = lastStatus,
+)
+
+class CronRowStatusTest {
+    @Test fun failed_last_run_is_FAILED() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(lastStatus = "error"), NOW))
+    }
+    @Test fun overdue_is_OVERDUE() {
+        assertEquals(CronRowStatus.OVERDUE, cronRowStatus(job(nextRunAt = iso(NOW - 10 * 60_000)), NOW))
+    }
+    @Test fun paused_or_disabled_not_failed_is_PAUSED() {
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(state = "paused"), NOW))
+        assertEquals(CronRowStatus.PAUSED, cronRowStatus(job(enabled = false), NOW))
+    }
+    @Test fun healthy_future_is_OK() {
+        assertEquals(CronRowStatus.OK, cronRowStatus(job(lastStatus = "success", nextRunAt = iso(NOW + 3_600_000)), NOW))
+    }
+    @Test fun failed_takes_priority_over_paused() {
+        assertEquals(CronRowStatus.FAILED, cronRowStatus(job(state = "paused", lastStatus = "error"), NOW))
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronRowStatusTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `cronRowStatus`/`CronRowStatus`.
+
+- [ ] **Step 3: Implement `CronRowStatus.kt`**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import com.hermes.client.data.network.CronJobDto
+import com.hermes.client.ui.activity.CronAlertReason
+import com.hermes.client.ui.activity.needsAttention
+
+enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }
+
+/** Pure: a cron job's at-a-glance status for the list. FAILED (last run errored) takes priority,
+ *  then OVERDUE, then PAUSED (disabled/paused), else OK. Reuses [needsAttention]. */
+fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus {
+    val alert = needsAttention(listOf(job), nowMs).firstOrNull()
+    return when {
+        alert?.reason == CronAlertReason.FAILED -> CronRowStatus.FAILED
+        alert?.reason == CronAlertReason.OVERDUE -> CronRowStatus.OVERDUE
+        !job.enabled || job.isPaused -> CronRowStatus.PAUSED
+        else -> CronRowStatus.OK
+    }
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronRowStatusTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronRowStatus.kt app/src/test/java/com/hermes/client/ui/cron/CronRowStatusTest.kt
+git commit -m "feat(cron): pure cronRowStatus for list status icons"
+```
+
+---
+
+### Task 2: Styled error/empty states (Item 1)
+
+**Files:** Modify `ui/cron/CronDetailScreen.kt`, `ui/cron/CronScreen.kt`, `ui/tools/AgentsToolsScreen.kt`, `ui/usage/UsageScreen.kt`
+
+**Interfaces:** Consumes existing `com.hermes.client.ui.components.{ErrorState, EmptyState}` — `ErrorState(message: String, modifier = Modifier.fillMaxSize(), onRetry: (() -> Unit)? = null)`, `EmptyState(title: String, modifier = …, subtitle: String? = null, …)`.
+
+- [ ] **Step 1: CronDetailScreen** — replace the bare error `Text`
+
+Find `state.job == null -> Text(state.error ?: "Not found", …)` (~line 77) and replace with:
+```kotlin
+                state.job == null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error ?: "Couldn't load this cron job",
+                    onRetry = { vm.load(jobId) },
+                )
+```
+(`jobId` is the composable's nav-arg param, already used in `LaunchedEffect(jobId) { vm.load(jobId) }`.)
+
+- [ ] **Step 2: CronScreen** — error + empty
+
+Replace the `state.error != null -> Text(...)` and `state.jobs.isEmpty() -> Text(...)` branches (~lines 52-59) with:
+```kotlin
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+                state.jobs.isEmpty() -> com.hermes.client.ui.components.EmptyState(
+                    title = "No cron jobs",
+                    subtitle = "Scheduled jobs for this profile will show up here.",
+                )
+```
+
+- [ ] **Step 3: AgentsToolsScreen** — error + empty
+
+Replace `state.error != null -> Text(state.error!!, …)` (~line 42) with:
+```kotlin
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+```
+If there is a "no skills/toolsets" empty case rendered as blank/nothing, add an `EmptyState(title = "No agents or tools")` branch (read the file to place it in the same `when`); if the screen has no empty branch, add one after the error branch guarded on the loaded-but-empty condition it exposes.
+
+- [ ] **Step 4: UsageScreen** — error
+
+Replace `state.error != null -> Text(state.error!!, …)` (~line 111) with:
+```kotlin
+                state.error != null -> com.hermes.client.ui.components.ErrorState(
+                    message = state.error!!, onRetry = { vm.load() },
+                )
+```
+
+- [ ] **Step 5: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`. (If a bare `Text` sat inside a centering `Box`, the `ErrorState`/`EmptyState` already fill/center themselves — remove any now-redundant `Modifier.align`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+git commit -m "feat(ux): route error/empty screens through shared ScreenStates (icon + Retry)"
+```
+
+---
+
+### Task 3: Wire the per-tenant accent into content (Item 2)
+
+**Files:** Modify (grep each; line numbers are guides): `ui/activity/MissionControlScreen.kt`, `ui/cron/CronScreen.kt`, `ui/cron/CronDetailScreen.kt`, `ui/chat/ChatScreen.kt`, `ui/chat/ChatComponents.kt`, `ui/usage/UsageScreen.kt`, `ui/sessions/SessionsScreen.kt`, `ui/models/ModelSelector.kt`, `ui/nav/YouHubScreen.kt`
+
+**Interfaces:** Consumes `com.hermes.client.ui.theme.LocalProfileAccent` (`.current.accent: Color`, a `@Composable` read). `HermesTheme` provides it app-wide for the active profile; MissionControl re-provides per page.
+
+- [ ] **Step 1: Replace in-content accent colour at each site**
+
+For each file, add `import com.hermes.client.ui.theme.LocalProfileAccent` and replace **in-content accent** uses of `MaterialTheme.colorScheme.primary` with `LocalProfileAccent.current.accent`. The sites (find via `grep -n "colorScheme.primary"` in each file and match the description):
+
+- `MissionControlScreen.kt` — the `SectionHeader` label `color`; the `ActivityRow` non-error icon `tint`.
+- `CronScreen.kt` — the schedule-overline `color` **only in the `job.enabled && !job.isPaused` branch** (keep the `else -> MaterialTheme.colorScheme.error`).
+- `CronDetailScreen.kt` — the "PROMPT" and "RUN HISTORY (…)" label colours.
+- `ChatScreen.kt` — the "COMMANDS" and "ATTACH · MENTION" (or similar) section-label colours.
+- `ChatComponents.kt` — the accent icon `tint = MaterialTheme.colorScheme.primary`.
+- `UsageScreen.kt` — the "DAILY TOKENS" / "TOP MODELS" section-label colours. **Leave the chart `inputColor` as `colorScheme.primary`.**
+- `SessionsScreen.kt` — the group-header chevron `tint`, the group label `color`, the `SectionHeader` label `color`, and the other icon `tint`.
+- `ModelSelector.kt` — the current-model row label `color` and the favourite-star `tint`.
+- `YouHubScreen.kt` — the "PROFILES" section label and the selected-avatar-name label `color`.
+
+Do **NOT** change any `colorScheme.error`, `onSurface`, `onSurfaceVariant`, `surfaceVariant`, etc. — only the enumerated `colorScheme.primary` accent uses.
+
+- [ ] **Step 2: Verify no stray content `colorScheme.primary` remain (beyond the intentionally-left chart)**
+
+Run: `grep -rn "colorScheme.primary" app/src/main/java/com/hermes/client/ui/{activity,cron,chat,usage,sessions,models,nav} 2>/dev/null`
+Expected: only the intentional leave-behinds (Usage chart `inputColor`, and any genuinely-semantic primary you deliberately kept). Note them in the report.
+
+- [ ] **Step 3: Compile + full suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(ux): render in-content accents in the active-tenant colour"
+```
+
+---
+
+### Task 4: Visible model chip in the chat header (Item 3)
+
+**Files:** Modify `ui/chat/ChatScreen.kt`
+
+- [ ] **Step 1: Replace the gated TextButton with an always-visible AssistChip**
+
+In the `HermesTopBar(...)` `actions` slot (~line 136-143), replace:
+```kotlin
+                if (providers.isNotEmpty()) {
+                    androidx.compose.material3.TextButton(onClick = { modelSheetOpen = true }) {
+                        Text(currentModel ?: "Model", maxLines = 1)
+                    }
+                }
+                StatusDot(connState)
+```
+with:
+```kotlin
+                androidx.compose.material3.AssistChip(
+                    onClick = { modelSheetOpen = true },
+                    label = { Text(currentModel ?: "Model", maxLines = 1) },
+                    trailingIcon = {
+                        Icon(
+                            androidx.compose.material.icons.Icons.Rounded.ArrowDropDown,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                )
+                StatusDot(connState)
+```
+Add imports if missing (`androidx.compose.material.icons.rounded.ArrowDropDown`, `androidx.compose.foundation.layout.size`, `androidx.compose.ui.unit.dp`). The chip is always shown (tapping opens the sheet, which loads providers).
+
+- [ ] **Step 2: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): visible model chip in the header (always shown, opens the sheet)"
+```
+
+---
+
+### Task 5: Cron status icon in the list (Item 4 UI)
+
+**Files:** Modify `ui/cron/CronScreen.kt`
+
+**Interfaces:** Consumes `cronRowStatus(job, nowMs): CronRowStatus` (Task 1); `LocalProfileAccent` (Task 3 import may already be present).
+
+- [ ] **Step 1: Add a leading status icon to the cron row**
+
+In the jobs `LazyColumn` (the `else ->` branch), compute a stable now and add `leadingContent` to the `ListItem`:
+```kotlin
+            else -> {
+                val nowMs = remember(state.jobs) { System.currentTimeMillis() }
+                LazyColumn(Modifier.fillMaxSize()) {
+                    items(state.jobs, key = { it.id }) { job ->
+                        ListItem(
+                            leadingContent = {
+                                val (icon, tint) = when (cronRowStatus(job, nowMs)) {
+                                    CronRowStatus.FAILED, CronRowStatus.OVERDUE ->
+                                        Icons.Rounded.ErrorOutline to MaterialTheme.colorScheme.error
+                                    CronRowStatus.PAUSED ->
+                                        Icons.Rounded.PauseCircleOutline to MaterialTheme.colorScheme.onSurfaceVariant
+                                    CronRowStatus.OK ->
+                                        Icons.Rounded.CheckCircle to com.hermes.client.ui.theme.LocalProfileAccent.current.accent
+                                }
+                                Icon(icon, contentDescription = null, tint = tint)
+                            },
+                            overlineContent = { /* unchanged */ },
+                            headlineContent = { Text(job.name ?: job.id) },
+                            supportingContent = { /* unchanged */ },
+                            modifier = Modifier.clickable { onOpen(job.id) },
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+```
+Keep the existing `overlineContent`/`supportingContent` bodies as they are (Task 3 already handled the overline colour). Add imports: `androidx.compose.material.icons.rounded.{ErrorOutline, PauseCircleOutline, CheckCircle}`, `androidx.compose.material3.Icon`, `androidx.compose.runtime.remember`.
+
+- [ ] **Step 2: Compile + full suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+git commit -m "feat(cron): leading status icon (failed/overdue/paused/ok) in the cron list"
+```
+
+---
+
+### Task 6: Tenant token near the composer (Item 5)
+
+**Files:** Create `ui/components/ProfileAvatar.kt`; Modify `ui/chat/ChatScreen.kt`, `ui/nav/YouHubScreen.kt`
+
+**Interfaces:** Produces `@Composable fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp)`. Consumes `rememberProfileAccent` (`ui/theme/ProfileAccent.kt`).
+
+- [ ] **Step 1: Create `ProfileAvatar.kt`**
+
+```kotlin
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.rememberProfileAccent
+
+/** A lettered, per-tenant-coloured avatar token (the profile's initial in its accent). */
+@Composable
+fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
+    val accent = rememberProfileAccent(name, isSystemInDarkTheme())
+    Box(
+        modifier.size(size).clip(CircleShape).background(accent.accent),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+    }
+}
+```
+
+- [ ] **Step 2: Place it in the chat composer Row**
+
+In `ChatScreen.kt`'s `bottomBar` composer `Row` (~line 146-186), add as the **first** child (before the paperclip `IconButton`):
+```kotlin
+        com.hermes.client.ui.components.ProfileAvatar(activeProfile)
+        Spacer(Modifier.width(4.dp))
+        IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) { /* unchanged */ }
+```
+(`activeProfile` is already collected in `ChatScreen`; `Spacer`/`Modifier.width` already imported.)
+
+- [ ] **Step 3: Refactor `YouHubScreen.ProfileAvatarRow` to reuse `ProfileAvatar`**
+
+In `YouHubScreen.kt`'s private `ProfileAvatarRow` (~lines 201-236), replace the inline `Box(...48dp...) { Text(initial) }` with `com.hermes.client.ui.components.ProfileAvatar(name, size = 48.dp)` wrapped in the existing `clickable { onSwitch(name) }` (keep the name label `Text` below it). Keep behaviour identical (48 dp avatar + name label).
+
+- [ ] **Step 4: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/ProfileAvatar.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+git commit -m "feat(ux): reusable ProfileAvatar; tenant token in the chat composer"
+```
+
+---
+
+### Task 7: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Use the mock (`http://10.0.2.2:8899`) which has multiple profiles, a failed + overdue cron (acme), and models.
+
+- [ ] **Step 2: Verify all five**
+
+1. **Error/empty:** open a cron detail with a bad id (or kill the mock mid-load), and the Cron/Agents/Usage screens under error → each shows the **icon + message + Retry** state (not bare text); an empty cron/agents profile shows the styled empty state.
+2. **Accent:** switch profiles (acme/globex/initech) → section headers, list icons, cron overline, chat command labels, sessions group headers render in that tenant's colour, in **both light and dark**.
+3. **Model chip:** the chat header shows a **chip** (model name + caret), visible even on cold-open; tap → the model sheet opens.
+4. **Cron status:** the Cron list shows a leading status icon per row — a failed job red, healthy a check (in the tenant accent), paused a pause glyph.
+5. **Composer token:** the chat composer shows the tenant avatar (correct letter + colour) left of the paperclip; it matches the active profile.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(ux): quick-wins verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Item 1 → Task 2 (route 4 screens through ScreenStates + Retry) ✓; Item 2 → Task 3 (accent at enumerated sites; error/onSurface untouched; chart left) ✓; Item 3 → Task 4 (always-visible AssistChip, un-gated) ✓; Item 4 → Task 1 (pure `cronRowStatus` + test) + Task 5 (leading icon) ✓; Item 5 → Task 6 (`ProfileAvatar` extract + composer token + YouHub reuse) ✓; on-device incl. light+dark, cold-open chip, error/empty, cron icons, composer token → Task 7 ✓; no bridge changes ✓.
+- **Placeholder scan:** every code step has concrete code; the conditional bits are the Task 2 AgentsTools empty-branch placement (guarded read-the-file), Task 3's "find via grep" (line numbers are guides, sites enumerated by description), and the Task 7 verification-only commit.
+- **Type consistency:** `cronRowStatus(job, nowMs): CronRowStatus{FAILED,OVERDUE,OK,PAUSED}` (Task 1) consumed in Task 5; `ErrorState(message,onRetry)`/`EmptyState(title,subtitle)` (existing) in Task 2; `LocalProfileAccent.current.accent` (Task 3) in Tasks 3+5; `ProfileAvatar(name, modifier, size)` (Task 6) used in chat + YouHub. Consistent.
+
+**Ordering:** Task 1 (pure) stands alone. Tasks 2, 4, 6 are independent UI items. Task 3 (accent) is broad but independent. Task 5 depends on Task 1. Task 7 verifies. (Tasks touch mostly disjoint files; `CronScreen.kt` is touched by Tasks 2, 3, 5 and `ChatScreen.kt` by Tasks 3, 4, 6 — execute in order to avoid conflicts.)

--- a/docs/superpowers/specs/2026-07-05-ux-quick-wins-design.md
+++ b/docs/superpowers/specs/2026-07-05-ux-quick-wins-design.md
@@ -1,0 +1,124 @@
+# UX Quick Wins (batch) — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/ux-quick-wins`
+**Source:** Top-5 quick wins in `docs/ideas/ux-review-2026-07-04.md`
+
+## Goal
+
+Five self-contained, no-bridge-change UI improvements, shipped together (one task each): styled error/empty states, full per-tenant accent wiring, a visible model chip, cron status in the list, and a persistent tenant token near the chat composer.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing state/data only. Material 3.
+- Multi-tenant isolation preserved (never blend client data).
+- Follow existing patterns; no unrelated refactors.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Item 1 — Route bare error/empty screens through the shared state composables
+
+`ui/components/ScreenStates.kt` already defines `LoadingState`, `ErrorState(message, modifier, onRetry)` (icon + message + **Retry**), and `EmptyState(title, subtitle, icon, actionLabel, onAction)`. Several screens bypass them with a bare `Text(error!!)`. Route these through the shared composables (retry wired to each VM's `load`):
+
+- `ui/cron/CronDetailScreen.kt:77` — `state.job == null -> Text(state.error ?: "Not found", …)` → `ErrorState(message = state.error ?: "Couldn't load this cron job", onRetry = { vm.load(jobId) })`. (`jobId` is the screen's nav arg, already used at line 53.)
+- `ui/cron/CronScreen.kt:52-59` — error `Text` → `ErrorState(message = state.error!!, onRetry = { vm.load() })`; empty `Text` → `EmptyState(title = "No cron jobs", subtitle = "Scheduled jobs for this profile will show up here.")`.
+- `ui/tools/AgentsToolsScreen.kt:42-43` — error `Text` → `ErrorState(message = state.error!!, onRetry = { vm.load() })` (`ToolsViewModel.load()`); add `EmptyState(title = "No agents or tools")` for the empty case.
+- `ui/usage/UsageScreen.kt:111-112` — error `Text` → `ErrorState(message = state.error!!, onRetry = { vm.load() })`.
+
+Leave `ChatScreen`'s `ConnectionBanner` as-is (already a styled `errorContainer` banner with Retry). Each `ErrorState`/`EmptyState` fills its content area (`Modifier.align(Center)` sites become the state composable centered in the same box/scaffold padding).
+
+## Item 2 — Wire the per-tenant accent through in-content elements
+
+**Verified:** `HermesTheme(profile = activeProfile)` (Theme.kt:36, fed by `MainActivity`) provides `LocalProfileAccent` app-wide as the **active** profile's accent; `MissionControlScreen` re-provides it per pager page. So reading `LocalProfileAccent.current.accent` in content yields the active tenant colour everywhere (and the correct per-page colour on the feed).
+
+Replace `MaterialTheme.colorScheme.primary` with `LocalProfileAccent.current.accent` at these **in-content accent** sites (imports: `com.hermes.client.ui.theme.LocalProfileAccent`):
+
+- `ui/activity/MissionControlScreen.kt` — `SectionHeader` label (`:259`), `ActivityRow` non-error icon tint (`:311`).
+- `ui/cron/CronScreen.kt:70` — the schedule overline colour (enabled/not-paused branch only; keep the `error` colour for the paused/disabled branch).
+- `ui/cron/CronDetailScreen.kt:115,123` — the "PROMPT" / "RUN HISTORY" labels.
+- `ui/chat/ChatScreen.kt:197,214` — the "COMMANDS" / "ATTACH · MENTION" labels.
+- `ui/chat/ChatComponents.kt:354` — the accent icon tint.
+- `ui/usage/UsageScreen.kt:128,134` — the section labels. **Leave `:159` (chart `inputColor`)** as `colorScheme.primary` for now unless it reads cleanly as the accent — the chart colour is a separate concern; changing it is optional and can stay primary.
+- `ui/sessions/SessionsScreen.kt:308,315,335,411` — group-header chevron tint, group label, `SectionHeader` label, and the icon tint.
+- `ui/models/ModelSelector.kt:148,191` — current-model row label and the favourite-star tint.
+- `ui/nav/YouHubScreen.kt:74,230` — "PROFILES" label and the selected-avatar-name label.
+
+Do **not** touch semantic non-accent uses of `colorScheme.error`/`onSurface`/etc. This item is purely `colorScheme.primary` → `LocalProfileAccent.current.accent` at the enumerated call sites. (`LocalProfileAccent.current.accent` is a `@Composable` read — valid at all these sites.)
+
+## Item 3 — Visible model chip in the chat header
+
+`ChatScreen.kt` (~138) currently renders the model control as a `TextButton(Text(currentModel ?: "Model"))` **gated on `providers.isNotEmpty()`** (so it's hidden until providers load, e.g. on cold-open) and reads as flat text. Replace with an always-visible, obviously-tappable chip:
+
+```kotlin
+androidx.compose.material3.AssistChip(
+    onClick = { modelSheetOpen = true },
+    label = { Text(currentModel ?: "Model", maxLines = 1) },
+    trailingIcon = { Icon(Icons.Rounded.ArrowDropDown, contentDescription = null, Modifier.size(18.dp)) },
+)
+```
+
+- Remove the `if (providers.isNotEmpty())` gate — always show the chip (tapping opens the sheet, which loads providers). Keep `StatusDot(connState)` after it.
+- The chip sits in the top-bar `actions` slot; its content inherits the accent-tinted `onBar` content colour as today.
+
+## Item 4 — Cron status indicator in the Cron list
+
+Add a **leading status icon** to each `CronScreen` row so failed/overdue jobs are triage-able from the list (same iconography as Home). Add a pure, unit-tested helper:
+
+`ui/cron/CronRowStatus.kt`:
+```kotlin
+enum class CronRowStatus { FAILED, OVERDUE, OK, PAUSED }
+
+/** Pure: a cron job's at-a-glance status for the list. Reuses needsAttention for FAILED/OVERDUE. */
+fun cronRowStatus(job: CronJobDto, nowMs: Long): CronRowStatus = when {
+    needsAttention(listOf(job), nowMs).firstOrNull()?.reason == CronAlertReason.FAILED -> CronRowStatus.FAILED
+    needsAttention(listOf(job), nowMs).firstOrNull()?.reason == CronAlertReason.OVERDUE -> CronRowStatus.OVERDUE
+    !job.enabled || job.isPaused -> CronRowStatus.PAUSED
+    else -> CronRowStatus.OK
+}
+```
+In `CronScreen.kt`'s `ListItem`, add `leadingContent = { Icon(...) }`:
+- `FAILED`/`OVERDUE` → `Icons.Rounded.ErrorOutline`, tint `MaterialTheme.colorScheme.error`.
+- `PAUSED` → `Icons.Rounded.PauseCircleOutline`, tint `onSurfaceVariant`.
+- `OK` → `Icons.Rounded.CheckCircle`, tint `LocalProfileAccent.current.accent`.
+
+Compute `nowMs = remember(state.jobs) { System.currentTimeMillis() }` in the list scope.
+
+## Item 5 — Persistent tenant token near the chat composer
+
+Extract the lettered, accent-coloured avatar (today private `ProfileAvatarRow` in `YouHubScreen.kt:201-236`) into a reusable composable in `ui/components/ProfileAvatar.kt`:
+
+```kotlin
+@Composable
+fun ProfileAvatar(name: String?, modifier: Modifier = Modifier, size: Dp = 28.dp) {
+    val dark = isSystemInDarkTheme()
+    val accent = rememberProfileAccent(name, dark)
+    Box(modifier.size(size).clip(CircleShape).background(accent.accent), contentAlignment = Alignment.Center) {
+        Text((name ?: "·").take(1).uppercase(), color = accent.onAccent, style = MaterialTheme.typography.labelLarge)
+    }
+}
+```
+- Place a `ProfileAvatar(activeProfile)` as the **leftmost** element of the Chat composer `Row` (`ChatScreen.kt:146-186`), before the paperclip `IconButton`, with a trailing `Spacer(Modifier.width(4.dp))`. It shows the active client's letter in its accent — always visible while typing.
+- Refactor `YouHubScreen`'s `ProfileAvatarRow` to use the new `ProfileAvatar` (drop the duplicated Box/Text; keep its 48 dp size + the name label below).
+
+## Testing
+
+- **Unit (pure), TDD — `CronRowStatusTest`:** failed `lastStatus="error"` → FAILED; overdue → OVERDUE; paused/disabled → PAUSED; healthy future → OK; FAILED priority over OVERDUE.
+- **On-device (per item):**
+  1. CronDetail with a bad id, Cron list load error, Agents error, Usage error → styled icon + message + **Retry** (not bare text); empty cron/agents → styled empty state.
+  2. Switch profiles (acme/globex/initech) → section headers, icons, cron overline, chat command labels, etc. all render in that tenant's accent (both light + dark).
+  3. Chat header shows a model **chip** (name + caret), visible on cold-open, taps → the model sheet.
+  4. Cron list rows show a leading status icon; a failed job is red, healthy shows a check, paused shows a pause.
+  5. The chat composer shows the tenant avatar token (correct letter + colour) next to the paperclip.
+
+## Not doing (YAGNI)
+
+- Any new component beyond `ProfileAvatar` (Item 1 reuses existing `ScreenStates`).
+- Chart-colour accenting (Usage `:159`) unless trivially clean.
+- Changing `ChatScreen`'s `ConnectionBanner` (already styled).
+- The P1/P2 items from the review (this batch is the Top-5 quick wins only).
+- Any gateway/API change.
+
+## Open questions (non-blocking; plan may settle)
+
+- Model chip style (`AssistChip` vs a tonal pill) — `AssistChip` proposed; the plan pins it.
+- Composer token size (28 dp proposed).


### PR DESCRIPTION
## Promote develop → main (production 0.1.32)

Promotes the UX quick-wins batch to production. main was last at 0.1.31 (#54).

### What ships to production (0.1.32)
The Top-5 UX quick wins from the design review — Compose-only, no bridge changes:
1. Styled error/empty states with **Retry** (fixes the bare "Failed to load…" screens).
2. Per-tenant **accent** wired through content (headers, list icons, cron overlines) — switches per client (acme green ↔ globex gold).
3. Visible **model chip** in the chat header.
4. **Cron status** icons in the list (failed/overdue/paused/ok).
5. Chat-composer **tenant token** + a reusable `ProfileAvatar`.

Built via spec → plan → subagent-driven development with per-task and opus final review; all five verified on-device (acme + globex). No bridge/gateway API changes.
