### PR TITLE
Promote to production: 0.1.34 (UX wave 3 — Home as navigation)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 34
-        versionName = "0.1.33"
+        versionCode = 35
+        versionName = "0.1.34"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -232,7 +232,7 @@ private fun MissionControlContent(
             }
         }
         if (state.needsYou.isNotEmpty()) {
-            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size) }
+            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size, onClick = { onOpen("cron") }) }
             items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
                 NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) })
             }
@@ -247,7 +247,7 @@ private fun MissionControlContent(
                 )
             }
             else -> state.sections.forEach { section ->
-                item(key = "h-${section.title}") { SectionHeader(section.title, section.items.size) }
+                item(key = "h-${section.title}") { SectionHeader(section.title, section.items.size, onClick = if (section.title.equals("Upcoming", ignoreCase = true)) ({ onOpen("cron") }) else null) }
                 items(section.items, key = { it.id }) { activity ->
                     val expandable = activity.kind == ActivityKind.CRON &&
                         activity.sessionId != null && !activity.upcoming
@@ -268,8 +268,13 @@ private fun MissionControlContent(
 }
 
 @Composable
-private fun SectionHeader(label: String, count: Int) {
-    Row(Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp)) {
+private fun SectionHeader(label: String, count: Int, onClick: (() -> Unit)? = null) {
+    Row(
+        Modifier.fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Text(
             label.uppercase(),
             style = MaterialTheme.typography.titleSmall,
@@ -281,6 +286,13 @@ private fun SectionHeader(label: String, count: Int) {
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        if (onClick != null) {
+            Icon(
+                Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -1,5 +1,6 @@
 package com.hermes.client.ui.activity
 
+import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -20,6 +21,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Chat
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.rounded.BarChart
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
@@ -46,8 +48,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -158,7 +162,18 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     }
     val onRetryResponse: (ActivityItem) -> Unit = { item -> item.sessionId?.let { vm.loadResponse(it) } }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     val now = remember(state.sections) { System.currentTimeMillis() }
+    val onRunNow: (CronAlert) -> Unit = { alert ->
+        scope.launch {
+            val ok = vm.runCron(alert.jobId)
+            Toast.makeText(
+                context,
+                if (ok) "Triggered ${alert.name}" else "Couldn't run ${alert.name}",
+                Toast.LENGTH_SHORT,
+            ).show()
+        }
+    }
 
     LaunchedEffect(profile) { vm.load(profile) }
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { vm.refresh() }
@@ -182,6 +197,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
                 state = state, nowMs = now, onRetry = { vm.refresh() },
                 responses = responses, expandedIds = expandedIds,
                 onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
+                onRunNow = onRunNow,
             )
         }
     }
@@ -197,6 +213,7 @@ private fun MissionControlContent(
     onToggle: (ActivityItem) -> Unit,
     onRetryResponse: (ActivityItem) -> Unit,
     onOpen: (String) -> Unit,
+    onRunNow: (CronAlert) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
         item(key = "quicklinks") {
@@ -217,7 +234,7 @@ private fun MissionControlContent(
         if (state.needsYou.isNotEmpty()) {
             item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size) }
             items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
-                NeedsYouRow(alert, onClick = { onOpen(alert.route) })
+                NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) })
             }
         }
         when {
@@ -268,19 +285,26 @@ private fun SectionHeader(label: String, count: Int) {
 }
 
 @Composable
-private fun NeedsYouRow(alert: CronAlert, onClick: () -> Unit) {
+private fun NeedsYouRow(alert: CronAlert, nowMs: Long, onClick: () -> Unit, onRunNow: () -> Unit) {
+    val reasonText = when (alert.reason) {
+        CronAlertReason.FAILED -> "Last run failed"
+        CronAlertReason.OVERDUE -> "Overdue"
+    }
+    val supporting = listOfNotNull(
+        reasonText,
+        alert.lastRunAtMs?.let { relativeTime(it, nowMs) },
+    ).joinToString(" · ")
     ListItem(
         leadingContent = {
             Icon(Icons.Rounded.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error)
         },
         headlineContent = { Text(alert.name) },
-        supportingContent = {
-            Text(
-                when (alert.reason) {
-                    CronAlertReason.FAILED -> "Last run failed"
-                    CronAlertReason.OVERDUE -> "Overdue"
-                },
-            )
+        supportingContent = { Text(supporting) },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextButton(onClick = onRunNow) { Text("Run now") }
+                Icon(Icons.AutoMirrored.Rounded.KeyboardArrowRight, contentDescription = null)
+            }
         },
         modifier = Modifier.clickable(onClick = onClick),
     )

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -122,7 +122,7 @@ fun MissionControlScreen(
                 Column {
                     HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })
                     if (names.size > 1) {
-                        com.hermes.client.ui.components.ProfileChips(
+                        com.hermes.client.ui.components.ProfileSwitcher(
                             names = names.filterNotNull(),
                             active = currentProfile,
                             onSelect = { name ->

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -120,7 +120,7 @@ fun MissionControlScreen(
         Scaffold(
             topBar = {
                 Column {
-                    HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })
+                    HermesTopBar(title = "Home")
                     if (names.size > 1) {
                         com.hermes.client.ui.components.ProfileSwitcher(
                             names = names.filterNotNull(),
@@ -216,21 +216,6 @@ private fun MissionControlContent(
     onRunNow: (CronAlert) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
-        item(key = "quicklinks") {
-            Row(
-                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState())
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
-            ) {
-                QUICK_LINKS.forEach { link ->
-                    AssistChip(
-                        onClick = { onOpen(link.route) },
-                        label = { Text(link.label) },
-                        leadingIcon = { Icon(link.icon, contentDescription = null, Modifier.width(18.dp)) },
-                    )
-                    Spacer(Modifier.width(8.dp))
-                }
-            }
-        }
         if (state.needsYou.isNotEmpty()) {
             item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size, onClick = { onOpen("cron") }) }
             items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
@@ -261,6 +246,21 @@ private fun MissionControlContent(
                         onRetry = { onRetryResponse(activity) },
                         onOpenFull = { onOpen(activity.route) },
                     )
+                }
+            }
+        }
+        item(key = "quicklinks") {
+            Row(
+                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+            ) {
+                QUICK_LINKS.forEach { link ->
+                    AssistChip(
+                        onClick = { onOpen(link.route) },
+                        label = { Text(link.label) },
+                        leadingIcon = { Icon(link.icon, contentDescription = null, Modifier.width(18.dp)) },
+                    )
+                    Spacer(Modifier.width(8.dp))
                 }
             }
         }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -112,8 +112,14 @@ class MissionControlViewModel @Inject constructor(
 
     /** Trigger a cron job now (existing endpoint) and reload the feed on success. Returns success. */
     suspend fun runCron(jobId: String): Boolean {
-        val ok = runCatching { tools.triggerCron(jobId, profile); true }.getOrDefault(false)
-        if (ok) load(profile)
-        return ok
+        return try {
+            tools.triggerCron(jobId, profile)
+            load(profile)
+            true
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            false
+        }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt
@@ -109,4 +109,11 @@ class MissionControlViewModel @Inject constructor(
             }
         }
     }
+
+    /** Trigger a cron job now (existing endpoint) and reload the feed on success. Returns success. */
+    suspend fun runCron(jobId: String): Boolean {
+        val ok = runCatching { tools.triggerCron(jobId, profile); true }.getOrDefault(false)
+        if (ok) load(profile)
+        return ok
+    }
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt
@@ -10,6 +10,7 @@ data class CronAlert(
     val name: String,
     val reason: CronAlertReason,
     val route: String,
+    val lastRunAtMs: Long? = null,
 )
 
 /** Default grace before an un-run scheduled job counts as overdue. */
@@ -29,11 +30,12 @@ fun needsAttention(
     val route = "cron_detail/${job.id}"
     val failed = job.lastStatus.equals("error", ignoreCase = true) ||
         job.lastStatus.equals("failed", ignoreCase = true)
+    val lastRunAtMs = isoToEpochMs(job.lastRunAt)
     when {
-        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route)
+        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route, lastRunAtMs)
         job.enabled && !job.isPaused -> {
             val next = isoToEpochMs(job.nextRunAt)
-            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route) else null
+            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route, lastRunAtMs) else null
         }
         else -> null
     }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -179,7 +179,7 @@ fun ChatScreen(
                     value = draft,
                     onValueChange = { draft = it },
                     modifier = Modifier.weight(1f),
-                    placeholder = { Text("Message Hermes…  (/ commands · @ attach)") },
+                    placeholder = { Text("Message Hermes…") },
                     maxLines = 5,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
                     keyboardActions = KeyboardActions(onSend = { submit() }),

--- a/app/src/main/java/com/hermes/client/ui/components/ProfileSwitcher.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/ProfileSwitcher.kt
@@ -13,29 +13,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
-/**
- * A single, shared tenant-switcher: a horizontal row of profile chips with the active one
- * selected. Used identically on the Chats and Agent Activity tabs so switching profiles looks
- * and behaves the same everywhere. [onSelect] receives the chosen profile name.
- */
+/** Tenant switcher: a row of chips, each with the profile's coloured initial. One consistent
+ *  control across Home / Chats / You. Same contract as the previous per-screen chip rows. */
 @Composable
-fun ProfileChips(
+fun ProfileSwitcher(
     names: List<String>,
     active: String?,
     onSelect: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier
-            .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp, vertical = 4.dp),
+        modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 12.dp, vertical = 4.dp),
     ) {
         names.forEach { name ->
             FilterChip(
                 selected = name == active,
                 onClick = { onSelect(name) },
                 label = { Text(name) },
+                leadingIcon = { ProfileAvatar(name, size = 18.dp) },
             )
             Spacer(Modifier.width(8.dp))
         }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -105,7 +105,7 @@ fun SessionsScreen(
                 // Same tenant switcher as Agent Activity: a chip row, active one selected. Tapping
                 // switches the active profile and the list re-fetches.
                 if (profiles.size > 1) {
-                    com.hermes.client.ui.components.ProfileChips(
+                    com.hermes.client.ui.components.ProfileSwitcher(
                         names = profiles.map { it.name },
                         active = activeProfile,
                         onSelect = vm::switchProfile,

--- a/app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -55,5 +56,23 @@ class MissionControlViewModelTest {
         vm.loadResponse("s1"); advanceUntilIdle()
         vm.loadResponse("s1"); advanceUntilIdle()
         coVerify(exactly = 1) { sessions.history("s1", any()) }
+    }
+
+    @Test fun runCron_success_triggers_and_reloads() = runTest(dispatcher) {
+        coEvery { tools.triggerCron("j1", any()) } returns Unit
+        coEvery { sessions.activityFeed() } returns emptyList()
+        coEvery { tools.cronJobs(any()) } returns emptyList()
+        val vm = vm()
+        val ok = vm.runCron("j1")
+        advanceUntilIdle()
+        assertTrue(ok)
+        coVerify { tools.triggerCron("j1", any()) }
+        coVerify(atLeast = 1) { sessions.activityFeed() }   // reload happened
+    }
+
+    @Test fun runCron_failure_returns_false() = runTest(dispatcher) {
+        coEvery { tools.triggerCron("j1", any()) } throws RuntimeException("boom")
+        val vm = vm()
+        assertFalse(vm.runCron("j1"))
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
@@ -10,9 +10,10 @@ private fun iso(ms: Long) = java.time.Instant.ofEpochMilli(ms).atOffset(java.tim
 private fun job(
     id: String = "j1", name: String? = null, enabled: Boolean = true, state: String? = null,
     pausedAt: String? = null, nextRunAt: String? = null, lastStatus: String? = null,
+    lastRunAt: String? = null,
 ) = CronJobDto(
     id = id, name = name, enabled = enabled, state = state, pausedAt = pausedAt,
-    nextRunAt = nextRunAt, lastStatus = lastStatus,
+    nextRunAt = nextRunAt, lastStatus = lastStatus, lastRunAt = lastRunAt,
 )
 
 class NeedsYouTest {
@@ -56,5 +57,16 @@ class NeedsYouTest {
         val a = needsAttention(listOf(job(id = "abc", name = "  ", lastStatus = "error")), NOW).single()
         assertEquals("abc", a.name)
         assertEquals("cron_detail/abc", a.route)
+    }
+
+    @Test fun failed_alert_carries_lastRunAt_epoch() {
+        val ran = iso(NOW - 2 * 60 * 60_000)
+        val a = needsAttention(listOf(job(lastStatus = "error", lastRunAt = ran)), NOW).single()
+        assertEquals(com.hermes.client.ui.util.isoToEpochMs(ran), a.lastRunAtMs)
+    }
+
+    @Test fun null_lastRunAt_gives_null_lastRunAtMs() {
+        val a = needsAttention(listOf(job(lastStatus = "error")), NOW).single()
+        assertEquals(null, a.lastRunAtMs)
     }
 }

--- a/docs/superpowers/plans/2026-07-05-ux-wave3.md
+++ b/docs/superpowers/plans/2026-07-05-ux-wave3.md
@@ -1,0 +1,435 @@
+# UX Wave 3 — Home as Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Home feed the navigation and act on a few — actionable Needs-You rows, tappable cron headers, a unified avatar tenant switcher, a lifted hero, and a cleaner composer.
+
+**Architecture:** Compose-only over existing infrastructure; reuses `ToolsRepository.triggerCron` (existing endpoint). One pure change (`CronAlert.lastRunAtMs`) and one VM method (`runCron`) are unit-tested; the rest is verified on-device.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, Hilt, JUnit + MockK.
+
+## Global Constraints
+
+- **No NEW gateway/bridge endpoints.** Reuse `ToolsRepository.triggerCron(jobId, profile)` (`POST /api/cron/jobs/{id}/trigger`, already present).
+- Material 3; multi-tenant isolation; follow patterns (`ProfileAvatar`, `AccentChrome`, `SectionHeader`, `needsAttention`/`CronAlert`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. compileSdk/targetSdk 36.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | tail -5`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `MissionControlViewModel`: injects `sessions: SessionRepository`, `tools: ToolsRepository`, `profileManager`; `private var profile`; `fun load(profile)`, `fun refresh() = load(profile)`; `loadInner` fetches `sessions.activityFeed()` + `tools.cronJobs(profile)`.
+- `ActivitySection.title` ∈ {"Live now","Upcoming","Recent"}; `NeedsYouRow` currently `(alert, onClick)`; `SectionHeader(label, count)`.
+- `ProfileChips` callers: `MissionControlScreen.kt:121`, `SessionsScreen.kt:108` (only two). `ProfileAvatar(name, modifier, size)` exists.
+- `isoToEpochMs`/`relativeTime` in `com.hermes.client.ui.util`; `CronJobDto.lastRunAt` is an ISO string.
+
+---
+
+### Task 1: `CronAlert.lastRunAtMs` (TDD, pure)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt`
+
+**Interfaces:** Produces `CronAlert(jobId, name, reason, route, lastRunAtMs: Long? = null)`.
+
+- [ ] **Step 1: Extend the test** — add `lastRunAt` to the test `job(...)` helper and assert the field. Append to `NeedsYouTest`:
+
+```kotlin
+    @Test fun failed_alert_carries_lastRunAt_epoch() {
+        val ran = iso(NOW - 2 * 60 * 60_000)
+        val a = needsAttention(listOf(job(lastStatus = "error", lastRunAt = ran)), NOW).single()
+        assertEquals(com.hermes.client.ui.util.isoToEpochMs(ran), a.lastRunAtMs)
+    }
+    @Test fun null_lastRunAt_gives_null_lastRunAtMs() {
+        val a = needsAttention(listOf(job(lastStatus = "error")), NOW).single()
+        assertEquals(null, a.lastRunAtMs)
+    }
+```
+Add a `lastRunAt: String? = null` parameter to the existing private `job(...)` helper in this test file and pass it as `lastRunAt = lastRunAt` into the `CronJobDto(...)` it builds.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NeedsYouTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — `CronAlert` has no `lastRunAtMs`.
+
+- [ ] **Step 3: Add the field + populate it**
+
+In `NeedsYou.kt`, add to `CronAlert`:
+```kotlin
+data class CronAlert(
+    val jobId: String,
+    val name: String,
+    val reason: CronAlertReason,
+    val route: String,
+    val lastRunAtMs: Long? = null,
+)
+```
+In `needsAttention`, compute `val lastRunAtMs = com.hermes.client.ui.util.isoToEpochMs(job.lastRunAt)` before the `when`, and pass it into both alert constructions:
+```kotlin
+        failed -> CronAlert(job.id, name, CronAlertReason.FAILED, route, lastRunAtMs)
+        job.enabled && !job.isPaused -> {
+            val next = isoToEpochMs(job.nextRunAt)
+            if (next != null && next < nowMs - graceMs) CronAlert(job.id, name, CronAlertReason.OVERDUE, route, lastRunAtMs) else null
+        }
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NeedsYouTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (all NeedsYou cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/NeedsYou.kt app/src/test/java/com/hermes/client/ui/activity/NeedsYouTest.kt
+git commit -m "feat(activity): carry lastRunAtMs on CronAlert for relative time"
+```
+
+---
+
+### Task 2: `MissionControlViewModel.runCron` (TDD)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt`
+
+**Interfaces:** Produces `suspend fun runCron(jobId: String): Boolean`.
+
+- [ ] **Step 1: Write the failing test** — add to `MissionControlViewModelTest`:
+
+```kotlin
+    @Test fun runCron_success_triggers_and_reloads() = runTest(dispatcher) {
+        coEvery { tools.triggerCron("j1", any()) } returns Unit
+        coEvery { sessions.activityFeed() } returns emptyList()
+        coEvery { tools.cronJobs(any()) } returns emptyList()
+        val vm = vm()
+        val ok = vm.runCron("j1")
+        advanceUntilIdle()
+        assertTrue(ok)
+        coVerify { tools.triggerCron("j1", any()) }
+        coVerify(atLeast = 1) { sessions.activityFeed() }   // reload happened
+    }
+
+    @Test fun runCron_failure_returns_false() = runTest(dispatcher) {
+        coEvery { tools.triggerCron("j1", any()) } throws RuntimeException("boom")
+        val vm = vm()
+        assertFalse(vm.runCron("j1"))
+    }
+```
+(If `tools`/`sessions` are `relaxed` mocks in `vm()`, the `coEvery` lines override the relevant calls; import `io.mockk.coVerify` and `org.junit.Assert.{assertTrue,assertFalse}` if not present. `triggerCron` signature is `suspend fun triggerCron(jobId: String, profile: String? = null)`.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MissionControlViewModelTest*' --console=plain 2>&1 | tail -8`
+Expected: FAIL — unresolved `runCron`.
+
+- [ ] **Step 3: Add `runCron`** to `MissionControlViewModel`:
+
+```kotlin
+    /** Trigger a cron job now (existing endpoint) and reload the feed on success. Returns success. */
+    suspend fun runCron(jobId: String): Boolean {
+        val ok = runCatching { tools.triggerCron(jobId, profile); true }.getOrDefault(false)
+        if (ok) load(profile)
+        return ok
+    }
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MissionControlViewModelTest*' --console=plain 2>&1 | tail -8`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlViewModel.kt app/src/test/java/com/hermes/client/ui/activity/MissionControlViewModelTest.kt
+git commit -m "feat(activity): runCron — trigger a cron now (existing endpoint) + reload"
+```
+
+---
+
+### Task 3: Actionable `NeedsYouRow` (Item 1 UI)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+**Interfaces:** Consumes `CronAlert.lastRunAtMs` (Task 1), `MissionControlViewModel.runCron` (Task 2), `relativeTime`.
+
+- [ ] **Step 1: Rewrite `NeedsYouRow`**
+
+```kotlin
+@Composable
+private fun NeedsYouRow(alert: CronAlert, nowMs: Long, onClick: () -> Unit, onRunNow: () -> Unit) {
+    val reasonText = when (alert.reason) {
+        CronAlertReason.FAILED -> "Last run failed"
+        CronAlertReason.OVERDUE -> "Overdue"
+    }
+    val supporting = listOfNotNull(
+        reasonText,
+        alert.lastRunAtMs?.let { com.hermes.client.ui.util.relativeTime(it, nowMs) },
+    ).joinToString(" · ")
+    ListItem(
+        leadingContent = {
+            Icon(Icons.Rounded.ErrorOutline, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+        },
+        headlineContent = { Text(alert.name) },
+        supportingContent = { Text(supporting) },
+        trailingContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextButton(onClick = onRunNow) { Text("Run now") }
+                Icon(Icons.AutoMirrored.Rounded.KeyboardArrowRight, contentDescription = null)
+            }
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
+```
+Add imports if missing: `androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight`, `androidx.compose.material3.TextButton`, `androidx.compose.foundation.layout.Row`, `androidx.compose.ui.Alignment`.
+
+- [ ] **Step 2: Wire `onRunNow` + `nowMs` in `MissionControlPage` / `MissionControlContent`**
+
+In `MissionControlPage`, obtain a context: `val context = androidx.compose.ui.platform.LocalContext.current`. Add an `onRunNow` handler and pass it down:
+```kotlin
+    val onRunNow: (CronAlert) -> Unit = { alert ->
+        scope.launch {
+            val ok = vm.runCron(alert.jobId)
+            android.widget.Toast.makeText(
+                context,
+                if (ok) "Triggered ${alert.name}" else "Couldn't run ${alert.name}",
+                android.widget.Toast.LENGTH_SHORT,
+            ).show()
+        }
+    }
+```
+Pass `onRunNow = onRunNow` into `MissionControlContent(...)`, add the param `onRunNow: (CronAlert) -> Unit` to `MissionControlContent`, and update the needs-you `items(...)` block:
+```kotlin
+            items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+                NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) })
+            }
+```
+(`nowMs` is already a `MissionControlContent` param.)
+
+- [ ] **Step 3: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(activity): Needs-you rows show relative time + chevron + Run-now"
+```
+
+---
+
+### Task 4: Tappable cron section headers (Item 2)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+- [ ] **Step 1: Add `onClick` to `SectionHeader`**
+
+```kotlin
+@Composable
+private fun SectionHeader(label: String, count: Int, onClick: (() -> Unit)? = null) {
+    Row(
+        Modifier.fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            label.uppercase(),
+            style = MaterialTheme.typography.titleSmall,
+            color = LocalProfileAccent.current.accent,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            count.toString(),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (onClick != null) {
+            Icon(
+                Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Pass `onClick` at the cron header sites**
+
+- Needs-you header: `SectionHeader("Needs you", state.needsYou.size, onClick = { onOpen("cron") })`.
+- The section loop header: `SectionHeader(section.title, section.items.size, onClick = if (section.title.equals("Upcoming", ignoreCase = true)) ({ onOpen("cron") }) else null)`.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(activity): tappable Upcoming/Needs-you headers deep-link to Cron"
+```
+
+---
+
+### Task 5: Unified `ProfileSwitcher` (Item 3)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/components/ProfileSwitcher.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`, `app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt`
+- Delete: `app/src/main/java/com/hermes/client/ui/components/ProfileChips.kt`
+
+- [ ] **Step 1: Create `ProfileSwitcher.kt`**
+
+```kotlin
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/** Tenant switcher: a row of chips, each with the profile's coloured initial. One consistent
+ *  control across Home / Chats / You. Same contract as the old ProfileChips. */
+@Composable
+fun ProfileSwitcher(
+    names: List<String>,
+    active: String?,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(horizontal = 12.dp, vertical = 4.dp),
+    ) {
+        names.forEach { name ->
+            FilterChip(
+                selected = name == active,
+                onClick = { onSelect(name) },
+                label = { Text(name) },
+                leadingIcon = { ProfileAvatar(name, size = 18.dp) },
+            )
+            Spacer(Modifier.width(8.dp))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Swap the two callers**
+
+In `MissionControlScreen.kt:121` replace `com.hermes.client.ui.components.ProfileChips(` with `com.hermes.client.ui.components.ProfileSwitcher(` (keep the exact `names`/`active`/`onSelect` arguments — the pager wiring is unchanged). Same in `SessionsScreen.kt:108` (`onSelect = vm::switchProfile` unchanged).
+
+- [ ] **Step 3: Delete the now-unused `ProfileChips.kt`**
+
+```bash
+git rm app/src/main/java/com/hermes/client/ui/components/ProfileChips.kt
+```
+Then `grep -rn "ProfileChips" app/src/main/java` → expect no matches.
+
+- [ ] **Step 4: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(ux): unified coloured-avatar ProfileSwitcher on Home + Chats"
+```
+
+---
+
+### Task 6: Lift the Home hero (Item 4)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+- [ ] **Step 1: Move the quicklinks Row to the bottom of the feed**
+
+In `MissionControlContent`'s `LazyColumn`, remove the `item(key = "quicklinks") { … }` block from the **top** and re-add the identical block as the **last** item, after the `when { … state.sections.forEach … }` block.
+
+- [ ] **Step 2: Drop the Home subtitle**
+
+Change `HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })` → `HermesTopBar(title = "Home")`.
+
+- [ ] **Step 3: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(home): lift the hero — quicklinks footer + drop redundant subtitle"
+```
+
+---
+
+### Task 7: Simpler composer placeholder (Item 5)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+- [ ] **Step 1: Simplify the placeholder**
+
+Change `placeholder = { Text("Message Hermes…  (/ commands · @ attach)") }` → `placeholder = { Text("Message Hermes…") }`.
+
+- [ ] **Step 2: Compile + commit**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): simplify composer placeholder"
+```
+
+---
+
+### Task 8: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point at the mock (`http://10.0.2.2:8899`), which has a failed + overdue cron under acme.
+
+- [ ] **Step 2: Verify all five**
+
+1. A **Needs-you** row shows the reason + a **relative time** ("· Xh ago"), a **"Run now"** button, and a "›". Tapping **Run now** shows a "Triggered …" toast and the feed reloads; tapping the row body still opens **cron detail**.
+2. The **UPCOMING** header and the **Needs you** header show a "›" and tapping them opens the **Cron** list.
+3. Home + Chats show the **coloured-avatar** tenant switcher (matching the You tab); tapping a chip still switches the Home pager and the Chats filter.
+4. On Home, **NEEDS YOU** / the sections sit near the top; the **quicklinks** are a footer at the bottom; the "Profile: acme" subtitle is gone.
+5. The chat composer placeholder reads **"Message Hermes…"**.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(ux): wave3 verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Item 1 → Task 1 (`CronAlert.lastRunAtMs` + test) + Task 3 (row: time + chevron + Run-now) + Task 2 (`runCron` via existing `triggerCron`, tested) ✓; Item 2 → Task 4 (`SectionHeader.onClick`, Upcoming + Needs-you → cron) ✓; Item 3 → Task 5 (`ProfileSwitcher`, swap both callers, delete `ProfileChips`) ✓; Item 4 → Task 6 (quicklinks → bottom, drop Home subtitle) ✓; Item 5 → Task 7 (placeholder) ✓; on-device incl. Run-now toast/refresh, tappable headers, switcher-drives-pager, lifted hero → Task 8 ✓; no new endpoint ✓.
+- **Placeholder scan:** every code step has full code; the only conditional is the Task 8 verification-only commit.
+- **Type consistency:** `CronAlert(…, lastRunAtMs)` (Task 1) → `NeedsYouRow(alert, nowMs, onClick, onRunNow)` (Task 3); `runCron(jobId): Boolean` (Task 2) → wired in Task 3; `SectionHeader(label, count, onClick?)` (Task 4); `ProfileSwitcher(names, active, onSelect, modifier)` (Task 5) matches the old `ProfileChips` contract. `ToolsRepository.triggerCron(jobId, profile)`, `relativeTime`, `isoToEpochMs` match the codebase.
+
+**Ordering:** Task 1 (pure) → Task 2 (VM, consumes 1's data via the DTO) → Task 3 (row, consumes 1+2). Tasks 4 + 6 also touch `MissionControlScreen.kt` — run 3 → 4 → 6 in order. Task 5 (switcher) touches MissionControl + Sessions; Task 7 is ChatScreen. Task 8 verifies.

--- a/docs/superpowers/specs/2026-07-05-ux-wave3-design.md
+++ b/docs/superpowers/specs/2026-07-05-ux-wave3-design.md
@@ -1,0 +1,90 @@
+# UX Wave 3 — Home as Navigation (batch) — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/ux-wave3`
+**Source:** `docs/ideas/ux-review-2026-07-04.md` (bigger bet #3 + remaining Home P1s)
+
+## Goal
+
+Advance "make the Home feed the navigation, act on a few": actionable Needs-You rows (relative time + chevron + one-tap "Run now"), tappable cron section headers, a unified coloured-avatar tenant switcher, a lifted Home hero, and a cleaner composer placeholder. **No new gateway/bridge endpoints** (reuses the existing `triggerCron`).
+
+## Hard constraints
+
+- **No NEW gateway/bridge endpoints.** Reuse existing REST/WS. (`ToolsRepository.triggerCron` / `POST /api/cron/jobs/{id}/trigger` already exists.)
+- Material 3; multi-tenant isolation; follow patterns (`ProfileAvatar`, `AccentChrome`, `SectionHeader`, `needsAttention`/`CronAlert`, `onOpen`/deep-link).
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Item 1 — Actionable "Needs You" rows (P1)
+
+`CronAlert` (`ui/activity/NeedsYou.kt`) carries no timestamp and `NeedsYouRow` (`MissionControlScreen.kt`) is icon + name + static reason (tap → `cron_detail`). Make each row telegraph what it is and offer the fix inline. All Needs-You alerts are FAILED/OVERDUE by construction, so every row gets "Run now".
+
+- **`CronAlert.lastRunAtMs: Long? = null`** — in `needsAttention`, set `lastRunAtMs = isoToEpochMs(job.lastRunAt)` in both the FAILED and OVERDUE branches (the DTO is in scope). Pure; unit-tested.
+- **`MissionControlViewModel.runCron(jobId): suspend (): Boolean`** — `runCatching { tools.triggerCron(jobId, profile); true }.getOrDefault(false)`, and on success call `refresh()` so the row's state updates. `ToolsRepository` is already injected.
+- **`NeedsYouRow`** (add `nowMs: Long`, `onRunNow: () -> Unit`):
+  - `supportingContent`: reason + relative time — `listOfNotNull(reasonText, alert.lastRunAtMs?.let { relativeTime(it, nowMs) }).joinToString(" · ")` → e.g. "Last run failed · 2h ago" (falls back to just the reason if `lastRunAtMs` is null).
+  - `trailingContent`: a `Row { TextButton("Run now", onClick = onRunNow); Icon(Icons.AutoMirrored.Rounded.KeyboardArrowRight, contentDescription = null) }`. The row body tap still → `cron_detail` (existing `onClick`).
+  - In `MissionControlContent`/`MissionControlPage`, wire `onRunNow = { scope.launch { val ok = vm.runCron(alert.jobId); Toast.makeText(context, if (ok) "Triggered ${alert.name}" else "Couldn't run ${alert.name}", Toast.LENGTH_SHORT).show() } }`. Pass the page's `now` as `nowMs`.
+
+*Files: `ui/activity/NeedsYou.kt`, `ui/activity/MissionControlViewModel.kt`, `ui/activity/MissionControlScreen.kt`.*
+
+## Item 2 — Tappable cron section headers (P2, bet #3)
+
+`SectionHeader(label, count)` is static text. Make cron-related headers deep-link to the Cron list.
+
+- Add `onClick: (() -> Unit)? = null` to `SectionHeader`; when non-null, the `Row` gets `Modifier.clickable(onClick = onClick)` and a trailing `Icon(Icons.AutoMirrored.Rounded.KeyboardArrowRight)` (the "›") after the count.
+- **Needs-you header:** `SectionHeader("Needs you", state.needsYou.size, onClick = { onOpen("cron") })`.
+- **Upcoming header:** in the `state.sections.forEach { section -> … }`, pass `onClick = { onOpen("cron") }` only when `section.title.equals("Upcoming", ignoreCase = true)`; else `null`.
+- **Live now / Recent:** stay plain (their rows already navigate; no clean single push target).
+
+*File: `ui/activity/MissionControlScreen.kt`.*
+
+## Item 3 — Unified coloured-avatar tenant switcher (P1 [01/06])
+
+Home (`MissionControlScreen`) and Chats (`SessionsScreen`) use `ProfileChips` (plain `FilterChip`s); the You tab uses coloured `ProfileAvatar`s. Standardise on one control that carries the tenant colour.
+
+- **New `ui/components/ProfileSwitcher.kt`** — same contract as `ProfileChips` (`names: List<String>, active: String?, onSelect: (String) -> Unit, modifier`): a horizontally-scrolling `Row` of `FilterChip`s, each `FilterChip(selected = name == active, onClick = { onSelect(name) }, label = { Text(name) }, leadingIcon = { ProfileAvatar(name, size = 18.dp) })`. This adds the per-tenant coloured initial to the existing chip while keeping M3 selected styling.
+- **Swap both callers** (`MissionControlScreen.kt:121`, `SessionsScreen.kt:108`) from `ProfileChips(...)` to `ProfileSwitcher(...)` — **identical arguments**, so the Home pager's two-way `active = currentProfile` / `onSelect = { animateScrollToPage(idx) }` linkage and the Sessions `onSelect = vm::switchProfile` are preserved untouched.
+- **Delete `ui/components/ProfileChips.kt`** (now unused — only those two callers exist).
+
+*Files: create `ui/components/ProfileSwitcher.kt`; modify `MissionControlScreen.kt`, `SessionsScreen.kt`; delete `ui/components/ProfileChips.kt`.*
+
+## Item 4 — Lift the Home hero (P1 §1 [01])
+
+The quicklinks Row is the first feed item, pushing "NEEDS YOU" down; the "Profile: acme" subtitle is redundant with the accent bar + the avatar switcher.
+
+- **Move the `item(key = "quicklinks") { … }`** from the **top** of `MissionControlContent`'s `LazyColumn` to the **bottom** (after the `when { … state.sections … }` block), so it reads as a "tools" footer and NEEDS YOU / the sections are the first content under the switcher.
+- **Drop the Home subtitle:** `HermesTopBar(title = "Home", subtitle = currentProfile?.let { "Profile: $it" })` → `HermesTopBar(title = "Home")`. (Scope: **Home only** — ChatScreen keeps its subtitle, since Chat has no switcher row.)
+
+*File: `ui/activity/MissionControlScreen.kt`.*
+
+## Item 5 — Simpler composer placeholder (P2 §4)
+
+The send arrow already tints the accent when `canSend` (grey only when empty/offline — correct), so only the placeholder changes.
+
+- `ChatScreen` `OutlinedTextField` `placeholder = { Text("Message Hermes…  (/ commands · @ attach)") }` → `placeholder = { Text("Message Hermes…") }`.
+
+*File: `ui/chat/ChatScreen.kt`.*
+
+## Testing
+
+- **Unit (pure), TDD — extend `NeedsYouTest`:** a job with `lastRunAt` set → the returned `CronAlert.lastRunAtMs` equals `isoToEpochMs(lastRunAt)`; a job with null `lastRunAt` → `lastRunAtMs == null`.
+- **Unit — `MissionControlViewModel.runCron`:** success (mock `tools.triggerCron`) returns `true` and calls a reload (`coVerify` on `sessions.activityFeed`/`tools.cronJobs` again, or a state re-emit); failure returns `false` (mock `triggerCron` throws) and does not crash.
+- **On-device:**
+  1. A failed/overdue cron in "Needs you" shows a relative time + a "Run now" button + a "›"; tapping **Run now** shows a "Triggered …" toast and the row refreshes; tapping the row body still opens cron detail.
+  2. The **UPCOMING** header and the **Needs you** header show a "›" and deep-link to the Cron list.
+  3. Home + Chats show the **coloured-avatar** tenant switcher (matching You); switching still drives the Home pager and the Chats filter.
+  4. On Home, **NEEDS YOU** sits near the top (quicklinks now a footer); the "Profile: acme" subtitle is gone.
+  5. The chat composer placeholder reads "Message Hermes…".
+
+## Not doing (YAGNI)
+
+- Confirmation dialog before "Run now" (triggering a cron is non-destructive; a toast suffices).
+- Deep-linking Live-now/Recent headers (no clean single push target; rows navigate).
+- Dropping the Chat subtitle or restyling the tall app bar (separate P2s).
+- Send-arrow tint change (already correct).
+- Any new gateway endpoint.
+
+## Open questions (non-blocking; plan may settle)
+
+- Whether "Run now" should also show a brief in-row spinner while triggering (a toast is the MVP; a spinner is optional polish).


### PR DESCRIPTION
## Promote develop → main (production 0.1.34)

Promotes the UX wave 3 batch to production. main was last at 0.1.33 (#58).

### What ships to production (0.1.34) — "Home as navigation"
Compose-only, no new gateway endpoints (reuses the existing cron trigger):
1. Actionable "Needs you" rows — relative time + a one-tap **"Run now"** (existing `POST /api/cron/jobs/{id}/trigger`) with a toast + reload.
2. Tappable UPCOMING/Needs-you section headers deep-link to Cron.
3. Unified coloured-avatar tenant switcher across Home + Chats (matching the You tab).
4. Lifted Home hero — quicklinks moved to a footer, redundant subtitle dropped, "Needs you" first.
5. Simpler composer placeholder.

Built via spec → plan → subagent-driven development with per-task and opus final review; multi-tenant safety of Run-now verified (per-page profile, no cross-tenant trigger). No bridge/gateway API changes.
