### PR TITLE
Promote to production: 0.1.33 (UX P1 wave 2)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 33
-        versionName = "0.1.32"
+        versionCode = 34
+        versionName = "0.1.33"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -54,6 +54,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.data.network.ConnectionState
 import com.hermes.client.ui.components.StatusDot
+import com.hermes.client.ui.components.bannerLabel
 import com.hermes.client.ui.components.connectionLabel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -297,14 +298,19 @@ private fun ConnectionBanner(state: ConnectionState, onRetry: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = connectionLabel(state),
+            text = bannerLabel(state),
             color = MaterialTheme.colorScheme.onErrorContainer,
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.weight(1f),
         )
         // While Connecting the client is already trying — no point offering a manual retry.
         if (state !is ConnectionState.Connecting) {
-            TextButton(onClick = onRetry) { Text("Retry") }
+            TextButton(
+                onClick = onRetry,
+                colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) { Text("Retry") }
         }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/components/HermesTopBar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/HermesTopBar.kt
@@ -31,9 +31,9 @@ fun HermesTopBar(
     val dark = isSystemInDarkTheme()
     val barBg = if (dark) accent.container else accent.accent
     val barOn = if (dark) accent.onContainer else accent.onAccent
-    // Soft tint: a pale accent-tinted bar with a contrast-checked dark/light on-color. Keeps
-    // the tenant signal without a heavy fully-saturated header, and — critically — every bit
-    // of chrome text/icon must use `onContainer` so nothing (e.g. action labels) goes illegible.
+    // The app bar carries the active tenant's colour: a bold saturated bar (accent + on-accent)
+    // in light mode, and a soft tinted bar (container + on-container) in dark mode. barBg/barOn
+    // pick the right pair so all chrome text/icons stay legible in both themes.
     val colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(
         containerColor = barBg,
         titleContentColor = barOn,

--- a/app/src/main/java/com/hermes/client/ui/components/HermesTopBar.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/HermesTopBar.kt
@@ -1,5 +1,6 @@
 package com.hermes.client.ui.components
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -27,26 +28,29 @@ fun HermesTopBar(
     actions: @Composable androidx.compose.foundation.layout.RowScope.() -> Unit = {},
 ) {
     val accent = LocalProfileAccent.current
+    val dark = isSystemInDarkTheme()
+    val barBg = if (dark) accent.container else accent.accent
+    val barOn = if (dark) accent.onContainer else accent.onAccent
     // Soft tint: a pale accent-tinted bar with a contrast-checked dark/light on-color. Keeps
     // the tenant signal without a heavy fully-saturated header, and — critically — every bit
     // of chrome text/icon must use `onContainer` so nothing (e.g. action labels) goes illegible.
     val colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(
-        containerColor = accent.container,
-        titleContentColor = accent.onContainer,
-        navigationIconContentColor = accent.onContainer,
-        actionIconContentColor = accent.onContainer,
+        containerColor = barBg,
+        titleContentColor = barOn,
+        navigationIconContentColor = barOn,
+        actionIconContentColor = barOn,
     )
     TopAppBar(
         modifier = modifier,
         colors = colors,
         title = {
             Column {
-                Text(title, style = MaterialTheme.typography.titleLarge, color = accent.onContainer)
+                Text(title, style = MaterialTheme.typography.titleLarge, color = barOn)
                 if (subtitle != null) {
                     Text(
                         subtitle,
                         style = MaterialTheme.typography.labelMedium,
-                        color = accent.onContainer.copy(alpha = 0.75f),
+                        color = barOn.copy(alpha = 0.75f),
                     )
                 }
             }
@@ -62,5 +66,7 @@ object AccentChrome {
     val onFab: Color @Composable get() = LocalProfileAccent.current.onAccent
 
     /** Legible content color for anything sitting on the soft-tinted top bar (e.g. action text). */
-    val onBar: Color @Composable get() = LocalProfileAccent.current.onContainer
+    val onBar: Color @Composable get() =
+        if (isSystemInDarkTheme()) LocalProfileAccent.current.onContainer
+        else LocalProfileAccent.current.onAccent
 }

--- a/app/src/main/java/com/hermes/client/ui/components/StatusDot.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/StatusDot.kt
@@ -1,11 +1,13 @@
 package com.hermes.client.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,7 +45,8 @@ fun StatusDot(state: ConnectionState, modifier: Modifier = Modifier, showLabel: 
             modifier = Modifier
                 .size(10.dp)
                 .clip(CircleShape)
-                .background(color),
+                .background(color)
+                .border(1.dp, LocalContentColor.current, CircleShape),
         )
         if (showLabel) {
             Text(

--- a/app/src/main/java/com/hermes/client/ui/components/StatusDot.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/StatusDot.kt
@@ -32,7 +32,7 @@ fun bannerLabel(state: ConnectionState): String = when (state) {
 }
 
 @Composable
-fun StatusDot(state: ConnectionState, modifier: Modifier = Modifier) {
+fun StatusDot(state: ConnectionState, modifier: Modifier = Modifier, showLabel: Boolean = false) {
     val color = when (state) {
         ConnectionState.Connected -> Color(0xFF2E7D32)
         ConnectionState.Connecting, ConnectionState.Reconnecting -> Color(0xFFF9A825)
@@ -45,10 +45,12 @@ fun StatusDot(state: ConnectionState, modifier: Modifier = Modifier) {
                 .clip(CircleShape)
                 .background(color),
         )
-        Text(
-            text = connectionLabel(state),
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(start = 6.dp),
-        )
+        if (showLabel) {
+            Text(
+                text = connectionLabel(state),
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(start = 6.dp),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/components/StatusDot.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/StatusDot.kt
@@ -24,6 +24,13 @@ fun connectionLabel(state: ConnectionState): String = when (state) {
     is ConnectionState.Error -> "Error: ${state.reason}"
 }
 
+/** Friendlier, sentence-form copy for the chat offline/error banner (vs the terse [connectionLabel]). */
+fun bannerLabel(state: ConnectionState): String = when (state) {
+    ConnectionState.Disconnected -> "You're offline — new messages send when you reconnect."
+    is ConnectionState.Error -> "Connection error — tap Retry."
+    else -> connectionLabel(state)
+}
+
 @Composable
 fun StatusDot(state: ConnectionState, modifier: Modifier = Modifier) {
     val color = when (state) {

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.PauseCircleOutline
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -50,7 +51,11 @@ fun CronScreen(
         },
         floatingActionButton = {
             androidx.compose.material3.ExtendedFloatingActionButton(
-                onClick = onNew, text = { Text("New") }, icon = {},
+                onClick = onNew,
+                text = { Text("New") },
+                icon = { Icon(androidx.compose.material.icons.Icons.Rounded.Add, contentDescription = null) },
+                containerColor = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                contentColor = com.hermes.client.ui.components.AccentChrome.onFab,
             )
         },
     ) { padding ->

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -419,7 +419,7 @@ private fun SessionRow(
             // Pinned rows pool across profiles, so the tenant prefix stays to disambiguate;
             // grouped rows already sit under a profile header, so it would be redundant there.
             supportingContent = {
-                Text(listOfNotNull(session.profile.takeIf { showProfile }, session.model).joinToString(" · "))
+                Text(listOfNotNull(session.profile?.takeIf { showProfile && it.isNotBlank() }, session.model).joinToString(" · "))
             },
             // Tap opens the session; long-press opens the management menu.
             modifier = Modifier.combinedClickable(

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -92,7 +92,7 @@ fun SessionsScreen(
         topBar = {
             Column {
                 com.hermes.client.ui.components.HermesTopBar(
-                    title = "Sessions",
+                    title = "Chats",
                     actions = {
                         TextButton(
                             onClick = onOpenArchived,
@@ -214,6 +214,7 @@ fun SessionsScreen(
                                 SessionRow(
                                     session = s,
                                     isPinned = true,
+                                    showProfile = true,
                                     // Switch to the session's profile (awaited) before navigating,
                                     // so the chat resumes against the right per-profile DB.
                                     onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
@@ -259,6 +260,7 @@ fun SessionsScreen(
                                     SessionRow(
                                         session = s,
                                         isPinned = false,
+                                        showProfile = false,
                                         onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                                         onTogglePin = { vm.togglePin(s) },
                                         onRename = { vm.rename(s, it) },
@@ -356,6 +358,7 @@ private fun SectionHeader(label: String, count: Int, note: String? = null) {
 private fun SessionRow(
     session: Session,
     isPinned: Boolean,
+    showProfile: Boolean,
     onOpen: () -> Unit,
     onTogglePin: () -> Unit,
     onRename: (String) -> Unit,
@@ -413,10 +416,10 @@ private fun SessionRow(
                     )
                 }
             } else null,
-            // Show the session's true profile (from the cross-profile list) next to its model so
-            // the tenant is unambiguous before the profile grouping lands.
+            // Pinned rows pool across profiles, so the tenant prefix stays to disambiguate;
+            // grouped rows already sit under a profile header, so it would be redundant there.
             supportingContent = {
-                Text(listOfNotNull(session.profile, session.model).joinToString(" · "))
+                Text(listOfNotNull(session.profile.takeIf { showProfile }, session.model).joinToString(" · "))
             },
             // Tap opens the session; long-press opens the management menu.
             modifier = Modifier.combinedClickable(

--- a/app/src/test/java/com/hermes/client/ui/components/BannerLabelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/components/BannerLabelTest.kt
@@ -1,0 +1,20 @@
+package com.hermes.client.ui.components
+
+import com.hermes.client.data.network.ConnectionState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BannerLabelTest {
+    @Test fun disconnected_is_friendly() {
+        assertEquals(
+            "You're offline — new messages send when you reconnect.",
+            bannerLabel(ConnectionState.Disconnected),
+        )
+    }
+    @Test fun error_is_error_copy() {
+        assertEquals("Connection error — tap Retry.", bannerLabel(ConnectionState.Error("boom")))
+    }
+    @Test fun connecting_delegates_to_connectionLabel() {
+        assertEquals(connectionLabel(ConnectionState.Connecting), bannerLabel(ConnectionState.Connecting))
+    }
+}

--- a/docs/superpowers/plans/2026-07-05-ux-p1-wave2.md
+++ b/docs/superpowers/plans/2026-07-05-ux-p1-wave2.md
@@ -1,0 +1,291 @@
+# UX P1 Wave 2 (batch) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Four UX P1 fixes — legible/deduplicated offline banner, "Chats" naming, bold light-mode tenant app bar, accent Cron FAB.
+
+**Architecture:** Compose-only edits over existing infrastructure (`StatusDot`, `HermesTopBar`/`AccentChrome`, `SessionsScreen`, `CronScreen`). One pure helper (`bannerLabel`) is unit-tested; the rest is verified on-device.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing state/data only. Material 3.
+- Multi-tenant isolation preserved; follow existing patterns (`AccentChrome`, `HermesTopBar`, `LocalProfileAccent`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `ConnectionState` (sealed interface, `com.hermes.client.data.network`): `Disconnected`, `Connecting`, `Connected`, `Reconnecting` (data objects), `Error(val reason: String)`.
+- `StatusDot`/`connectionLabel` in `ui/components/StatusDot.kt`; `StatusDot` has ONE caller: `ChatScreen.kt:156` `StatusDot(connState)`.
+- `HermesTopBar`/`AccentChrome` in `ui/components/HermesTopBar.kt`; `container`/`onContainer` consumed only by the chrome.
+
+---
+
+### Task 1: Pure `bannerLabel` (TDD)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/components/StatusDot.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/components/BannerLabelTest.kt`
+
+**Interfaces:**
+- Produces: `fun bannerLabel(state: ConnectionState): String`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.components
+
+import com.hermes.client.data.network.ConnectionState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BannerLabelTest {
+    @Test fun disconnected_is_friendly() {
+        assertEquals(
+            "You're offline — new messages send when you reconnect.",
+            bannerLabel(ConnectionState.Disconnected),
+        )
+    }
+    @Test fun error_is_error_copy() {
+        assertEquals("Connection error — tap Retry.", bannerLabel(ConnectionState.Error("boom")))
+    }
+    @Test fun connecting_delegates_to_connectionLabel() {
+        assertEquals(connectionLabel(ConnectionState.Connecting), bannerLabel(ConnectionState.Connecting))
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*BannerLabelTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `bannerLabel`.
+
+- [ ] **Step 3: Add `bannerLabel` to `StatusDot.kt`** (beside `connectionLabel`)
+
+```kotlin
+/** Friendlier, sentence-form copy for the chat offline/error banner (vs the terse [connectionLabel]). */
+fun bannerLabel(state: ConnectionState): String = when (state) {
+    ConnectionState.Disconnected -> "You're offline — new messages send when you reconnect."
+    is ConnectionState.Error -> "Connection error — tap Retry."
+    else -> connectionLabel(state)
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*BannerLabelTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/StatusDot.kt app/src/test/java/com/hermes/client/ui/components/BannerLabelTest.kt
+git commit -m "feat(chat): pure bannerLabel for the offline banner copy"
+```
+
+---
+
+### Task 2: Offline banner — dot-only StatusDot, legible Retry, friendly copy (Item 1)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/components/StatusDot.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `bannerLabel` (Task 1).
+
+- [ ] **Step 1: Make `StatusDot` dot-only by default**
+
+Change the `StatusDot` signature + body so the label is opt-in:
+```kotlin
+@Composable
+fun StatusDot(state: ConnectionState, modifier: Modifier = Modifier, showLabel: Boolean = false) {
+    val color = when (state) {
+        ConnectionState.Connected -> Color(0xFF2E7D32)
+        ConnectionState.Connecting, ConnectionState.Reconnecting -> Color(0xFFF9A825)
+        else -> Color(0xFFC62828)
+    }
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Box(Modifier.size(10.dp).clip(CircleShape).background(color))
+        if (showLabel) {
+            Text(
+                text = connectionLabel(state),
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(start = 6.dp),
+            )
+        }
+    }
+}
+```
+(The single caller `ChatScreen.kt:156` `StatusDot(connState)` passes no `showLabel` → dot-only. No other callers exist.)
+
+- [ ] **Step 2: In `ChatScreen.ConnectionBanner`, use `bannerLabel` + legible Retry**
+
+Replace the banner's `Text(text = connectionLabel(state), …)` with `Text(text = bannerLabel(state), …)` (keep `color = MaterialTheme.colorScheme.onErrorContainer`, `style = bodySmall`, `Modifier.weight(1f)`), and make the Retry button legible:
+```kotlin
+        if (state !is ConnectionState.Connecting) {
+            TextButton(
+                onClick = onRetry,
+                colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) { Text("Retry") }
+        }
+```
+
+- [ ] **Step 3: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/StatusDot.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): dedupe offline signal (dot-only status) + legible Retry + friendly copy"
+```
+
+---
+
+### Task 3: "Chats" naming + drop redundant tenant prefix (Item 2)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt`
+
+- [ ] **Step 1: Rename the title**
+
+`HermesTopBar(title = "Sessions", …)` → `title = "Chats"`.
+
+- [ ] **Step 2: Add `showProfile` to `SessionRow` and gate the subtitle**
+
+Add a `showProfile: Boolean` parameter to the private `SessionRow` composable, and change its supporting content:
+```kotlin
+        supportingContent = {
+            Text(listOfNotNull(session.profile.takeIf { showProfile }, session.model).joinToString(" · "))
+        },
+```
+
+- [ ] **Step 3: Pass `showProfile` at the two call sites**
+
+Read the file for the two `SessionRow(...)` call sites: the **Pinned** section (sessions pooled across profiles) and the **grouped** tree (rows nested under a profile header). Pass `showProfile = true` at the Pinned call site and `showProfile = false` at the grouped call site.
+
+- [ ] **Step 4: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+git commit -m "feat(sessions): title 'Chats'; drop redundant profile prefix on grouped rows"
+```
+
+---
+
+### Task 4: Bold per-tenant app bar in light mode (Item 3)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/components/HermesTopBar.kt`
+
+- [ ] **Step 1: Use accent-as-bar in light mode**
+
+At the top of `HermesTopBar` (where `val accent = LocalProfileAccent.current` is), compute:
+```kotlin
+    val accent = LocalProfileAccent.current
+    val dark = androidx.compose.foundation.isSystemInDarkTheme()
+    val barBg = if (dark) accent.container else accent.accent
+    val barOn = if (dark) accent.onContainer else accent.onAccent
+```
+Then replace every `accent.container` with `barBg` and every `accent.onContainer` with `barOn` in this composable: the `TopAppBarDefaults.topAppBarColors(containerColor = …, titleContentColor = …, navigationIconContentColor = …, actionIconContentColor = …)`, the title `Text(color = …)`, and the subtitle `Text(color = ….copy(alpha = 0.75f))`.
+
+- [ ] **Step 2: Make `AccentChrome.onBar` follow the light-mode bar**
+
+```kotlin
+    val onBar: Color @Composable get() =
+        if (androidx.compose.foundation.isSystemInDarkTheme()) LocalProfileAccent.current.onContainer
+        else LocalProfileAccent.current.onAccent
+```
+Do **not** change `ProfileAccent.kt` (`container`/`onContainer` values are unchanged; only the chrome's choice of which to use in light mode changes).
+
+- [ ] **Step 3: Compile + full suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/HermesTopBar.kt
+git commit -m "feat(theme): bold per-tenant app bar in light mode (accent bar + on-accent text)"
+```
+
+---
+
+### Task 5: Cron FAB accent + Add icon (Item 5)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt`
+
+- [ ] **Step 1: Tint the Cron FAB with the accent + add an icon**
+
+Replace the `floatingActionButton = { ExtendedFloatingActionButton(onClick = onNew, text = { Text("New") }, icon = {}) }` with:
+```kotlin
+        floatingActionButton = {
+            androidx.compose.material3.ExtendedFloatingActionButton(
+                onClick = onNew,
+                text = { Text("New") },
+                icon = { Icon(androidx.compose.material.icons.Icons.Rounded.Add, contentDescription = null) },
+                containerColor = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                contentColor = com.hermes.client.ui.components.AccentChrome.onFab,
+            )
+        },
+```
+Add imports if missing: `androidx.compose.material.icons.rounded.Add`, `androidx.compose.material3.Icon`.
+
+- [ ] **Step 2: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+git commit -m "feat(cron): accent-tinted New FAB with Add icon (matches Sessions)"
+```
+
+---
+
+### Task 6: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point at the mock (`http://10.0.2.2:8899`).
+
+- [ ] **Step 2: Verify**
+
+1. **Offline banner:** open a chat cold (WS not yet connected) → **one** "You're offline — new messages send when you reconnect." banner with a **legible** Retry (on-error-container, not lavender); the top bar shows only a **red dot** (no second "Offline"). Once connected, the banner clears and the dot is green.
+2. **Chats naming:** the Chats tab's screen title reads **"Chats"**; grouped session rows show just the model (no "acme ·") in the subtitle; a **Pinned** session still shows `profile · model`.
+3. **Light-mode bar:** toggle light mode + switch profiles → the app bar is a **saturated tenant colour** (acme green / globex gold) with legible text (not near-white); dark mode looks unchanged.
+4. **Cron FAB:** the Cron **New** FAB is the tenant accent with an **Add** icon (matches Sessions).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(ux): p1-wave2 verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Item 1 → Task 1 (`bannerLabel` + test) + Task 2 (dot-only StatusDot, legible Retry, friendly copy) ✓; Item 2 → Task 3 ("Chats" title + `showProfile` gating, pinned keeps profile) ✓; Item 3 → Task 4 (accent bar in light via `HermesTopBar` + `AccentChrome.onBar`, `ProfileAccent` untouched) ✓; Item 5 → Task 5 (Cron FAB accent + Add icon) ✓; code-block scroll correctly dropped ✓; on-device incl. light mode + pinned-vs-grouped + dedupe → Task 6 ✓; no bridge changes ✓.
+- **Placeholder scan:** every code step has full code; the only read-the-file bit is Task 3 Step 3 (the two `SessionRow` call sites, described by pinned-vs-grouped) and the Task 6 verification-only commit.
+- **Type consistency:** `bannerLabel(state)` (Task 1) used in Task 2; `StatusDot(state, modifier, showLabel)` (Task 2); `SessionRow(..., showProfile)` (Task 3); `barBg`/`barOn` + `AccentChrome.onBar` (Task 4); `AccentChrome.fabContainer`/`onFab` (Task 5). `ConnectionState.{Disconnected,Connecting,Error}` match the sealed interface.
+
+**Ordering:** Task 1 (pure) → Task 2 (consumes it; both touch `StatusDot.kt`, run in order). Tasks 3, 4, 5 are independent files. Task 6 verifies.

--- a/docs/superpowers/specs/2026-07-05-ux-p1-wave2-design.md
+++ b/docs/superpowers/specs/2026-07-05-ux-p1-wave2-design.md
@@ -1,0 +1,83 @@
+# UX P1 Wave 2 (batch) — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/ux-p1-wave2`
+**Source:** P1 findings in `docs/ideas/ux-review-2026-07-04.md`
+
+## Goal
+
+Four Compose-only, no-bridge-change UI fixes (one task each): a legible/deduplicated offline banner, "Chats" naming, a bold per-tenant app bar in light mode, and an accent-tinted Cron FAB.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing state/data only. Material 3.
+- Multi-tenant isolation preserved; follow existing patterns (`AccentChrome`, `HermesTopBar`, `LocalProfileAccent`).
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Dropped from the original 5
+
+**Chat code-block horizontal scroll — already implemented.** `ChatComponents.CodeWithCopy` already applies `.horizontalScroll(rememberScrollState())` and reserves 44 dp for the copy button; long code lines already scroll. The review misread a scrollable block as truncated. No change.
+
+## Item 1 — Offline banner: contrast, dedupe, copy
+
+`ChatScreen.ConnectionBanner` (~line 290) renders on an `errorContainer` background; its **"Retry" `TextButton` uses the default `primary` (lavender) content colour** → poor contrast on the red banner. And "Offline" is shown **twice** at once — in the banner text and in the top-bar `StatusDot`'s label.
+
+- **Retry legibility:** `TextButton(onClick = onRetry, colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onErrorContainer)) { Text("Retry") }`.
+- **Friendlier copy:** add a pure `bannerLabel(state): String` (in `StatusDot.kt`, beside `connectionLabel`) → `Disconnected → "You're offline — new messages send when you reconnect."`, `is Error → "Connection error — tap Retry."`, else `connectionLabel(state)` (Connecting…/Reconnecting…). The banner uses `bannerLabel(state)`; `StatusDot` keeps `connectionLabel` semantics but loses its label (below).
+- **Dedupe:** make `StatusDot` **dot-only** — drop its trailing `Text(connectionLabel(state))`, keep just the coloured dot. The banner carries the words when offline; the green dot alone reads as "connected" in the top bar, and it declutters the now-crowded bar (back + title + model chip + status). Add a `showLabel: Boolean = false` param to `StatusDot` (default dot-only) so any other caller can opt back into the label; audit callers (likely only `ChatScreen`).
+
+*Files: `ui/chat/ChatScreen.kt`, `ui/components/StatusDot.kt`.*
+
+## Item 2 — "Chats" naming
+
+- `SessionsScreen` `HermesTopBar(title = "Sessions")` → `title = "Chats"` (matches the bottom-nav tab).
+- The row subtitle `listOfNotNull(session.profile, session.model).joinToString(" · ")` (`SessionRow`, ~line 418) shows `"acme · model"`, which is **redundant under a profile group header** — but **not** in the **Pinned** section (which pools sessions across profiles, unheadered). Add a `showProfile: Boolean` param to `SessionRow`: subtitle = `listOfNotNull(session.profile.takeIf { showProfile }, session.model).joinToString(" · ")`. **Pinned** rows pass `showProfile = true`; **grouped** rows pass `showProfile = false` (subtitle becomes just the model).
+
+*File: `ui/sessions/SessionsScreen.kt`.*
+
+## Item 3 — Bold per-tenant app bar in light mode
+
+**Decided: bold coloured bar.** In light mode `profileAccentColors` sets `container` to HSL lightness `0.90` (near-white), so `HermesTopBar` (which paints `containerColor = accent.container`) loses the tenant hue. Fix in the **chrome only** (verified: `container`/`onContainer` are consumed solely by `HermesTopBar` + `AccentChrome.onBar`):
+
+- **`HermesTopBar`** — compute `val dark = isSystemInDarkTheme()`; use `val barBg = if (dark) accent.container else accent.accent` and `val barOn = if (dark) accent.onContainer else accent.onAccent`. Replace the four `accent.container`/`accent.onContainer` uses (TopAppBar `containerColor`/`titleContentColor`/`navigationIconContentColor`/`actionIconContentColor`, plus the title `color` and the subtitle `color = barOn.copy(alpha = 0.75f)`) with `barBg`/`barOn`. Dark mode is unchanged; light mode now shows the saturated tenant accent bar with legible on-accent text.
+- **`AccentChrome.onBar`** — `@Composable get() = if (isSystemInDarkTheme()) LocalProfileAccent.current.onContainer else LocalProfileAccent.current.onAccent`, so action text (Sessions "Archived") and the chat model chip stay legible on the now-accent light bar.
+
+No change to `container`/`onContainer` values or other elements (this is scoped to the app bar chrome). Dark mode's look is preserved.
+
+*Files: `ui/components/HermesTopBar.kt`.*
+
+## Item 5 — Cron FAB accent + icon
+
+`CronScreen`'s `ExtendedFloatingActionButton` uses Material's default `primaryContainer` (static brand indigo) and an empty `icon = {}`; `SessionsScreen`'s already uses `AccentChrome.fabContainer`/`onFab` + an Add icon. Make Cron's match:
+```kotlin
+androidx.compose.material3.ExtendedFloatingActionButton(
+    onClick = onNew,
+    text = { Text("New") },
+    icon = { Icon(Icons.Rounded.Add, contentDescription = null) },
+    containerColor = com.hermes.client.ui.components.AccentChrome.fabContainer,
+    contentColor = com.hermes.client.ui.components.AccentChrome.onFab,
+)
+```
+
+*File: `ui/cron/CronScreen.kt`.*
+
+## Testing
+
+- **Unit (pure), TDD — `bannerLabel`:** `Disconnected` → the friendly offline copy; `Error("x")` → the error copy; `Connecting`/`Reconnecting` → `connectionLabel(...)` (delegates).
+- **On-device:**
+  1. Chat while offline → one "You're offline…" banner with a **legible** Retry; the top bar shows only a red dot (no second "Offline"). Reconnect → banner clears, dot goes green.
+  2. Chats tab title reads **"Chats"**; grouped session rows show just the model in the subtitle; Pinned rows still show `profile · model`.
+  3. Switch to **light mode** and across profiles → the app bar is a saturated tenant colour (acme green / globex gold) with legible text; dark mode unchanged.
+  4. The Cron **New** FAB is the tenant accent with an Add icon (matches Sessions).
+
+## Not doing (YAGNI)
+
+- Chat code-block scroll (already implemented); a scroll-affordance fade (P2).
+- Any deeper offline/queue behaviour beyond copy + styling.
+- The other P1/P2 review items (separate future batches).
+- Any gateway/API change.
+
+## Open questions (non-blocking; plan may settle)
+
+- Whether any non-`ChatScreen` caller of `StatusDot` needs the label (the `showLabel` param covers it; the plan pins the audit result).


### PR DESCRIPTION
## Promote develop → main (production 0.1.33)

Promotes the UX P1 wave 2 batch to production. main was last at 0.1.32 (#56).

### What ships to production (0.1.33)
Four more design-review P1 fixes — Compose-only, no bridge changes:
1. Offline banner — one legible banner (dark Retry + friendly copy) + dot-only status with a legibility ring (no duplicate "Offline").
2. "Chats" title (matches the tab) + dropped the redundant `profile ·` prefix on grouped session rows.
3. **Bold light-mode tenant app bar** — the tenant accent now carries through in light mode (was near-white) across Chat/Chats/Cron; dark mode unchanged.
4. Cron FAB accented + Add icon (matches Sessions).

Built via spec → plan → subagent-driven development with per-task and final review; verified on-device in light mode. No bridge/gateway API changes.
