### PR TITLE
QS-tile ANR hardening: move tile DataStore I/O off the main thread

### DIFF
--- a/app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt
@@ -13,42 +13,55 @@ import com.hermes.client.MainActivity
 import com.hermes.client.R
 import com.hermes.client.data.repository.NotificationSettings
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
  * Quick Settings tile that shows and toggles the notification service — mirrors the
  * Settings > Notifications "Enable" switch. On/off state is [NotificationSettings.prefs].enabled.
- * TileService callbacks run on the main thread; a single fast DataStore read via runBlocking is fine.
+ * Tile callbacks run reads/writes on a service-owned `Main.immediate` scope so DataStore I/O never blocks the main thread.
  */
 @AndroidEntryPoint
 class NotificationTileService : TileService() {
     @Inject lateinit var settings: NotificationSettings
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
     override fun onStartListening() {
         super.onStartListening()
-        renderTile(runBlocking { settings.prefs.first().enabled })
+        scope.launch { renderTile(settings.prefs.first().enabled) }
     }
 
     override fun onClick() {
         super.onClick()
-        val enabled = runBlocking { settings.prefs.first().enabled }
-        val canStart = Build.VERSION.SDK_INT < 33 ||
-            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
-            PackageManager.PERMISSION_GRANTED
-        when (tileClickAction(enabled, canStart)) {
-            TileAction.ENABLE -> {
-                runBlocking { settings.setEnabled(true) }
-                GatewayConnectionService.start(this)
-                renderTile(true)
+        scope.launch {
+            val enabled = settings.prefs.first().enabled
+            val canStart = Build.VERSION.SDK_INT < 33 ||
+                ContextCompat.checkSelfPermission(this@NotificationTileService, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            when (tileClickAction(enabled, canStart)) {
+                TileAction.ENABLE -> {
+                    settings.setEnabled(true)
+                    GatewayConnectionService.start(this@NotificationTileService)
+                    renderTile(true)
+                }
+                TileAction.DISABLE -> {
+                    settings.setEnabled(false)
+                    GatewayConnectionService.stop(this@NotificationTileService)
+                    renderTile(false)
+                }
+                TileAction.OPEN_FOR_PERMISSION -> openNotificationSettings()
             }
-            TileAction.DISABLE -> {
-                runBlocking { settings.setEnabled(false) }
-                GatewayConnectionService.stop(this)
-                renderTile(false)
-            }
-            TileAction.OPEN_FOR_PERMISSION -> openNotificationSettings()
         }
     }
 

--- a/docs/superpowers/plans/2026-07-05-qstile-anr-hardening.md
+++ b/docs/superpowers/plans/2026-07-05-qstile-anr-hardening.md
@@ -1,0 +1,114 @@
+# QS-Tile ANR Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the Quick-Settings tile's DataStore reads/writes off the main thread onto a service-owned coroutine scope, removing an ANR risk.
+
+**Architecture:** Add a `CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)` to `NotificationTileService` (mirroring `GatewayConnectionService` in the same package), cancelled in `onDestroy`; run the tile callbacks' reads/writes in `scope.launch { … }`. Behaviour is unchanged.
+
+**Tech Stack:** Kotlin, Android `TileService`, Hilt, DataStore, coroutines.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Native Android only.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+---
+
+### Task 1: Move tile I/O onto a service scope
+
+**Files:** Modify `app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt`
+
+The `TileService` currently does `runBlocking { … }` on the main-thread callbacks (`onStartListening` read; `onClick` read + `settings.setEnabled(...)` write). Move them onto a service-owned coroutine scope.
+
+- [ ] **Step 1: Add the scope + `onDestroy`**
+
+Add a field and lifecycle cancel to the class (mirroring `GatewayConnectionService` in the same package, but with `Dispatchers.Main.immediate` so the coroutine can safely touch `qsTile`/`updateTile()`):
+```kotlin
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+```
+
+- [ ] **Step 2: Make `onStartListening` async**
+
+```kotlin
+    override fun onStartListening() {
+        super.onStartListening()
+        scope.launch { renderTile(settings.prefs.first().enabled) }
+    }
+```
+
+- [ ] **Step 3: Make `onClick` async**
+
+Wrap the whole body in `scope.launch { … }`, using `this@NotificationTileService` for the service `Context`:
+```kotlin
+    override fun onClick() {
+        super.onClick()
+        scope.launch {
+            val enabled = settings.prefs.first().enabled
+            val canStart = Build.VERSION.SDK_INT < 33 ||
+                ContextCompat.checkSelfPermission(this@NotificationTileService, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            when (tileClickAction(enabled, canStart)) {
+                TileAction.ENABLE -> {
+                    settings.setEnabled(true)
+                    GatewayConnectionService.start(this@NotificationTileService)
+                    renderTile(true)
+                }
+                TileAction.DISABLE -> {
+                    settings.setEnabled(false)
+                    GatewayConnectionService.stop(this@NotificationTileService)
+                    renderTile(false)
+                }
+                TileAction.OPEN_FOR_PERMISSION -> openNotificationSettings()
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Fix imports + the stale doc comment**
+
+Remove `import kotlinx.coroutines.runBlocking`. Add: `import kotlinx.coroutines.CoroutineScope`, `import kotlinx.coroutines.Dispatchers`, `import kotlinx.coroutines.SupervisorJob`, `import kotlinx.coroutines.cancel`, `import kotlinx.coroutines.launch`. Keep `import kotlinx.coroutines.flow.first`. Replace the class-doc line "TileService callbacks run on the main thread; a single fast DataStore read via runBlocking is fine." with: "Tile callbacks run reads/writes on a service-owned `Main.immediate` scope so DataStore I/O never blocks the main thread." Leave `renderTile`, `openNotificationSettings`, and the pure `tileClickAction(enabled, canStart)` helper unchanged.
+
+- [ ] **Step 5: Compile + full unit suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED` (the existing `tileClickAction` test still passes — logic unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt
+git commit -m "fix(tile): run QS-tile DataStore I/O on a service scope (no main-thread blocking)"
+```
+
+---
+
+### Task 2: Package + sanity
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Assemble the beta variant**
+
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 2: Behaviour note**
+
+This is a threading-only change: the QS tile still shows On/Off and toggling it still starts/stops `GatewayConnectionService` and flips the tile state — no user-visible behaviour change. (Optional manual check: add the Hermes tile to the Quick Settings panel and toggle it.)
+
+---
+
+## Self-Review
+
+- **Spec coverage:** the spec's whole "Design" section → Task 1 (scope + `onDestroy`, async `onStartListening`/`onClick`, imports, doc comment) ✓; "Testing" (compile + suite + assembleBeta, no new unit test) → Task 1 Step 5 + Task 2 ✓. Dropped siblings (model-error, New-FAB) intentionally have no task, per the spec.
+- **Placeholder scan:** every code step shows the full code; no TBD/TODO.
+- **Type consistency:** `scope`, `onDestroy`, `tileClickAction(enabled, canStart)`, `TileAction.{ENABLE,DISABLE,OPEN_FOR_PERMISSION}`, `GatewayConnectionService.start/stop`, `renderTile`, `openNotificationSettings`, `settings.prefs.first().enabled`, `settings.setEnabled(...)` all match the explored source.
+
+**Ordering:** single file, single implementation task; Task 2 verifies.

--- a/docs/superpowers/specs/2026-07-05-qstile-anr-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-05-qstile-anr-hardening-design.md
@@ -1,0 +1,79 @@
+# QS-Tile ANR Hardening — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/qstile-anr-hardening`
+**Source:** `docs/ideas/native-command-surface.md` ("Remaining" → QS-tile `runBlocking` → async)
+
+## Goal
+
+Remove blocking DataStore I/O from the Quick-Settings tile's main-thread callbacks (an ANR risk) by moving reads and writes onto a service-owned coroutine scope. No behaviour change — the tile still shows and toggles the notification service.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Native Android only. Material 3 N/A (no UI).
+- Multi-tenant isolation unaffected (this is the notification tile).
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Problem
+
+`app/src/main/java/com/hermes/client/notifications/NotificationTileService.kt` (a `TileService`) runs `runBlocking { … }` on the main-thread tile callbacks:
+- `onStartListening()` — `runBlocking { settings.prefs.first().enabled }` (READ)
+- `onClick()` — a READ, then in the ENABLE/DISABLE branches `runBlocking { settings.setEnabled(...) }` (WRITE)
+
+A blocking DataStore **write** on the main thread, inside a QS-tile callback's short binder-transaction window, is an ANR risk on slow devices or during cold DataStore initialization. The file's own comment ("a single fast DataStore read via runBlocking is fine") understates the write's cost.
+
+## Dropped after exploration (siblings from the same "Remaining" list)
+
+- **Model-switch failure in Settings — no gap.** The real model-write path (`ModelsViewModel.select`) already surfaces failures via `onFailure { message = "Failed to set model: …" }` through a working `SnackbarHost` in `ModelsScreen`. `MemorySettingsScreen`'s "Default model" row is read-only display and writes nothing. Nothing to fix.
+- **New-FAB last-used profile — not worth it.** New chat creates in the gateway's **active** profile, which the switcher chip row keeps in sync and visibly shows; "New" already opens in the tenant the user can see is selected. Auto-switching to the most-recent session's profile would be a *silent tenant-context switch* — a multi-tenant surprise. Current behaviour is safer and more predictable.
+
+## Design
+
+Mirror the existing `GatewayConnectionService` pattern in the same package (a service-owned `CoroutineScope(SupervisorJob())` cancelled in `onDestroy`), using `Dispatchers.Main.immediate` so the coroutine can safely touch `qsTile`/`updateTile()` after the suspend calls resolve.
+
+- **Add a scope:** `private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)`.
+- **Cancel it:** add `override fun onDestroy() { scope.cancel(); super.onDestroy() }`.
+- **`onStartListening`:** `scope.launch { renderTile(settings.prefs.first().enabled) }`.
+- **`onClick`:** wrap the whole body in `scope.launch { … }`:
+```kotlin
+    override fun onClick() {
+        super.onClick()
+        scope.launch {
+            val enabled = settings.prefs.first().enabled
+            val canStart = Build.VERSION.SDK_INT < 33 ||
+                ContextCompat.checkSelfPermission(this@NotificationTileService, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            when (tileClickAction(enabled, canStart)) {
+                TileAction.ENABLE -> {
+                    settings.setEnabled(true)
+                    GatewayConnectionService.start(this@NotificationTileService)
+                    renderTile(true)
+                }
+                TileAction.DISABLE -> {
+                    settings.setEnabled(false)
+                    GatewayConnectionService.stop(this@NotificationTileService)
+                    renderTile(false)
+                }
+                TileAction.OPEN_FOR_PERMISSION -> openNotificationSettings()
+            }
+        }
+    }
+```
+- **Imports:** remove `kotlinx.coroutines.runBlocking`; add `kotlinx.coroutines.CoroutineScope`, `kotlinx.coroutines.SupervisorJob`, `kotlinx.coroutines.Dispatchers`, `kotlinx.coroutines.cancel`, `kotlinx.coroutines.launch` (keep `kotlinx.coroutines.flow.first`).
+- **Doc comment:** replace the stale "TileService callbacks run on the main thread; a single fast DataStore read via runBlocking is fine." line with a note that reads/writes run on a service-owned Main.immediate scope to keep the tile callbacks non-blocking.
+
+`renderTile`, `openNotificationSettings`, and the pure `tileClickAction(enabled, canStart)` helper are unchanged.
+
+## Testing
+
+- The pure decision logic `tileClickAction(enabled, canStart)` is already covered by its existing unit test (unchanged). No new unit test — the change is a threading move with no logic change.
+- Compile + `assembleBeta` green.
+- Manual (optional, on-device): add the Hermes QS tile to the Quick Settings panel; toggling it still starts/stops the service and flips the tile On/Off (unchanged behaviour); no ANR/jank.
+
+## Not doing (YAGNI)
+
+- The dropped siblings above.
+- Any refactor of `NotificationSettings`/DataStore.
+- `canStart` extraction/dedup (a separate cosmetic item; `tileClickAction` already isolates the decision).
+- Any gateway/API change.


### PR DESCRIPTION
## QS-tile ANR hardening

The Quick-Settings tile (`NotificationTileService`) did `runBlocking { … }` DataStore reads/writes on the main-thread tile callbacks — a blocking write inside a QS-tile callback's short binder-transaction window is an ANR risk on slow/cold-start devices.

Fix: give the service its own `CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)` (cancelled in `onDestroy`, mirroring `GatewayConnectionService` in the same package), and run `onStartListening`'s read and the whole `onClick` body in `scope.launch { … }`. No blocking I/O on the main thread; behaviour unchanged (the tile still shows On/Off and toggles the service).

### Verification
- No new unit test (threading-only move; the pure `tileClickAction` helper is already covered). Full suite + `assembleBeta` green; gitleaks clean.
- Reviewed (spec ✅, approved): all `runBlocking` removed, scope cancelled in `onDestroy`, `Main.immediate` so `qsTile`/`updateTile()` stay on the main thread, `this@NotificationTileService` used for the service Context, onClick ordering preserved.

### Scope note
This was a "polish & hardening" candidate batch; two sibling items were dropped after exploration (model-switch failures are already surfaced via `ModelsScreen`'s Snackbar; "New chat" already opens in the visibly-active profile, and auto-switching would be a silent tenant change). This is the one real fix.

Spec/plan: `docs/superpowers/specs/2026-07-05-qstile-anr-hardening-design.md`, `docs/superpowers/plans/2026-07-05-qstile-anr-hardening.md`.
