### PR TITLE
Promote to production: 0.1.37 (Home feed refresh)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 37
-        versionName = "0.1.36"
+        versionCode = 38
+        versionName = "0.1.37"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt
@@ -3,6 +3,7 @@ package com.hermes.client.ui.activity
 import com.hermes.client.data.network.CronJobDto
 import com.hermes.client.domain.Session
 import com.hermes.client.ui.util.isoToEpochMs
+import com.hermes.client.ui.util.isSameDay
 
 // Mission Control (Phase 2): a unified, time-grouped activity feed merging conversations and cron
 // for the active profile. Sessions and cron jobs are flattened into a common [ActivityItem], then
@@ -94,4 +95,35 @@ fun groupActivity(items: List<ActivityItem>, nowMs: Long): List<ActivitySection>
         upcoming.takeIf { it.isNotEmpty() }?.let { ActivitySection("Upcoming", it) },
         recent.takeIf { it.isNotEmpty() }?.let { ActivitySection("Recent", it) },
     )
+}
+
+enum class FeedFilter { ALL, TODAY, UPCOMING, RECENT }
+
+data class FeedView(val needsYou: List<CronAlert>, val sections: List<ActivitySection>) {
+    val count: Int get() = needsYou.size + sections.sumOf { it.items.size }
+}
+
+/** Filter the assembled feed for the selected tab (grouping headers still apply within a filter). */
+fun feedView(
+    sections: List<ActivitySection>,
+    needsYou: List<CronAlert>,
+    nowMs: Long,
+    filter: FeedFilter,
+): FeedView = when (filter) {
+    FeedFilter.ALL -> FeedView(needsYou, sections)
+    FeedFilter.TODAY -> FeedView(
+        needsYou,
+        sections
+            .map { s -> s.copy(items = s.items.filter { it.timestampMs != null && isSameDay(it.timestampMs, nowMs) }) }
+            .filter { it.items.isNotEmpty() },
+    )
+    FeedFilter.UPCOMING -> FeedView(emptyList(), sections.filter { it.title.equals("Upcoming", ignoreCase = true) })
+    FeedFilter.RECENT -> FeedView(emptyList(), sections.filterNot { it.title.equals("Upcoming", ignoreCase = true) })
+}
+
+/** Short state label for an activity row, or null (plain recent items get no pill). */
+fun statusPill(item: ActivityItem, nowMs: Long): String? = when {
+    item.upcoming -> "Scheduled"
+    item.timestampMs != null && (nowMs - item.timestampMs) in 0..LIVE_WINDOW_MS -> "Live"
+    else -> null
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
@@ -29,9 +29,12 @@ fun FeedTabs(
     modifier: Modifier = Modifier,
 ) {
     val accent = LocalProfileAccent.current
+    val counts = androidx.compose.runtime.remember(sections, needsYou, nowMs) {
+        FILTERS.associate { (filter, _) -> filter to feedView(sections, needsYou, nowMs, filter).count }
+    }
     SingleChoiceSegmentedButtonRow(modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
         FILTERS.forEachIndexed { i, (filter, label) ->
-            val count = feedView(sections, needsYou, nowMs, filter).count
+            val count = counts[filter] ?: 0
             SegmentedButton(
                 selected = selected == filter,
                 onClick = { onSelect(filter) },

--- a/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
@@ -1,0 +1,46 @@
+package com.hermes.client.ui.activity
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+private val FILTERS = listOf(
+    FeedFilter.ALL to "All",
+    FeedFilter.TODAY to "Today",
+    FeedFilter.UPCOMING to "Upcoming",
+    FeedFilter.RECENT to "Recent",
+)
+
+/** Per-tenant-accent segmented time filter for the Home feed; counts reflect the current page. */
+@Composable
+fun FeedTabs(
+    sections: List<ActivitySection>,
+    needsYou: List<CronAlert>,
+    nowMs: Long,
+    selected: FeedFilter,
+    onSelect: (FeedFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accent = LocalProfileAccent.current
+    SingleChoiceSegmentedButtonRow(modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+        FILTERS.forEachIndexed { i, (filter, label) ->
+            val count = feedView(sections, needsYou, nowMs, filter).count
+            SegmentedButton(
+                selected = selected == filter,
+                onClick = { onSelect(filter) },
+                shape = SegmentedButtonDefaults.itemShape(i, FILTERS.size),
+                colors = SegmentedButtonDefaults.colors(
+                    activeContainerColor = accent.accent,
+                    activeContentColor = accent.onAccent,
+                ),
+            ) { Text("$label $count") }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -155,6 +155,9 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     var expandedIds by androidx.compose.runtime.saveable.rememberSaveable {
         androidx.compose.runtime.mutableStateOf(emptySet<String>())
     }
+    var filter by androidx.compose.runtime.saveable.rememberSaveable {
+        androidx.compose.runtime.mutableStateOf(FeedFilter.ALL)
+    }
     val onToggle: (ActivityItem) -> Unit = { item ->
         val nowExpanded = item.id !in expandedIds
         expandedIds = if (nowExpanded) expandedIds + item.id else expandedIds - item.id
@@ -193,12 +196,23 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
             isRefreshing = refreshing,
             onRefresh = { refreshing = true; vm.refresh() },
         ) {
-            MissionControlContent(
-                state = state, nowMs = now, onRetry = { vm.refresh() },
-                responses = responses, expandedIds = expandedIds,
-                onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
-                onRunNow = onRunNow,
-            )
+            Column {
+                FeedTabs(
+                    sections = state.sections,
+                    needsYou = state.needsYou,
+                    nowMs = now,
+                    selected = filter,
+                    onSelect = { filter = it },
+                )
+                MissionControlContent(
+                    state = state,
+                    view = feedView(state.sections, state.needsYou, now, filter),
+                    nowMs = now, onRetry = { vm.refresh() },
+                    responses = responses, expandedIds = expandedIds,
+                    onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
+                    onRunNow = onRunNow,
+                )
+            }
         }
     }
 }
@@ -206,6 +220,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
 @Composable
 private fun MissionControlContent(
     state: MissionControlState,
+    view: FeedView,
     nowMs: Long,
     onRetry: () -> Unit,
     responses: Map<String, MissionControlViewModel.CronResponseUi>,
@@ -216,22 +231,22 @@ private fun MissionControlContent(
     onRunNow: (CronAlert) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
-        if (state.needsYou.isNotEmpty()) {
-            item(key = "needs-header") { SectionHeader("Needs you", state.needsYou.size, onClick = { onOpen("cron") }) }
-            items(state.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+        if (view.needsYou.isNotEmpty()) {
+            item(key = "needs-header") { SectionHeader("Needs you", view.needsYou.size, onClick = { onOpen("cron") }) }
+            items(view.needsYou, key = { "needs-${it.jobId}" }) { alert ->
                 NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) })
             }
         }
         when {
             state.loading && state.sections.isEmpty() -> item { LoadingState() }
             state.error != null -> item { ErrorState(message = state.error!!, onRetry = onRetry) }
-            state.sections.isEmpty() -> item {
+            view.needsYou.isEmpty() && view.sections.isEmpty() -> item {
                 EmptyState(
-                    title = "Nothing happening yet",
-                    subtitle = "Conversations and scheduled runs for this profile will show up here.",
+                    title = "Nothing here",
+                    subtitle = "Nothing matches this filter for this profile yet.",
                 )
             }
-            else -> state.sections.forEach { section ->
+            else -> view.sections.forEach { section ->
                 item(key = "h-${section.title}") { SectionHeader(section.title, section.items.size, onClick = if (section.title.equals("Upcoming", ignoreCase = true)) ({ onOpen("cron") }) else null) }
                 items(section.items, key = { it.id }) { activity ->
                     val expandable = activity.kind == ActivityKind.CRON &&

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -213,6 +213,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
                 MissionControlContent(
                     state = state,
                     view = feedView(state.sections, state.needsYou, now, filter),
+                    filter = filter,
                     nowMs = now, onRetry = { vm.refresh() },
                     responses = responses, expandedIds = expandedIds,
                     onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
@@ -228,6 +229,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
 private fun MissionControlContent(
     state: MissionControlState,
     view: FeedView,
+    filter: FeedFilter,
     nowMs: Long,
     onRetry: () -> Unit,
     responses: Map<String, MissionControlViewModel.CronResponseUi>,
@@ -259,10 +261,17 @@ private fun MissionControlContent(
             state.loading && state.sections.isEmpty() -> item { LoadingState() }
             state.error != null -> item { ErrorState(message = state.error!!, onRetry = onRetry) }
             view.needsYou.isEmpty() && view.sections.isEmpty() -> item {
-                EmptyState(
-                    title = "Nothing here",
-                    subtitle = "Nothing matches this filter for this profile yet.",
-                )
+                if (filter == FeedFilter.ALL) {
+                    EmptyState(
+                        title = "Nothing happening yet",
+                        subtitle = "Conversations and scheduled runs for this profile will show up here.",
+                    )
+                } else {
+                    EmptyState(
+                        title = "Nothing here",
+                        subtitle = "Nothing matches this filter yet.",
+                    )
+                }
             }
             else -> view.sections.forEach { section ->
                 item(key = "h-${section.title}") {

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -158,6 +158,12 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
     var filter by androidx.compose.runtime.saveable.rememberSaveable {
         androidx.compose.runtime.mutableStateOf(FeedFilter.ALL)
     }
+    var collapsed by androidx.compose.runtime.saveable.rememberSaveable {
+        androidx.compose.runtime.mutableStateOf(emptySet<String>())
+    }
+    val onToggleSection: (String) -> Unit = { title ->
+        collapsed = if (title in collapsed) collapsed - title else collapsed + title
+    }
     val onToggle: (ActivityItem) -> Unit = { item ->
         val nowExpanded = item.id !in expandedIds
         expandedIds = if (nowExpanded) expandedIds + item.id else expandedIds - item.id
@@ -211,6 +217,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
                     responses = responses, expandedIds = expandedIds,
                     onToggle = onToggle, onRetryResponse = onRetryResponse, onOpen = onOpen,
                     onRunNow = onRunNow,
+                    collapsed = collapsed, onToggleSection = onToggleSection,
                 )
             }
         }
@@ -229,12 +236,23 @@ private fun MissionControlContent(
     onRetryResponse: (ActivityItem) -> Unit,
     onOpen: (String) -> Unit,
     onRunNow: (CronAlert) -> Unit,
+    collapsed: Set<String>,
+    onToggleSection: (String) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {
         if (view.needsYou.isNotEmpty()) {
-            item(key = "needs-header") { SectionHeader("Needs you", view.needsYou.size, onClick = { onOpen("cron") }) }
-            items(view.needsYou, key = { "needs-${it.jobId}" }) { alert ->
-                NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) })
+            item(key = "needs-header") {
+                SectionHeader(
+                    "Needs you",
+                    view.needsYou.size,
+                    collapsed = "Needs you" in collapsed,
+                    onToggle = { onToggleSection("Needs you") },
+                )
+            }
+            if ("Needs you" !in collapsed) {
+                items(view.needsYou, key = { "needs-${it.jobId}" }) { alert ->
+                    NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) })
+                }
             }
         }
         when {
@@ -247,20 +265,29 @@ private fun MissionControlContent(
                 )
             }
             else -> view.sections.forEach { section ->
-                item(key = "h-${section.title}") { SectionHeader(section.title, section.items.size, onClick = if (section.title.equals("Upcoming", ignoreCase = true)) ({ onOpen("cron") }) else null) }
-                items(section.items, key = { it.id }) { activity ->
-                    val expandable = activity.kind == ActivityKind.CRON &&
-                        activity.sessionId != null && !activity.upcoming
-                    ActivityRow(
-                        item = activity,
-                        nowMs = nowMs,
-                        expandable = expandable,
-                        isExpanded = activity.id in expandedIds,
-                        response = activity.sessionId?.let { responses[it] },
-                        onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
-                        onRetry = { onRetryResponse(activity) },
-                        onOpenFull = { onOpen(activity.route) },
+                item(key = "h-${section.title}") {
+                    SectionHeader(
+                        section.title,
+                        section.items.size,
+                        collapsed = section.title in collapsed,
+                        onToggle = { onToggleSection(section.title) },
                     )
+                }
+                if (section.title !in collapsed) {
+                    items(section.items, key = { it.id }) { activity ->
+                        val expandable = activity.kind == ActivityKind.CRON &&
+                            activity.sessionId != null && !activity.upcoming
+                        ActivityRow(
+                            item = activity,
+                            nowMs = nowMs,
+                            expandable = expandable,
+                            isExpanded = activity.id in expandedIds,
+                            response = activity.sessionId?.let { responses[it] },
+                            onClick = { if (expandable) onToggle(activity) else onOpen(activity.route) },
+                            onRetry = { onRetryResponse(activity) },
+                            onOpenFull = { onOpen(activity.route) },
+                        )
+                    }
                 }
             }
         }
@@ -283,10 +310,9 @@ private fun MissionControlContent(
 }
 
 @Composable
-private fun SectionHeader(label: String, count: Int, onClick: (() -> Unit)? = null) {
+private fun SectionHeader(label: String, count: Int, collapsed: Boolean, onToggle: () -> Unit) {
     Row(
-        Modifier.fillMaxWidth()
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+        Modifier.fillMaxWidth().clickable(onClick = onToggle)
             .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -301,13 +327,11 @@ private fun SectionHeader(label: String, count: Int, onClick: (() -> Unit)? = nu
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        if (onClick != null) {
-            Icon(
-                Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        Icon(
+            if (collapsed) Icons.Rounded.ExpandMore else Icons.Rounded.ExpandLess,
+            contentDescription = if (collapsed) "Expand $label" else "Collapse $label",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -362,6 +362,22 @@ private fun NeedsYouRow(alert: CronAlert, nowMs: Long, onClick: () -> Unit, onRu
 }
 
 @Composable
+private fun StatusPill(label: String) {
+    val accent = LocalProfileAccent.current
+    androidx.compose.material3.Surface(
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+        color = accent.container,
+    ) {
+        Text(
+            label,
+            Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = accent.onContainer,
+        )
+    }
+}
+
+@Composable
 private fun ActivityRow(
     item: ActivityItem,
     nowMs: Long,
@@ -386,17 +402,23 @@ private fun ActivityRow(
         else -> LocalProfileAccent.current.accent
     }
     val time = relativeTime(item.timestampMs, nowMs)
+    val pill = statusPill(item, nowMs)
     Column {
         ListItem(
             leadingContent = { Icon(icon, contentDescription = null, tint = tint) },
             headlineContent = { Text(item.title) },
             supportingContent = { Text(listOfNotNull(item.subtitle, time).joinToString(" · ")) },
-            trailingContent = if (expandable) {
+            trailingContent = if (pill != null || expandable) {
                 {
-                    Icon(
-                        if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
-                        contentDescription = if (isExpanded) "Collapse response" else "Show response",
-                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        pill?.let { StatusPill(it); Spacer(Modifier.width(6.dp)) }
+                        if (expandable) {
+                            Icon(
+                                if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                                contentDescription = if (isExpanded) "Collapse response" else "Show response",
+                            )
+                        }
+                    }
                 }
             } else {
                 null

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -159,7 +159,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
         androidx.compose.runtime.mutableStateOf(FeedFilter.ALL)
     }
     var collapsed by androidx.compose.runtime.saveable.rememberSaveable {
-        androidx.compose.runtime.mutableStateOf(emptySet<String>())
+        androidx.compose.runtime.mutableStateOf(emptyList<String>())
     }
     val onToggleSection: (String) -> Unit = { title ->
         collapsed = if (title in collapsed) collapsed - title else collapsed + title
@@ -202,6 +202,9 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
             isRefreshing = refreshing,
             onRefresh = { refreshing = true; vm.refresh() },
         ) {
+            val view = remember(state.sections, state.needsYou, now, filter) {
+                feedView(state.sections, state.needsYou, now, filter)
+            }
             Column {
                 FeedTabs(
                     sections = state.sections,
@@ -212,7 +215,7 @@ private fun MissionControlPage(profile: String?, dark: Boolean, onNavigate: (Str
                 )
                 MissionControlContent(
                     state = state,
-                    view = feedView(state.sections, state.needsYou, now, filter),
+                    view = view,
                     filter = filter,
                     nowMs = now, onRetry = { vm.refresh() },
                     responses = responses, expandedIds = expandedIds,
@@ -238,7 +241,7 @@ private fun MissionControlContent(
     onRetryResponse: (ActivityItem) -> Unit,
     onOpen: (String) -> Unit,
     onRunNow: (CronAlert) -> Unit,
-    collapsed: Set<String>,
+    collapsed: List<String>,
     onToggleSection: (String) -> Unit,
 ) {
     LazyColumn(Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/hermes/client/ui/util/Time.kt
+++ b/app/src/main/java/com/hermes/client/ui/util/Time.kt
@@ -28,6 +28,11 @@ fun isoToEpochMs(iso: String?): Long? =
 /** Convert epoch-seconds (as the gateway reports last_active) to epoch millis. */
 fun secondsToEpochMs(seconds: Double?): Long? = seconds?.let { (it * 1000).toLong() }
 
+/** Check if two epoch-ms timestamps fall on the same calendar day in a given time zone. */
+fun isSameDay(aMs: Long, bMs: Long, zone: java.time.ZoneId = java.time.ZoneId.systemDefault()): Boolean =
+    java.time.Instant.ofEpochMilli(aMs).atZone(zone).toLocalDate() ==
+        java.time.Instant.ofEpochMilli(bMs).atZone(zone).toLocalDate()
+
 /**
  * Compact relative time for the activity feed: "just now", "5m ago", "3h ago", "2d ago" for the
  * past; "in 5m", "in 2h" for the future. Pure — [nowMs] is passed in so it is unit-testable.

--- a/app/src/test/java/com/hermes/client/ui/activity/FeedViewTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/activity/FeedViewTest.kt
@@ -1,0 +1,62 @@
+package com.hermes.client.ui.activity
+
+import com.hermes.client.ui.util.isSameDay
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.ZoneId
+
+class FeedViewTest {
+    private val utc = ZoneId.of("UTC")
+    private val day = 24 * 60 * 60_000L
+    private val t0 = 1_720_000_000_000L // fixed "now"
+
+    private fun item(id: String, ts: Long?, upcoming: Boolean) =
+        ActivityItem(id, ActivityKind.CRON, id, null, ts, upcoming, null, "r/$id")
+    private fun alert(id: String) = CronAlert(id, id, CronAlertReason.FAILED, "cron_detail/$id")
+
+    @Test fun isSameDay_true_within_day() {
+        assertEquals(true, isSameDay(t0, t0 + 60_000, utc))
+    }
+    @Test fun isSameDay_false_next_day() {
+        assertEquals(false, isSameDay(t0, t0 + day, utc))
+    }
+
+    private val sections = listOf(
+        ActivitySection("Live now", listOf(item("live", t0 - 60_000, false))),
+        ActivitySection("Upcoming", listOf(item("up-today", t0 + 60_000, true), item("up-future", t0 + 3 * day, true))),
+        ActivitySection("Recent", listOf(item("old", t0 - 3 * day, false))),
+    )
+    private val needs = listOf(alert("a1"))
+
+    @Test fun feedView_all_is_everything() {
+        val v = feedView(sections, needs, t0, FeedFilter.ALL)
+        assertEquals(1, v.needsYou.size)
+        assertEquals(3, v.sections.size)
+        assertEquals(1 + 4, v.count)
+    }
+    @Test fun feedView_today_keeps_needs_and_today_items() {
+        val v = feedView(sections, needs, t0, FeedFilter.TODAY)
+        assertEquals(1, v.needsYou.size)
+        // today items: live (t0-60s), up-today (t0+60s) -> 2, in their sections; old & up-future dropped
+        assertEquals(2, v.sections.sumOf { it.items.size })
+        assertEquals(1 + 2, v.count)
+    }
+    @Test fun feedView_upcoming_only_upcoming_section_no_needs() {
+        val v = feedView(sections, needs, t0, FeedFilter.UPCOMING)
+        assertEquals(0, v.needsYou.size)
+        assertEquals(listOf("Upcoming"), v.sections.map { it.title })
+        assertEquals(2, v.count)
+    }
+    @Test fun feedView_recent_excludes_upcoming_and_needs() {
+        val v = feedView(sections, needs, t0, FeedFilter.RECENT)
+        assertEquals(0, v.needsYou.size)
+        assertEquals(listOf("Live now", "Recent"), v.sections.map { it.title })
+        assertEquals(2, v.count)
+    }
+
+    @Test fun statusPill_scheduled_live_none() {
+        assertEquals("Scheduled", statusPill(item("s", t0 + day, true), t0))
+        assertEquals("Live", statusPill(item("l", t0 - 60_000, false), t0))
+        assertEquals(null, statusPill(item("o", t0 - 3 * day, false), t0))
+    }
+}

--- a/docs/superpowers/plans/2026-07-06-home-feed-refresh.md
+++ b/docs/superpowers/plans/2026-07-06-home-feed-refresh.md
@@ -1,0 +1,445 @@
+# Home Feed Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add segmented time-filter tabs, collapsible counted sections, and status pills to the Home / Mission Control feed — over the existing feed data, per-tenant-accent tinted.
+
+**Architecture:** Pure filter/label helpers (`feedView`, `isSameDay`, `statusPill`) are unit-tested; the UI (a new `FeedTabs`, a collapsible `SectionHeader`, a `StatusPill`) renders from a filtered `FeedView` and per-page `rememberSaveable` state. The feed's data assembly (`groupActivity`, the VM) is untouched.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Compose UI over existing `MissionControlState` only.
+- Multi-tenant isolation: all new chrome tints to `LocalProfileAccent.current` (per-tenant accent), never a hardcoded colour.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `ActivityModels.kt`: `enum ActivityKind { CONVERSATION, CRON }`; `ActivityItem(id, kind, title, subtitle, timestampMs: Long?, upcoming: Boolean, status: String?, route, sessionId)`; `ActivitySection(title, items)`; `const val LIVE_WINDOW_MS = 15*60_000L`; `groupActivity` yields titles "Live now"/"Upcoming"/"Recent".
+- `NeedsYou.kt`: `data class CronAlert(jobId, name, reason, route, lastRunAtMs)`.
+- `MissionControlScreen.kt`: `MissionControlScreen` (Scaffold topBar = `Column { HermesTopBar("Home"); ProfileSwitcher }`, `HorizontalPager` of `MissionControlPage`); `MissionControlPage` hoists `expandedIds` + `now` and calls `MissionControlContent`; `MissionControlContent(state, nowMs, …, onOpen, onRunNow, expandedIds, onToggle, responses, onRetryResponse)` is a `LazyColumn`; `SectionHeader(label, count, onClick)`; `ActivityRow(item, nowMs, expandable, isExpanded, response, onClick, onRetry, onOpenFull)`; `NeedsYouRow(...)`.
+- `ui/util/Time.kt`: `isoToEpochMs`, `relativeTime`.
+- `SingleChoiceSegmentedButtonRow`/`SegmentedButton` precedent: `ui/settings/AppearanceScreen.kt:45-53`.
+- `LocalProfileAccent.current.{accent, onAccent, container, onContainer}` (`ui/theme/ProfileAccent.kt`).
+
+---
+
+### Task 1: Pure helpers — `isSameDay`, `FeedFilter`/`feedView`, `statusPill` (TDD)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/util/Time.kt`, `app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/activity/FeedViewTest.kt` (new)
+
+**Interfaces:** Produces `isSameDay(aMs, bMs, zone): Boolean`; `enum FeedFilter { ALL, TODAY, UPCOMING, RECENT }`; `data class FeedView(needsYou, sections) { val count: Int }`; `feedView(sections, needsYou, nowMs, filter): FeedView`; `statusPill(item, nowMs): String?`.
+
+- [ ] **Step 1: Write the failing tests** — create `FeedViewTest.kt`:
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import com.hermes.client.ui.util.isSameDay
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.ZoneId
+
+class FeedViewTest {
+    private val utc = ZoneId.of("UTC")
+    private val day = 24 * 60 * 60_000L
+    private val t0 = 1_720_000_000_000L // fixed "now"
+
+    private fun item(id: String, ts: Long?, upcoming: Boolean) =
+        ActivityItem(id, ActivityKind.CRON, id, null, ts, upcoming, null, "r/$id")
+    private fun alert(id: String) = CronAlert(id, id, CronAlertReason.FAILED, "cron_detail/$id")
+
+    @Test fun isSameDay_true_within_day() {
+        assertEquals(true, isSameDay(t0, t0 + 60_000, utc))
+    }
+    @Test fun isSameDay_false_next_day() {
+        assertEquals(false, isSameDay(t0, t0 + day, utc))
+    }
+
+    private val sections = listOf(
+        ActivitySection("Live now", listOf(item("live", t0 - 60_000, false))),
+        ActivitySection("Upcoming", listOf(item("up-today", t0 + 60_000, true), item("up-future", t0 + 3 * day, true))),
+        ActivitySection("Recent", listOf(item("old", t0 - 3 * day, false))),
+    )
+    private val needs = listOf(alert("a1"))
+
+    @Test fun feedView_all_is_everything() {
+        val v = feedView(sections, needs, t0, FeedFilter.ALL)
+        assertEquals(1, v.needsYou.size)
+        assertEquals(3, v.sections.size)
+        assertEquals(1 + 4, v.count)
+    }
+    @Test fun feedView_today_keeps_needs_and_today_items() {
+        val v = feedView(sections, needs, t0, FeedFilter.TODAY)
+        assertEquals(1, v.needsYou.size)
+        // today items: live (t0-60s), up-today (t0+60s) -> 2, in their sections; old & up-future dropped
+        assertEquals(2, v.sections.sumOf { it.items.size })
+        assertEquals(1 + 2, v.count)
+    }
+    @Test fun feedView_upcoming_only_upcoming_section_no_needs() {
+        val v = feedView(sections, needs, t0, FeedFilter.UPCOMING)
+        assertEquals(0, v.needsYou.size)
+        assertEquals(listOf("Upcoming"), v.sections.map { it.title })
+        assertEquals(2, v.count)
+    }
+    @Test fun feedView_recent_excludes_upcoming_and_needs() {
+        val v = feedView(sections, needs, t0, FeedFilter.RECENT)
+        assertEquals(0, v.needsYou.size)
+        assertEquals(listOf("Live now", "Recent"), v.sections.map { it.title })
+        assertEquals(2, v.count)
+    }
+
+    @Test fun statusPill_scheduled_live_none() {
+        assertEquals("Scheduled", statusPill(item("s", t0 + day, true), t0))
+        assertEquals("Live", statusPill(item("l", t0 - 60_000, false), t0))
+        assertEquals(null, statusPill(item("o", t0 - 3 * day, false), t0))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*FeedViewTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `isSameDay`/`FeedFilter`/`feedView`/`statusPill`.
+
+- [ ] **Step 3: Add `isSameDay` to `Time.kt`**
+
+```kotlin
+fun isSameDay(aMs: Long, bMs: Long, zone: java.time.ZoneId = java.time.ZoneId.systemDefault()): Boolean =
+    java.time.Instant.ofEpochMilli(aMs).atZone(zone).toLocalDate() ==
+        java.time.Instant.ofEpochMilli(bMs).atZone(zone).toLocalDate()
+```
+
+- [ ] **Step 4: Add `FeedFilter`/`FeedView`/`feedView`/`statusPill` to `ActivityModels.kt`**
+
+```kotlin
+enum class FeedFilter { ALL, TODAY, UPCOMING, RECENT }
+
+data class FeedView(val needsYou: List<CronAlert>, val sections: List<ActivitySection>) {
+    val count: Int get() = needsYou.size + sections.sumOf { it.items.size }
+}
+
+/** Filter the assembled feed for the selected tab (grouping headers still apply within a filter). */
+fun feedView(
+    sections: List<ActivitySection>,
+    needsYou: List<CronAlert>,
+    nowMs: Long,
+    filter: FeedFilter,
+): FeedView = when (filter) {
+    FeedFilter.ALL -> FeedView(needsYou, sections)
+    FeedFilter.TODAY -> FeedView(
+        needsYou,
+        sections
+            .map { s -> s.copy(items = s.items.filter { it.timestampMs != null && com.hermes.client.ui.util.isSameDay(it.timestampMs, nowMs) }) }
+            .filter { it.items.isNotEmpty() },
+    )
+    FeedFilter.UPCOMING -> FeedView(emptyList(), sections.filter { it.title.equals("Upcoming", ignoreCase = true) })
+    FeedFilter.RECENT -> FeedView(emptyList(), sections.filterNot { it.title.equals("Upcoming", ignoreCase = true) })
+}
+
+/** Short state label for an activity row, or null (plain recent items get no pill). */
+fun statusPill(item: ActivityItem, nowMs: Long): String? = when {
+    item.upcoming -> "Scheduled"
+    item.timestampMs != null && (nowMs - item.timestampMs) in 0..LIVE_WINDOW_MS -> "Live"
+    else -> null
+}
+```
+(`import com.hermes.client.ui.util.isSameDay` at the top of `ActivityModels.kt`, or use the fully-qualified call shown.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*FeedViewTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (all 8 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/util/Time.kt app/src/main/java/com/hermes/client/ui/activity/ActivityModels.kt app/src/test/java/com/hermes/client/ui/activity/FeedViewTest.kt
+git commit -m "feat(activity): feed filter + status-pill pure helpers (isSameDay/feedView/statusPill)"
+```
+
+---
+
+### Task 2: `FeedTabs` composable
+
+**Files:** Create `app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt`
+
+**Interfaces:** Consumes `FeedFilter`, `feedView(...).count`, `ActivitySection`, `CronAlert`, `LocalProfileAccent`. Produces `@Composable fun FeedTabs(sections, needsYou, nowMs, selected, onSelect, modifier)`.
+
+- [ ] **Step 1: Create `FeedTabs.kt`**
+
+```kotlin
+package com.hermes.client.ui.activity
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+private val FILTERS = listOf(
+    FeedFilter.ALL to "All",
+    FeedFilter.TODAY to "Today",
+    FeedFilter.UPCOMING to "Upcoming",
+    FeedFilter.RECENT to "Recent",
+)
+
+/** Per-tenant-accent segmented time filter for the Home feed; counts reflect the current page. */
+@Composable
+fun FeedTabs(
+    sections: List<ActivitySection>,
+    needsYou: List<CronAlert>,
+    nowMs: Long,
+    selected: FeedFilter,
+    onSelect: (FeedFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accent = LocalProfileAccent.current
+    SingleChoiceSegmentedButtonRow(modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+        FILTERS.forEachIndexed { i, (filter, label) ->
+            val count = feedView(sections, needsYou, nowMs, filter).count
+            SegmentedButton(
+                selected = selected == filter,
+                onClick = { onSelect(filter) },
+                shape = SegmentedButtonDefaults.itemShape(i, FILTERS.size),
+                colors = SegmentedButtonDefaults.colors(
+                    activeContainerColor = accent.accent,
+                    activeContentColor = accent.onAccent,
+                ),
+            ) { Text("$label $count") }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
+git commit -m "feat(activity): FeedTabs segmented time filter (accent-tinted, counts)"
+```
+
+---
+
+### Task 3: Wire the tabs into `MissionControlPage`
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+**Interfaces:** Consumes `FeedTabs`, `FeedFilter`, `feedView`, `FeedView`.
+
+- [ ] **Step 1: Add per-page filter state + render the tabs above the content**
+
+In `MissionControlPage`, add near the other hoisted state: `var filter by androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(FeedFilter.ALL) }`. Replace the single `MissionControlContent(...)` call with a `Column`:
+```kotlin
+        Column {
+            FeedTabs(
+                sections = state.sections,
+                needsYou = state.needsYou,
+                nowMs = now,
+                selected = filter,
+                onSelect = { filter = it },
+            )
+            MissionControlContent(
+                state = state,
+                view = feedView(state.sections, state.needsYou, now, filter),
+                nowMs = now,
+                // …forward the remaining existing args unchanged (onRetry, responses, expandedIds, onToggle, onOpen, onRunNow, onRetryResponse)…
+            )
+        }
+```
+(Keep every existing `MissionControlContent` argument; only add `view`.)
+
+- [ ] **Step 2: Make `MissionControlContent` render from the `FeedView`**
+
+Add a `view: FeedView` parameter to `MissionControlContent`. In its `LazyColumn`, change the feed body to read `view.needsYou` and `view.sections` instead of `state.needsYou`/`state.sections` (the needs-you header+items block and the `else -> view.sections.forEach { … }`). Keep the `when` guards reading `state` for `loading`/`error`, but base the empty check on the filtered view:
+```kotlin
+        if (view.needsYou.isNotEmpty()) {
+            item(key = "needs-header") { /* SectionHeader — updated in Task 4 */ }
+            items(view.needsYou, key = { "needs-${it.jobId}" }) { alert -> NeedsYouRow(alert, nowMs = nowMs, onClick = { onOpen(alert.route) }, onRunNow = { onRunNow(alert) }) }
+        }
+        when {
+            state.loading && state.sections.isEmpty() -> item { LoadingState() }
+            state.error != null -> item { ErrorState(message = state.error!!, onRetry = onRetry) }
+            view.needsYou.isEmpty() && view.sections.isEmpty() -> item {
+                EmptyState(title = "Nothing here", subtitle = "Nothing matches this filter for this profile yet.")
+            }
+            else -> view.sections.forEach { section ->
+                item(key = "h-${section.title}") { /* SectionHeader — updated in Task 4 */ }
+                items(section.items, key = { it.id }) { activity -> /* ActivityRow — unchanged this task */ }
+            }
+        }
+```
+(This task keeps `SectionHeader`/`ActivityRow` call sites as-is except for swapping the data source to `view`; Tasks 4 and 5 change those composables.)
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(home): wire FeedTabs — filter the feed per page"
+```
+
+---
+
+### Task 4: Collapsible sections
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+- [ ] **Step 1: Hoist collapse state in `MissionControlPage`**
+
+```kotlin
+    var collapsed by androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(emptySet<String>()) }
+    val onToggleSection: (String) -> Unit = { title -> collapsed = if (title in collapsed) collapsed - title else collapsed + title }
+```
+Pass `collapsed = collapsed` and `onToggleSection = onToggleSection` into `MissionControlContent` (add both params).
+
+- [ ] **Step 2: Make `SectionHeader` a collapse toggle**
+
+```kotlin
+@Composable
+private fun SectionHeader(label: String, count: Int, collapsed: Boolean, onToggle: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().clickable(onClick = onToggle)
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label.uppercase(), style = MaterialTheme.typography.titleSmall, color = LocalProfileAccent.current.accent, modifier = Modifier.weight(1f))
+        Text(count.toString(), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Icon(
+            if (collapsed) Icons.Rounded.ExpandMore else Icons.Rounded.ExpandLess,
+            contentDescription = if (collapsed) "Expand $label" else "Collapse $label",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+```
+Add imports `androidx.compose.material.icons.rounded.ExpandMore` / `ExpandLess` (the per-row expander already uses these — likely already imported).
+
+- [ ] **Step 3: Gate the items on collapse state in `MissionControlContent`**
+
+Needs-you: header passes `collapsed = "Needs you" in collapsed, onToggle = { onToggleSection("Needs you") }`; render `items(view.needsYou, …)` only when `"Needs you" !in collapsed`. Each section: header passes `collapsed = section.title in collapsed, onToggle = { onToggleSection(section.title) }`; render `items(section.items, …)` only when `section.title !in collapsed`.
+
+- [ ] **Step 4: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(home): collapsible section headers (persisted)"
+```
+
+---
+
+### Task 5: Status pills on rows
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt`
+
+- [ ] **Step 1: Add a `StatusPill` composable + use it in `ActivityRow`**
+
+Add:
+```kotlin
+@Composable
+private fun StatusPill(label: String) {
+    val accent = LocalProfileAccent.current
+    androidx.compose.material3.Surface(
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+        color = accent.container,
+    ) {
+        Text(
+            label,
+            Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = accent.onContainer,
+        )
+    }
+}
+```
+In `ActivityRow`, compute `val pill = statusPill(item, nowMs)` and replace `trailingContent`:
+```kotlin
+            trailingContent = if (pill != null || expandable) {
+                {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        pill?.let { StatusPill(it); Spacer(Modifier.width(6.dp)) }
+                        if (expandable) {
+                            Icon(
+                                if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                                contentDescription = if (isExpanded) "Collapse response" else "Show response",
+                            )
+                        }
+                    }
+                }
+            } else {
+                null
+            },
+```
+Add `androidx.compose.foundation.layout.Row`/`Spacer`/`width` imports if missing.
+
+- [ ] **Step 2: Compile + full suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+git commit -m "feat(home): status pills on activity rows (Scheduled/Live, accent-tinted)"
+```
+
+---
+
+### Task 6: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`; point at the mock (`http://10.0.2.2:8899`), which has cron (upcoming/failed) + sessions under acme.
+
+- [ ] **Step 2: Verify**
+
+1. Home shows `All / Today / Upcoming / Recent` tabs (accent-tinted) under the tenant switcher, each with a count; tapping a tab filters the feed; counts reflect the active profile.
+2. Tapping a section header collapses/expands it (⌃/⌄); state survives scroll and a rotation.
+3. Rows show a "Scheduled" pill (upcoming cron) and "Live" (recent activity within 15 min); plain recent chats show none; Needs-you rows still show Run-now.
+4. Swiping to another profile (globex) keeps its own tab + collapse state and re-tints everything to that tenant's accent.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(home): feed-refresh verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Element 1 (tabs) → Task 1 (`FeedFilter`/`feedView`/`isSameDay` + tests) + Task 2 (`FeedTabs`) + Task 3 (wiring) ✓; Element 2 (collapsible) → Task 4 ✓; Element 3 (pills) → Task 1 (`statusPill` + test) + Task 5 (`StatusPill` + `ActivityRow`) ✓; on-device → Task 6 ✓. Deferred items (time-rail, avatar-dropdown, real status threading) intentionally have no task, per the spec.
+- **Placeholder scan:** every code step shows full code; the Task-3 "…forward the remaining existing args…" refers to concrete existing parameters named in the Grounding block; the only conditional is the Task-6 verification-only commit.
+- **Type consistency:** `FeedFilter`, `FeedView(needsYou, sections).count`, `feedView(sections, needsYou, nowMs, filter)`, `isSameDay(aMs, bMs, zone)`, `statusPill(item, nowMs)`, `SectionHeader(label, count, collapsed, onToggle)`, `FeedTabs(sections, needsYou, nowMs, selected, onSelect, modifier)`, `StatusPill(label)` are consistent across tasks; `LocalProfileAccent.current.{accent,onAccent,container,onContainer}` matches the theme.
+
+**Ordering:** Task 1 (pure) first. `MissionControlScreen.kt` is touched by Tasks 3 → 4 → 5 — run strictly in order (each builds on the prior's `MissionControlContent`/`SectionHeader`/`ActivityRow` shape). Task 2 (new file) can precede Task 3. Task 6 verifies.

--- a/docs/superpowers/specs/2026-07-06-home-feed-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-06-home-feed-refresh-design.md
@@ -1,0 +1,103 @@
+# Home Feed Refresh — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/home-feed-refresh`
+**Source:** user reference mockup (segmented tabs + collapsible counted sections + status pills), adapted to the Mission Control / Home feed.
+
+## Goal
+
+Bring a task-manager mockup's structure into Home: **segmented time-filter tabs**, **collapsible counted sections**, and **status pills** on rows — reskinning/refiltering *on top of* the existing feed (its data/logic are untouched). Keep the per-tenant accent as the identity/safety signal (not the mockup's gold). Compose-only, no gateway changes.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Compose UI over existing `MissionControlState` only. Material 3.
+- Multi-tenant isolation: all new chrome tints to `LocalProfileAccent.current` (per-tenant accent), never a hardcoded colour.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Grounding (from exploration)
+
+- `MissionControlScreen`: `Scaffold` topBar = `Column { HermesTopBar("Home"); if (names.size>1) ProfileSwitcher(...) }` (shared chrome); a `HorizontalPager` of `MissionControlPage(profile)`. Each page hoists `expandedIds` (`rememberSaveable`) and renders `MissionControlContent` (a `LazyColumn`: needs-you header+rows → `state.sections.forEach { header + items }` → quicklinks footer).
+- `MissionControlState(sections: List<ActivitySection>, needsYou: List<CronAlert>, loading, error, unauthorized)`. `ActivitySection(title, items)`, titles ∈ {"Live now","Upcoming","Recent"}. `ActivityItem(id, kind, title, subtitle, timestampMs: Long?, upcoming: Boolean, status: String?, route, sessionId)` — **`status` is always null today** (pills must derive from `upcoming` + the live window, not a status string).
+- `LIVE_WINDOW_MS = 15*60_000`. `SingleChoiceSegmentedButtonRow`/`SegmentedButton` already used in `AppearanceScreen`/`ModelSelector` (the tab primitive). `rememberSaveable` id-set + toggle is the collapse pattern. `relativeTime`/`isoToEpochMs` in `ui/util/Time.kt`; **no** day-boundary helper exists.
+
+## Layout decision
+
+The tabs render as **per-page fixed chrome inside `MissionControlPage`**, above the content `LazyColumn` (so each profile's tab **counts** reflect that page's own feed, and the tabs stay visible while the feed scrolls). Visual stack: status bar → `HermesTopBar("Home")` → `ProfileSwitcher` (shared) → **FeedTabs** (per page) → feed. This is one more chrome row than wave-3's lifted hero — an accepted, mockup-faithful trade. (Collapsing the switcher into a top-bar avatar-dropdown is a cleaner but bigger restructure — **deferred**.)
+
+## Element 1 — Segmented time-filter tabs
+
+`All / Today / Upcoming / Recent`, each with a count, tinted to the active tenant accent.
+
+- **Pure model (testable), in `ActivityModels.kt`:**
+```kotlin
+enum class FeedFilter { ALL, TODAY, UPCOMING, RECENT }
+
+data class FeedView(val needsYou: List<CronAlert>, val sections: List<ActivitySection>) {
+    val count: Int get() = needsYou.size + sections.sumOf { it.items.size }
+}
+
+fun feedView(
+    sections: List<ActivitySection>,
+    needsYou: List<CronAlert>,
+    nowMs: Long,
+    filter: FeedFilter,
+): FeedView = when (filter) {
+    FeedFilter.ALL -> FeedView(needsYou, sections)
+    FeedFilter.TODAY -> FeedView(
+        needsYou,
+        sections.map { s -> s.copy(items = s.items.filter { it.timestampMs != null && isSameDay(it.timestampMs, nowMs) }) }
+            .filter { it.items.isNotEmpty() },
+    )
+    FeedFilter.UPCOMING -> FeedView(emptyList(), sections.filter { it.title.equals("Upcoming", ignoreCase = true) })
+    FeedFilter.RECENT -> FeedView(emptyList(), sections.filterNot { it.title.equals("Upcoming", ignoreCase = true) })
+}
+```
+  - **ALL** = everything. **TODAY** = Needs-you (always — they need you now) + items dated today. **UPCOMING** = the "Upcoming" section only (scheduled). **RECENT** = the non-Upcoming sections ("Live now" + "Recent"). Empty sections drop out.
+- **New day helper, in `ui/util/Time.kt`:**
+```kotlin
+fun isSameDay(aMs: Long, bMs: Long, zone: java.time.ZoneId = java.time.ZoneId.systemDefault()): Boolean =
+    java.time.Instant.ofEpochMilli(aMs).atZone(zone).toLocalDate() ==
+        java.time.Instant.ofEpochMilli(bMs).atZone(zone).toLocalDate()
+```
+- **`FeedTabs` composable** (new, `ui/activity/FeedTabs.kt`): a `SingleChoiceSegmentedButtonRow` of the 4 filters; each `SegmentedButton(selected = filter == it, onClick = { onSelect(it) }, shape = SegmentedButtonDefaults.itemShape(index, 4), colors = SegmentedButtonDefaults.colors(activeContainerColor = LocalProfileAccent.current.accent, activeContentColor = LocalProfileAccent.current.onAccent))` with a label `"<Name> <count>"` (count computed via `feedView(...).count` per filter). Compact (fits one row).
+- **Wiring:** `MissionControlPage` gains `var filter by rememberSaveable { mutableStateOf(FeedFilter.ALL) }`; renders `Column { FeedTabs(state, filter, onSelect = { filter = it }); MissionControlContent(view = feedView(state.sections, state.needsYou, now, filter), …) }`. `MissionControlContent` renders from the filtered `FeedView` (its `needsYou`/`sections`) instead of raw `state` for the feed body (loading/error/empty branches still read `state`).
+
+## Element 2 — Collapsible sections
+
+- `SectionHeader(label, count, collapsed: Boolean, onToggle: () -> Unit)` — the whole header is `clickable(onClick = onToggle)`; trailing icon `if (collapsed) Icons.Rounded.ExpandMore else Icons.Rounded.ExpandLess` (⌄ collapsed / ⌃ expanded), `contentDescription` = "Expand <label>" / "Collapse <label>". **The header→Cron deep-link is removed** (Cron stays reachable via the quicklinks footer + any cron row).
+- **State:** `MissionControlPage` hoists `var collapsed by rememberSaveable { mutableStateOf(emptySet<String>()) }` (default all expanded); `onToggleSection(title) = { collapsed = if (title in collapsed) collapsed - title else collapsed + title }`. In `MissionControlContent`, the needs-you header and each `section` header pass `collapsed = title in collapsed`; the `items(...)` block for that section/needs-you renders **only when not collapsed**. (Keys: needs-you uses `"Needs you"`; sections use `section.title`.)
+
+## Element 3 — Status pills
+
+- **Pure helper, in `ActivityModels.kt`:**
+```kotlin
+/** Short state label for an activity row, or null (plain recent items get no pill). */
+fun statusPill(item: ActivityItem, nowMs: Long): String? = when {
+    item.upcoming -> "Scheduled"
+    item.timestampMs != null && (nowMs - item.timestampMs) in 0..LIVE_WINDOW_MS -> "Live"
+    else -> null
+}
+```
+- **`ActivityRow`:** compute `val pill = statusPill(item, nowMs)`. `trailingContent` becomes: if `pill != null || expandable`, a `Row(verticalAlignment = CenterVertically) { pill?.let { StatusPill(it) }; if (expandable) Icon(ExpandMore/ExpandLess…) }`; else `null`. `StatusPill(label)` = a small `Surface(shape = RoundedCornerShape(50), color = LocalProfileAccent.current.container) { Text(label, Modifier.padding(horizontal = 8.dp, vertical = 2.dp), style = labelSmall, color = LocalProfileAccent.current.onContainer) }`.
+- **Needs-you rows unchanged** (they already carry "Failed/Overdue" + "Run now"). **Left time-rail deferred** (relative time is already in the subtitle).
+
+## Testing
+
+- **Unit (pure), TDD:**
+  - `isSameDay`: same-calendar-day (fixed zone) → true; different day → false; across a day boundary → false.
+  - `feedView`: ALL returns all; TODAY keeps needsYou + only today's items (drops empty sections); UPCOMING = only the "Upcoming" section, no needsYou; RECENT = non-Upcoming sections, no needsYou; `count` sums correctly.
+  - `statusPill`: upcoming → "Scheduled"; within live window → "Live"; older → null.
+- **On-device:**
+  1. Home shows the `All/Today/Upcoming/Recent` tabs (accent-tinted) under the switcher, with counts; selecting a tab filters the feed; counts reflect the active profile.
+  2. Tapping a section header collapses/expands it (⌃/⌄), and the state survives scroll/rotation.
+  3. Rows show a "Scheduled"/"Live" pill where applicable; recent chats show none; Needs-you rows still show Run-now.
+  4. Everything stays tenant-accent tinted (green acme / gold globex); swiping profiles keeps each page's tab + collapse state.
+
+## Not doing (YAGNI)
+
+- Left time-rail on rows (deferred).
+- Collapsing the switcher into a top-bar avatar-dropdown (deferred).
+- Threading real cron `lastStatus` onto `ActivityItem.status` for richer pills (the derive-from-`upcoming`/live-window approach is honest to current data; failed crons already surface in Needs-you).
+- "Priority High/Medium" tags and a literal "Completed" state (no clean mapping; Hermes isn't a to-do app).
+- Any gateway/API change.


### PR DESCRIPTION
## Promote develop → main (production 0.1.37)

Promotes the Home feed refresh to production. main was last at 0.1.36 (#64).

### What ships to production (0.1.37)
Adapts a reference mockup's structure into the Home / Mission Control feed — Compose-only over the existing feed, per-tenant-accent tinted:
1. Segmented `All / Today / Upcoming / Recent` time-filter tabs (accent-tinted, per-filter counts, stable across switches).
2. Collapsible section headers (⌃/⌄, persisted).
3. `Scheduled` / `Live` status pills on rows.

Built via spec → plan → subagent-driven development with per-task and an opus final whole-branch review ("ready to merge"; state/filtered-view split, per-page state isolation, and multi-tenant tinting all confirmed). 8 new unit tests. No bridge/gateway API changes.
