### PR TITLE
Promote to production: 0.1.35 (UX wave 4 — lean P2 polish)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 35
-        versionName = "0.1.34"
+        versionCode = 36
+        versionName = "0.1.35"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.minimumInteractiveComponentSize
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -141,6 +142,7 @@ fun ChatScreen(
                 actions = {
                     AssistChip(
                         onClick = { modelSheetOpen = true },
+                        modifier = Modifier.minimumInteractiveComponentSize(),
                         label = { Text(currentModel ?: "Model", maxLines = 1) },
                         trailingIcon = {
                             Icon(

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -90,7 +90,7 @@ fun YouHubScreen(
 
             HubRow(Icons.Rounded.People, "Profiles", "Manage tenant profiles") { onNavigate("profiles") }
             HorizontalDivider()
-            HubRow(Icons.Rounded.AutoAwesome, "Models", "Model catalog & defaults") { onNavigate("models") }
+            HubRow(Icons.Rounded.AutoAwesome, "Models", "Browse & pick models") { onNavigate("models") }
             HorizontalDivider()
             HubRow(Icons.Rounded.AdminPanelSettings, "Management", "Admin & session tools") { onNavigate("management") }
             HorizontalDivider()

--- a/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
@@ -38,7 +38,7 @@ fun SettingsScreen(
             HorizontalDivider()
             Entry("Notifications", "Approvals, cron, and messaging alerts") { onNavigate("settings_notifications") }
             HorizontalDivider()
-            Entry("Models & memory", "Default model, memory toggles & budgets") { onNavigate("settings_memory") }
+            Entry("Memory & budgets", "Memory, user profile & default model") { onNavigate("settings_memory") }
             HorizontalDivider()
             Entry("MCP servers", "View and edit connected MCP servers") { onNavigate("settings_mcp") }
             HorizontalDivider()

--- a/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
@@ -186,9 +186,14 @@ private fun DailyTokensChart(daily: List<com.hermes.client.data.network.UsageDay
 
 @Composable
 private fun Stat(label: String, value: String, modifier: Modifier = Modifier) {
-    Column(modifier) {
-        Text(label, style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(value, style = MaterialTheme.typography.titleMedium)
+    androidx.compose.material3.Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium)
+        }
     }
 }

--- a/docs/superpowers/plans/2026-07-05-ux-wave4.md
+++ b/docs/superpowers/plans/2026-07-05-ux-wave4.md
@@ -1,0 +1,141 @@
+# UX Wave 4 — Lean P2 Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three small, honest P2 polish fixes — a 48 dp touch target for the model picker, grouped Usage stat tiles, and a copy-only rename disambiguating the two "Models" entries.
+
+**Architecture:** Pure Compose/copy changes across four files; no logic branches, so verification is on-device (no unit tests).
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Compose UI + copy only. Material 3.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+---
+
+### Task 1: Model-picker touch target
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+The model `AssistChip` in `ModelPickerButton` (~line 142) has M3's ~32 dp height and is not auto-expanded to a 48 dp touch target (it's the only interactive control below 48 dp; buttons/icon-buttons already get 48 dp from M3 defaults).
+
+- [ ] **Step 1: Add the touch-target modifier**
+
+Add `modifier = Modifier.minimumInteractiveComponentSize()` to the `AssistChip(...)` call. If the `AssistChip` already has a `modifier` argument, merge it with `.minimumInteractiveComponentSize()`; otherwise add the `modifier` parameter. Add the import `androidx.compose.material3.minimumInteractiveComponentSize` (and `androidx.compose.ui.Modifier` if not already imported). This enforces a 48 dp minimum touch target without changing the chip's 32 dp visual height.
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "fix(chat): 48dp touch target for the model picker chip"
+```
+
+---
+
+### Task 2: Usage stat tiles
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt`
+
+The private `Stat(label, value, modifier)` renders a bare `Column { Text(label); Text(value) }`, so the four stats float with no container.
+
+- [ ] **Step 1: Wrap the `Stat` body in a tonal Surface**
+
+Replace the `Stat` composable with:
+```kotlin
+@Composable
+private fun Stat(label: String, value: String, modifier: Modifier = Modifier) {
+    androidx.compose.material3.Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+```
+Leave the call sites (incl. `Stat("Est. cost", …, Modifier.weight(1f))`) and the "Est. cost" text unchanged. Ensure `androidx.compose.foundation.layout.padding` and `androidx.compose.ui.Modifier` are imported (they almost certainly already are in this file).
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+git commit -m "feat(usage): group stats into tonal tiles"
+```
+
+---
+
+### Task 3: "Models" disambiguation (copy-only)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt`, `app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt`
+
+Two entries both advertise model defaults; make "Models" unambiguously the picker and stop Settings competing on the word "Models". Routes and behaviour unchanged.
+
+- [ ] **Step 1: You-tab subtitle**
+
+In `YouHubScreen.kt` (~line 93), change the "Models" `HubRow` subtitle from `"Model catalog & defaults"` to `"Browse & pick models"`. Keep the title `"Models"`, the icon, and `onNavigate("models")` unchanged.
+
+- [ ] **Step 2: Settings entry title + subtitle**
+
+In `SettingsScreen.kt` (~line 41), change the `Entry` from title `"Models & memory"` / subtitle `"Default model, memory toggles & budgets"` to title `"Memory & budgets"` / subtitle `"Memory, user profile & default model"`. Keep `onNavigate("settings_memory")` unchanged.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
+git commit -m "feat(nav): disambiguate the two model entry points (copy)"
+```
+
+---
+
+### Task 4: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`. Point at the mock (`http://10.0.2.2:8899`).
+
+- [ ] **Step 2: Verify all three**
+
+1. **Chat** — the model chip looks the same size (~32 dp tall) but has a comfortable ~48 dp tap area.
+2. **Usage** (You → Usage) — the four stats (Sessions / API calls / Tokens in-out / Est. cost) render as grouped tonal tiles; "Est. cost" label unchanged.
+3. **Naming** — the You tab shows **"Models" / "Browse & pick models"**; Settings shows **"Memory & budgets" / "Memory, user profile & default model"**; tapping each still opens its screen (models picker / memory settings).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(ux): wave4 verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Item 1 → Task 1 (`minimumInteractiveComponentSize` on the model chip) ✓; Item 2 → Task 2 (`Stat` wrapped in a tonal `Surface`) ✓; Item 3 → Task 3 (You subtitle + Settings title/subtitle copy) ✓; on-device → Task 4 ✓. Dropped items (app-bar height, contrast, "(7d)") intentionally have no task, per the spec's "Dropped after exploration".
+- **Placeholder scan:** every code step shows the concrete change; the only conditional is the Task 4 verification-only commit.
+- **Type consistency:** `Stat(label, value, modifier)` signature preserved (only the body wrapped); `minimumInteractiveComponentSize()` is a real M3 modifier; copy strings match the spec verbatim.
+
+**Ordering:** all four files are disjoint (ChatScreen / UsageScreen / YouHubScreen + SettingsScreen) — tasks are independent and may run in any order; Task 4 verifies.

--- a/docs/superpowers/specs/2026-07-05-ux-wave4-design.md
+++ b/docs/superpowers/specs/2026-07-05-ux-wave4-design.md
@@ -1,0 +1,79 @@
+# UX Wave 4 — P2 Polish (lean) — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/ux-wave4`
+**Source:** `docs/ideas/ux-review-2026-07-04.md` (remaining P2s)
+
+## Goal
+
+Three small, honest P2 polish fixes (one task each): a 48 dp touch target for the model picker, grouped Usage stat tiles, and a copy-only rename that disambiguates the two "Models" entry points. Compose/copy only.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Compose UI + copy only. Material 3.
+- Multi-tenant isolation preserved; follow existing patterns.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Dropped after exploration (premises didn't hold)
+
+- **Right-size the app bar — dropped.** `HermesTopBar` is a *standard* M3 `TopAppBar` (no explicit height); its only extra height is a small `labelMedium` subtitle line. The review's "eats a third of the viewport / ~250 px band" was the bar **plus the two chip rows below it** — already addressed in wave 3 (quicklinks moved to a footer, Home subtitle dropped). There is no oversized custom band to shrink.
+- **Contrast bump on muted text — dropped.** Measured: dark `onSurfaceVariant` (#C9C5D0 on #121218) ≈ **11:1**, light ≈ **9:1** — both clear WCAG AA and AAA. The review's "~3:1" is inaccurate at the token level; the only dimmer spots are *intentional* `alpha` reductions (0.75 subtitle, 0.4 disabled send icon). No real contrast defect.
+- **"Est. cost (7d)" label — dropped.** `UsageDto`/`UsageDayDto` carry no time-window field; `estimatedCost` is a sum over whatever `daily` rows the backend returns. Labeling it "7d" would be inaccurate. The Usage task keeps the honest "Est. cost" label and only adds visual grouping.
+
+## Item 1 — Model-picker touch target (P2 §7)
+
+The model `AssistChip` in `ChatScreen`'s `ModelPickerButton` has M3's default ~32 dp height and — unlike `Button`/`IconButton` — is **not** auto-expanded to a 48 dp touch target (verified: it's the only interactive control below 48 dp; the "Archived"/"Retry" `TextButton`s and the copy `IconButton` already get 48 dp from M3 defaults).
+
+- Add `Modifier.minimumInteractiveComponentSize()` to the `AssistChip` (`ChatScreen.kt` ~line 142). This enforces a 48 dp minimum touch target **without** changing the chip's 32 dp visual height. Add the import `androidx.compose.material3.minimumInteractiveComponentSize`.
+
+*File: `ui/chat/ChatScreen.kt`.*
+
+## Item 2 — Usage stat tiles (P2 §2 [08])
+
+`UsageScreen`'s private `Stat(label, value, modifier)` renders a bare `Column { Text(label); Text(value) }`, so the four stats (Sessions / API calls / Tokens in-out / Est. cost) float with no container.
+
+- Wrap the `Stat` body in a tonal container so the stats read as grouped tiles:
+```kotlin
+@Composable
+private fun Stat(label: String, value: String, modifier: Modifier = Modifier) {
+    androidx.compose.material3.Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(value, style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+```
+Keep the `modifier` passthrough (the "Est. cost" call site passes `Modifier.weight(1f)`); the existing call sites and the "Est. cost" text are unchanged.
+
+*File: `ui/usage/UsageScreen.kt`.*
+
+## Item 3 — "Models" disambiguation (P2 §3/§6 [06/07], copy-only)
+
+Two entry points both currently advertise model defaults, so it's unclear which owns model selection:
+- You-tab (`YouHubScreen.kt:93`): `HubRow(Icons.Rounded.AutoAwesome, "Models", "Model catalog & defaults") { onNavigate("models") }` → `ModelsScreen` (a browse / favourite / pick screen; picking sets the global default).
+- Settings (`SettingsScreen.kt:41`): `Entry("Models & memory", "Default model, memory toggles & budgets") { onNavigate("settings_memory") }` → `MemorySettingsScreen` (memory toggles, char-limit budgets, and a default-model field).
+
+Rename so "Models" is unambiguously the picker and Settings stops competing on the word "Models" (copy-only — routes and behaviour unchanged):
+- **You-tab:** title stays `"Models"`; subtitle `"Model catalog & defaults"` → **`"Browse & pick models"`**.
+- **Settings:** `"Models & memory"` → **`"Memory & budgets"`**; subtitle `"Default model, memory toggles & budgets"` → **`"Memory, user profile & default model"`** (still honest that it holds a default-model field).
+
+*Files: `ui/nav/YouHubScreen.kt`, `ui/settings/SettingsScreen.kt`.*
+
+## Testing
+
+No unit tests (all three are pure UI/copy with no logic branch). Verification is on-device:
+1. The chat model chip has a comfortable tap area (48 dp) though it still looks the same size.
+2. The Usage screen shows the four stats as grouped tiles (tonal containers).
+3. The You tab shows **"Models" / "Browse & pick models"**; Settings shows **"Memory & budgets" / "Memory, user profile & default model"**; both destinations still open correctly.
+
+## Not doing (YAGNI)
+
+- App-bar height change, muted-text contrast bump, "(7d)" cost label (see "Dropped after exploration").
+- The deeper dual-ownership of the default-model setting (both the picker and Settings write it) — a behavioural change, out of scope for a copy-only pass.
+- Any gateway/API change.


### PR DESCRIPTION
## Promote develop → main (production 0.1.35)

Promotes the UX wave 4 (lean P2 polish) batch to production. main was last at 0.1.34 (#60).

### What ships to production (0.1.35)
Compose/copy only, no gateway changes:
1. Model-picker `AssistChip` gets a 48 dp touch target (32 dp visual unchanged).
2. Usage stats grouped into tonal tiles.
3. Copy-only "Models" disambiguation — You "Models / Browse & pick models" vs Settings "Memory & budgets / Memory, user profile & default model".

Built via spec → plan → subagent-driven development with per-task verification and a final whole-branch review ("Ready to merge", no findings). No bridge/gateway API changes.
