### PR TITLE
Promote to production: 0.1.38 (cron schedule builder)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 38
-        versionName = "0.1.37"
+        versionCode = 39
+        versionName = "0.1.38"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
@@ -232,7 +232,9 @@ private fun ScheduleBuilder(schedule: Schedule, onChange: (Schedule) -> Unit, no
         }
         Spacer(Modifier.height(8.dp))
         val next = schedule.nextRun(nowMs)?.let { epochMs ->
-            " · Next: " + com.hermes.client.ui.util.formatIso(java.time.Instant.ofEpochMilli(epochMs).toString())
+            " · Next: " + com.hermes.client.ui.util.formatIso(
+                java.time.Instant.ofEpochMilli(epochMs).atZone(java.time.ZoneId.systemDefault()).toOffsetDateTime().toString()
+            )
         }.orEmpty()
         Text(schedule.describe() + next, style = MaterialTheme.typography.bodyMedium, color = accent.accent)
     }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
@@ -1,21 +1,41 @@
 package com.hermes.client.ui.cron
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -130,15 +150,189 @@ fun CronEditScreen(
         Column(Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp)) {
             OutlinedTextField(state.name, vm::setName, label = { Text("Name (optional)") },
                 singleLine = true, modifier = Modifier.fillMaxWidth())
-            OutlinedTextField(state.schedule.describe(), {}, label = { Text("Schedule (cron, e.g. 0 9 * * *)") },
-                singleLine = true, modifier = Modifier.fillMaxWidth().padding(top = 8.dp), enabled = false)
-            Text("min hour day month weekday", style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(top = 2.dp))
+            Spacer(Modifier.height(8.dp))
+            ScheduleBuilder(schedule = state.schedule, onChange = vm::setSchedule, nowMs = System.currentTimeMillis())
             OutlinedTextField(state.prompt, vm::setPrompt, label = { Text("Prompt") },
                 minLines = 5, modifier = Modifier.fillMaxWidth().padding(top = 8.dp))
-            Button(onClick = { vm.save() }, modifier = Modifier.padding(top = 16.dp)) {
+            Button(
+                onClick = { vm.save() },
+                enabled = state.prompt.isNotBlank() &&
+                    (state.schedule !is Schedule.Advanced || isValidCron((state.schedule as Schedule.Advanced).expr)),
+                modifier = Modifier.padding(top = 16.dp),
+            ) {
                 Text(if (state.isNew) "Create" else "Save")
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScheduleBuilder(schedule: Schedule, onChange: (Schedule) -> Unit, nowMs: Long) {
+    val accent = com.hermes.client.ui.theme.LocalProfileAccent.current
+    val kinds = listOf("Hourly", "Daily", "Weekly", "Monthly", "Advanced")
+    val current = when (schedule) {
+        is Schedule.Hourly -> 0; is Schedule.Daily -> 1; is Schedule.Weekly -> 2
+        is Schedule.Monthly -> 3; is Schedule.Advanced -> 4
+    }
+    // time carried across kind switches
+    val (h, m) = when (schedule) {
+        is Schedule.Daily -> schedule.hour to schedule.minute
+        is Schedule.Weekly -> schedule.hour to schedule.minute
+        is Schedule.Monthly -> schedule.hour to schedule.minute
+        is Schedule.Hourly -> 9 to schedule.minute
+        is Schedule.Advanced -> 9 to 0
+    }
+    Column(Modifier.fillMaxWidth()) {
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            kinds.forEachIndexed { i, label ->
+                SegmentedButton(
+                    selected = current == i,
+                    onClick = {
+                        onChange(when (i) {
+                            0 -> Schedule.Hourly(m.coerceIn(0, 59))
+                            1 -> Schedule.Daily(h, m)
+                            2 -> Schedule.Weekly(setOf(Weekday.MON), h, m)
+                            3 -> Schedule.Monthly(1, h, m)
+                            else -> Schedule.Advanced(schedule.toCron())
+                        })
+                    },
+                    shape = SegmentedButtonDefaults.itemShape(i, kinds.size),
+                    colors = SegmentedButtonDefaults.colors(activeContainerColor = accent.accent, activeContentColor = accent.onAccent),
+                ) { Text(label, maxLines = 1) }
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        when (schedule) {
+            is Schedule.Hourly -> MinutePicker(schedule.minute) { onChange(schedule.copy(minute = it)) }
+            is Schedule.Daily -> TimeRow(schedule.hour, schedule.minute) { hh, mm -> onChange(schedule.copy(hour = hh, minute = mm)) }
+            is Schedule.Weekly -> {
+                WeekdayChips(schedule.days) { onChange(schedule.copy(days = it)) }
+                Spacer(Modifier.height(8.dp))
+                TimeRow(schedule.hour, schedule.minute) { hh, mm -> onChange(schedule.copy(hour = hh, minute = mm)) }
+            }
+            is Schedule.Monthly -> {
+                DayOfMonthPicker(schedule.dayOfMonth) { onChange(schedule.copy(dayOfMonth = it)) }
+                Spacer(Modifier.height(8.dp))
+                TimeRow(schedule.hour, schedule.minute) { hh, mm -> onChange(schedule.copy(hour = hh, minute = mm)) }
+            }
+            is Schedule.Advanced -> {
+                val valid = isValidCron(schedule.expr)
+                OutlinedTextField(
+                    schedule.expr, { onChange(Schedule.Advanced(it)) },
+                    label = { Text("Schedule (cron, e.g. 0 9 * * *)") }, singleLine = true,
+                    isError = schedule.expr.isNotBlank() && !valid, modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    if (schedule.expr.isNotBlank() && !valid) "Not a valid 5-field cron expression" else "min hour day month weekday",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (schedule.expr.isNotBlank() && !valid) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        val next = schedule.nextRun(nowMs)?.let { epochMs ->
+            " · Next: " + com.hermes.client.ui.util.formatIso(java.time.Instant.ofEpochMilli(epochMs).toString())
+        }.orEmpty()
+        Text(schedule.describe() + next, style = MaterialTheme.typography.bodyMedium, color = accent.accent)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MinutePicker(minute: Int, onPick: (Int) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }, modifier = Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = ":%02d".format(minute),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Minute") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, true).fillMaxWidth(),
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            (0..59).forEach { minuteOption ->
+                DropdownMenuItem(
+                    text = { Text(":%02d".format(minuteOption)) },
+                    onClick = { onPick(minuteOption); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DayOfMonthPicker(day: Int, onPick: (Int) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }, modifier = Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = day.toString(),
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Day of month") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, true).fillMaxWidth(),
+        )
+        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            (1..28).forEach { dayOption ->
+                DropdownMenuItem(
+                    text = { Text(dayOption.toString()) },
+                    onClick = { onPick(dayOption); expanded = false },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WeekdayChips(days: Set<Weekday>, onChange: (Set<Weekday>) -> Unit) {
+    val accent = com.hermes.client.ui.theme.LocalProfileAccent.current
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Weekday.values().sortedBy { it.cron }.forEach { day ->
+            val selected = day in days
+            FilterChip(
+                selected = selected,
+                onClick = {
+                    val next = if (selected) days - day else days + day
+                    if (next.isNotEmpty()) onChange(next)
+                },
+                label = { Text(day.short) },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = accent.accent,
+                    selectedLabelColor = accent.onAccent,
+                ),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimeRow(hour: Int, minute: Int, onPick: (Int, Int) -> Unit) {
+    val accent = com.hermes.client.ui.theme.LocalProfileAccent.current
+    var showDialog by remember { mutableStateOf(false) }
+    OutlinedButton(
+        onClick = { showDialog = true },
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = accent.accent),
+    ) {
+        Text("At %02d:%02d".format(hour, minute))
+    }
+    if (showDialog) {
+        val state = rememberTimePickerState(initialHour = hour, initialMinute = minute, is24Hour = true)
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            confirmButton = {
+                TextButton(onClick = { onPick(state.hour, state.minute); showDialog = false }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+            },
+            text = { TimePicker(state = state) },
+        )
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 
 data class CronEditState(
     val name: String = "",
-    val schedule: String = "",
+    val schedule: Schedule = Schedule.Daily(9, 0),
     val prompt: String = "",
     val isNew: Boolean = true,
     val loading: Boolean = false,
@@ -66,7 +66,7 @@ class CronEditViewModel @Inject constructor(
                 .onSuccess { job ->
                     _state.value = CronEditState(
                         name = job.name ?: "",
-                        schedule = job.scheduleText,
+                        schedule = parseCron(job.schedule?.expr ?: job.scheduleText),
                         prompt = job.prompt ?: "",
                         isNew = false,
                         loading = false,
@@ -77,17 +77,20 @@ class CronEditViewModel @Inject constructor(
     }
 
     fun setName(v: String) { _state.value = _state.value.copy(name = v) }
-    fun setSchedule(v: String) { _state.value = _state.value.copy(schedule = v) }
+    fun setSchedule(v: Schedule) { _state.value = _state.value.copy(schedule = v) }
     fun setPrompt(v: String) { _state.value = _state.value.copy(prompt = v) }
 
     fun save() = viewModelScope.launch {
         val s = _state.value
-        if (s.prompt.isBlank() || s.schedule.isBlank()) {
-            _state.value = s.copy(message = "Schedule and prompt are required"); return@launch
+        val advancedInvalid = s.schedule is Schedule.Advanced && !isValidCron((s.schedule as Schedule.Advanced).expr)
+        if (s.prompt.isBlank() || advancedInvalid) {
+            _state.value = s.copy(message = if (s.prompt.isBlank()) "Prompt is required" else "Schedule is not a valid cron expression")
+            return@launch
         }
+        val cron = s.schedule.toCron()
         runCatching {
-            if (s.isNew) tools.createCron(s.prompt, s.schedule, s.name, profile)
-            else tools.updateCron(jobId, s.prompt, s.schedule, s.name, profile)
+            if (s.isNew) tools.createCron(s.prompt, cron, s.name, profile)
+            else tools.updateCron(jobId, s.prompt, cron, s.name, profile)
         }.onSuccess { _state.value = s.copy(saved = true) }
             .onFailure { _state.value = s.copy(message = "Save failed: ${it.message}") }
     }
@@ -127,8 +130,8 @@ fun CronEditScreen(
         Column(Modifier.padding(padding).fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp)) {
             OutlinedTextField(state.name, vm::setName, label = { Text("Name (optional)") },
                 singleLine = true, modifier = Modifier.fillMaxWidth())
-            OutlinedTextField(state.schedule, vm::setSchedule, label = { Text("Schedule (cron, e.g. 0 9 * * *)") },
-                singleLine = true, modifier = Modifier.fillMaxWidth().padding(top = 8.dp))
+            OutlinedTextField(state.schedule.describe(), {}, label = { Text("Schedule (cron, e.g. 0 9 * * *)") },
+                singleLine = true, modifier = Modifier.fillMaxWidth().padding(top = 8.dp), enabled = false)
             Text("min hour day month weekday", style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.padding(top = 2.dp))
             OutlinedTextField(state.prompt, vm::setPrompt, label = { Text("Prompt") },

--- a/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
@@ -151,7 +151,8 @@ fun CronEditScreen(
             OutlinedTextField(state.name, vm::setName, label = { Text("Name (optional)") },
                 singleLine = true, modifier = Modifier.fillMaxWidth())
             Spacer(Modifier.height(8.dp))
-            ScheduleBuilder(schedule = state.schedule, onChange = vm::setSchedule, nowMs = System.currentTimeMillis())
+            val nowMs = androidx.compose.runtime.remember(state.schedule) { System.currentTimeMillis() }
+            ScheduleBuilder(schedule = state.schedule, onChange = vm::setSchedule, nowMs = nowMs)
             OutlinedTextField(state.prompt, vm::setPrompt, label = { Text("Prompt") },
                 minLines = 5, modifier = Modifier.fillMaxWidth().padding(top = 8.dp))
             Button(
@@ -295,7 +296,7 @@ private fun WeekdayChips(days: Set<Weekday>, onChange: (Set<Weekday>) -> Unit) {
         Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        Weekday.values().sortedBy { it.cron }.forEach { day ->
+        Weekday.entries.forEach { day ->
             val selected = day in days
             FilterChip(
                 selected = selected,

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -12,22 +12,29 @@ import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.PauseCircleOutline
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import android.widget.Toast
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -71,6 +78,14 @@ fun CronScreen(
                 )
                 else -> {
                     val nowMs = remember(state.jobs) { System.currentTimeMillis() }
+                    val menuFor = remember { mutableStateOf<String?>(null) }
+                    val context = LocalContext.current
+                    LaunchedEffect(state.message) {
+                        state.message?.let {
+                            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+                            vm.clearMessage()
+                        }
+                    }
                     LazyColumn(Modifier.fillMaxSize()) {
                         items(state.jobs, key = { it.id }) { job ->
                             ListItem(
@@ -100,6 +115,29 @@ fun CronScreen(
                                 supportingContent = {
                                     val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
                                     Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())
+                                },
+                                trailingContent = {
+                                    Box {
+                                        IconButton(onClick = { menuFor.value = job.id }) {
+                                            Icon(Icons.Rounded.MoreVert, contentDescription = "Actions")
+                                        }
+                                        DropdownMenu(expanded = menuFor.value == job.id, onDismissRequest = { menuFor.value = null }) {
+                                            DropdownMenuItem(
+                                                text = { Text(if (job.isPaused) "Resume" else "Pause") },
+                                                onClick = {
+                                                    vm.runAction(job.id, job.name ?: job.id, if (job.isPaused) CronAction.RESUME else CronAction.PAUSE)
+                                                    menuFor.value = null
+                                                }
+                                            )
+                                            DropdownMenuItem(
+                                                text = { Text("Run now") },
+                                                onClick = {
+                                                    vm.runAction(job.id, job.name ?: job.id, CronAction.RUN)
+                                                    menuFor.value = null
+                                                }
+                                            )
+                                        }
+                                    }
                                 },
                                 modifier = Modifier.clickable { onOpen(job.id) },
                             )

--- a/app/src/main/java/com/hermes/client/ui/cron/CronViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronViewModel.kt
@@ -55,8 +55,8 @@ class CronViewModel @Inject constructor(
             }
         }.isSuccess
         val verb = when (action) { CronAction.PAUSE -> "Paused"; CronAction.RESUME -> "Resumed"; CronAction.RUN -> "Triggered" }
-        _state.value = _state.value.copy(message = if (ok) "$verb $name" else "Couldn't $verb.lowercase() $name")
-        if (ok) load()
+        _state.value = _state.value.copy(message = if (ok) "$verb $name" else "Couldn't ${verb.lowercase()} $name")
+        if (ok) runCatching { tools.cronJobs(p) }.onSuccess { jobs -> _state.value = _state.value.copy(jobs = jobs) }
     }
 
     fun clearMessage() { _state.value = _state.value.copy(message = null) }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronViewModel.kt
@@ -12,11 +12,14 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+enum class CronAction { PAUSE, RESUME, RUN }
+
 data class CronUiState(
     val jobs: List<CronJobDto> = emptyList(),
     val profile: String? = null,
     val loading: Boolean = true,
     val error: String? = null,
+    val message: String? = null,
 )
 
 @HiltViewModel
@@ -41,4 +44,20 @@ class CronViewModel @Inject constructor(
                 _state.value = _state.value.copy(loading = false, error = it.message ?: "Failed to load cron jobs")
             }
     }
+
+    fun runAction(jobId: String, name: String, action: CronAction) = viewModelScope.launch {
+        val p = _state.value.profile
+        val ok = runCatching {
+            when (action) {
+                CronAction.PAUSE -> tools.pauseCron(jobId, p)
+                CronAction.RESUME -> tools.resumeCron(jobId, p)
+                CronAction.RUN -> tools.triggerCron(jobId, p)
+            }
+        }.isSuccess
+        val verb = when (action) { CronAction.PAUSE -> "Paused"; CronAction.RESUME -> "Resumed"; CronAction.RUN -> "Triggered" }
+        _state.value = _state.value.copy(message = if (ok) "$verb $name" else "Couldn't $verb.lowercase() $name")
+        if (ok) load()
+    }
+
+    fun clearMessage() { _state.value = _state.value.copy(message = null) }
 }

--- a/app/src/main/java/com/hermes/client/ui/cron/Schedule.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/Schedule.kt
@@ -8,7 +8,7 @@ enum class Weekday(val cron: Int, val short: String) {
     SUN(0, "Sun"), MON(1, "Mon"), TUE(2, "Tue"), WED(3, "Wed"), THU(4, "Thu"), FRI(5, "Fri"), SAT(6, "Sat");
 
     companion object {
-        fun fromCron(v: Int): Weekday? = values().firstOrNull { it.cron == v % 7 }
+        fun fromCron(v: Int): Weekday? = entries.firstOrNull { it.cron == v % 7 }
     }
 }
 
@@ -82,8 +82,12 @@ fun Schedule.nextRun(nowMs: Long, zone: ZoneId = ZoneId.systemDefault()): Long? 
 
 private fun String.toIntOrStar(): Int? = toIntOrNull()
 
+private val WHITESPACE = Regex("\\s+")
+private const val CRON_PART = "(\\*|\\d+(-\\d+)?)(/\\d+)?"
+private val CRON_FIELD = Regex("^$CRON_PART(,$CRON_PART)*$")
+
 fun parseCron(expr: String): Schedule {
-    val f = expr.trim().split(Regex("\\s+"))
+    val f = expr.trim().split(WHITESPACE)
     if (f.size != 5) return Schedule.Advanced(expr.trim())
     val minS = f[0]
     val hourS = f[1]
@@ -108,11 +112,9 @@ private fun dowIsList(s: String): Boolean =
     s != "*" && s.split(",").all { it.toIntOrNull()?.let { n -> n in 0..7 } == true }
 
 fun isValidCron(expr: String): Boolean {
-    val f = expr.trim().split(Regex("\\s+"))
+    val f = expr.trim().split(WHITESPACE)
     if (f.size != 5) return false
     // A field is "*" (optionally with a /step) or a comma-separated list of
     // numbers/ranges, each optionally with a /step, e.g. "9-17/2,30".
-    val part = "(\\*|\\d+(-\\d+)?)(/\\d+)?"
-    val token = Regex("^$part(,$part)*$")
-    return f.all { token.matches(it) }
+    return f.all { CRON_FIELD.matches(it) }
 }

--- a/app/src/main/java/com/hermes/client/ui/cron/Schedule.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/Schedule.kt
@@ -1,0 +1,118 @@
+package com.hermes.client.ui.cron
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+enum class Weekday(val cron: Int, val short: String) {
+    SUN(0, "Sun"), MON(1, "Mon"), TUE(2, "Tue"), WED(3, "Wed"), THU(4, "Thu"), FRI(5, "Fri"), SAT(6, "Sat");
+
+    companion object {
+        fun fromCron(v: Int): Weekday? = values().firstOrNull { it.cron == v % 7 }
+    }
+}
+
+sealed interface Schedule {
+    data class Hourly(val minute: Int) : Schedule
+    data class Daily(val hour: Int, val minute: Int) : Schedule
+    data class Weekly(val days: Set<Weekday>, val hour: Int, val minute: Int) : Schedule
+    data class Monthly(val dayOfMonth: Int, val hour: Int, val minute: Int) : Schedule
+    data class Advanced(val expr: String) : Schedule
+}
+
+fun Schedule.toCron(): String = when (this) {
+    is Schedule.Hourly -> "$minute * * * *"
+    is Schedule.Daily -> "$minute $hour * * *"
+    is Schedule.Weekly -> "$minute $hour * * ${days.sortedBy { it.cron }.joinToString(",") { it.cron.toString() }}"
+    is Schedule.Monthly -> "$minute $hour $dayOfMonth * *"
+    is Schedule.Advanced -> expr
+}
+
+private fun hm(h: Int, m: Int) = "%02d:%02d".format(h, m)
+
+fun Schedule.describe(): String = when (this) {
+    is Schedule.Hourly -> if (minute == 0) "Every hour" else "Every hour at :%02d".format(minute)
+    is Schedule.Daily -> "Every day at ${hm(hour, minute)}"
+    is Schedule.Weekly ->
+        if (days.size == 7) "Every day at ${hm(hour, minute)}"
+        else "${days.sortedBy { it.cron }.joinToString(", ") { it.short }} at ${hm(hour, minute)}"
+    is Schedule.Monthly -> "Day $dayOfMonth of each month at ${hm(hour, minute)}"
+    is Schedule.Advanced -> expr
+}
+
+fun Schedule.nextRun(nowMs: Long, zone: ZoneId = ZoneId.systemDefault()): Long? {
+    val now = Instant.ofEpochMilli(nowMs).atZone(zone).toLocalDateTime()
+    fun ms(dt: LocalDateTime) = dt.atZone(zone).toInstant().toEpochMilli()
+    return when (this) {
+        is Schedule.Hourly -> {
+            var c = now.withMinute(minute).withSecond(0).withNano(0)
+            if (!c.isAfter(now)) c = c.plusHours(1)
+            ms(c)
+        }
+        is Schedule.Daily -> {
+            var c = now.toLocalDate().atTime(hour, minute)
+            if (!c.isAfter(now)) c = c.plusDays(1)
+            ms(c)
+        }
+        is Schedule.Weekly -> {
+            if (days.isEmpty()) return null
+            val wanted = days.map { it.cron }.toSet() // 0=Sun..6=Sat
+            var c = now.toLocalDate().atTime(hour, minute)
+            repeat(8) {
+                val dow = c.dayOfWeek.value % 7 // java: Mon=1..Sun=7 -> 0=Sun..6=Sat
+                if (dow in wanted && c.isAfter(now)) return ms(c)
+                c = c.plusDays(1).toLocalDate().atTime(hour, minute)
+            }
+            null
+        }
+        is Schedule.Monthly -> {
+            var date = now.toLocalDate()
+            repeat(13) {
+                if (dayOfMonth <= date.lengthOfMonth()) {
+                    val c = date.withDayOfMonth(dayOfMonth).atTime(hour, minute)
+                    if (c.isAfter(now)) return ms(c)
+                }
+                date = date.plusMonths(1).withDayOfMonth(1)
+            }
+            null
+        }
+        is Schedule.Advanced -> null
+    }
+}
+
+private fun String.toIntOrStar(): Int? = toIntOrNull()
+
+fun parseCron(expr: String): Schedule {
+    val f = expr.trim().split(Regex("\\s+"))
+    if (f.size != 5) return Schedule.Advanced(expr.trim())
+    val minS = f[0]
+    val hourS = f[1]
+    val domS = f[2]
+    val monS = f[3]
+    val dowS = f[4]
+    val min = minS.toIntOrStar()
+    val hour = hourS.toIntOrStar()
+    val dom = domS.toIntOrStar()
+    val star = { s: String -> s == "*" }
+    return when {
+        min != null && star(hourS) && star(domS) && star(monS) && star(dowS) -> Schedule.Hourly(min)
+        min != null && hour != null && star(domS) && star(monS) && star(dowS) -> Schedule.Daily(hour, min)
+        min != null && hour != null && star(domS) && star(monS) && dowIsList(dowS) ->
+            Schedule.Weekly(dowS.split(",").mapNotNull { Weekday.fromCron(it.toInt()) }.toSet(), hour, min)
+        min != null && hour != null && dom != null && star(monS) && star(dowS) -> Schedule.Monthly(dom, hour, min)
+        else -> Schedule.Advanced(expr.trim())
+    }
+}
+
+private fun dowIsList(s: String): Boolean =
+    s != "*" && s.split(",").all { it.toIntOrNull()?.let { n -> n in 0..7 } == true }
+
+fun isValidCron(expr: String): Boolean {
+    val f = expr.trim().split(Regex("\\s+"))
+    if (f.size != 5) return false
+    // A field is "*" (optionally with a /step) or a comma-separated list of
+    // numbers/ranges, each optionally with a /step, e.g. "9-17/2,30".
+    val part = "(\\*|\\d+(-\\d+)?)(/\\d+)?"
+    val token = Regex("^$part(,$part)*$")
+    return f.all { token.matches(it) }
+}

--- a/app/src/test/java/com/hermes/client/ui/cron/ScheduleTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/cron/ScheduleTest.kt
@@ -1,0 +1,86 @@
+package com.hermes.client.ui.cron
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+
+class ScheduleTest {
+    private val utc = ZoneId.of("UTC")
+    // 2026-07-06 10:30:00 UTC (a Monday)
+    private val now = Instant.parse("2026-07-06T10:30:00Z").toEpochMilli()
+    private fun at(iso: String) = Instant.parse(iso).toEpochMilli()
+
+    @Test fun toCron_all() {
+        assertEquals("5 * * * *", Schedule.Hourly(5).toCron())
+        assertEquals("0 9 * * *", Schedule.Daily(9, 0).toCron())
+        assertEquals("0 2 * * 1", Schedule.Weekly(setOf(Weekday.MON), 2, 0).toCron())
+        assertEquals("0 9 * * 1,3,5", Schedule.Weekly(setOf(Weekday.FRI, Weekday.MON, Weekday.WED), 9, 0).toCron())
+        assertEquals("0 3 15 * *", Schedule.Monthly(15, 3, 0).toCron())
+        assertEquals("*/15 9-17 * * 1-5", Schedule.Advanced("*/15 9-17 * * 1-5").toCron())
+    }
+
+    @Test fun describe_representatives() {
+        assertEquals("Every hour", Schedule.Hourly(0).describe())
+        assertEquals("Every hour at :05", Schedule.Hourly(5).describe())
+        assertEquals("Every day at 09:00", Schedule.Daily(9, 0).describe())
+        assertEquals("Mon at 02:00", Schedule.Weekly(setOf(Weekday.MON), 2, 0).describe())
+        assertEquals("Mon, Wed, Fri at 09:00", Schedule.Weekly(setOf(Weekday.FRI, Weekday.MON, Weekday.WED), 9, 0).describe())
+        assertEquals("Every day at 09:00", Schedule.Weekly(Weekday.values().toSet(), 9, 0).describe())
+        assertEquals("Day 15 of each month at 03:00", Schedule.Monthly(15, 3, 0).describe())
+        assertEquals("*/15 9-17 * * 1-5", Schedule.Advanced("*/15 9-17 * * 1-5").describe())
+    }
+
+    @Test fun nextRun_daily() {
+        // now = Mon 10:30. Daily 09:00 already passed today -> tomorrow 09:00.
+        assertEquals(at("2026-07-07T09:00:00Z"), Schedule.Daily(9, 0).nextRun(now, utc))
+        // Daily 14:00 is later today.
+        assertEquals(at("2026-07-06T14:00:00Z"), Schedule.Daily(14, 0).nextRun(now, utc))
+    }
+    @Test fun nextRun_hourly() {
+        // now = 10:30. Hourly :45 -> today 10:45.
+        assertEquals(at("2026-07-06T10:45:00Z"), Schedule.Hourly(45).nextRun(now, utc))
+        // Hourly :15 already passed this hour -> 11:15.
+        assertEquals(at("2026-07-06T11:15:00Z"), Schedule.Hourly(15).nextRun(now, utc))
+    }
+    @Test fun nextRun_weekly() {
+        // now = Mon 10:30. Weekly {WED} at 09:00 -> Wed 2026-07-08 09:00.
+        assertEquals(at("2026-07-08T09:00:00Z"), Schedule.Weekly(setOf(Weekday.WED), 9, 0).nextRun(now, utc))
+        // Weekly {MON} at 09:00 -> passed today -> next Mon.
+        assertEquals(at("2026-07-13T09:00:00Z"), Schedule.Weekly(setOf(Weekday.MON), 9, 0).nextRun(now, utc))
+    }
+    @Test fun nextRun_monthly() {
+        // now = Jul 6. Monthly day 15 09:00 -> Jul 15 this month.
+        assertEquals(at("2026-07-15T09:00:00Z"), Schedule.Monthly(15, 9, 0).nextRun(now, utc))
+        // Monthly day 3 09:00 -> passed -> Aug 3.
+        assertEquals(at("2026-08-03T09:00:00Z"), Schedule.Monthly(3, 9, 0).nextRun(now, utc))
+    }
+    @Test fun nextRun_advanced_null() {
+        assertNull(Schedule.Advanced("*/15 * * * *").nextRun(now, utc))
+    }
+
+    @Test fun parseCron_presets_and_fallback() {
+        assertEquals(Schedule.Hourly(5), parseCron("5 * * * *"))
+        assertEquals(Schedule.Daily(9, 0), parseCron("0 9 * * *"))
+        assertEquals(Schedule.Weekly(setOf(Weekday.MON), 2, 0), parseCron("0 2 * * 1"))
+        assertEquals(Schedule.Weekly(setOf(Weekday.MON, Weekday.WED, Weekday.FRI), 9, 0), parseCron("0 9 * * 1,3,5"))
+        assertEquals(Schedule.Monthly(15, 3, 0), parseCron("0 3 15 * *"))
+        assertEquals(Schedule.Advanced("*/15 9-17 * * 1-5"), parseCron("*/15 9-17 * * 1-5"))
+        assertEquals(Schedule.Advanced("garbage"), parseCron("garbage"))
+    }
+    @Test fun parseCron_roundtrips_presets() {
+        for (x in listOf("5 * * * *", "0 9 * * *", "0 2 * * 1", "0 9 * * 1,3,5", "0 3 15 * *")) {
+            assertEquals(x, parseCron(x).toCron())
+        }
+    }
+    @Test fun isValidCron_cases() {
+        assertTrue(isValidCron("0 9 * * *"))
+        assertTrue(isValidCron("*/15 9-17 * * 1-5"))
+        assertFalse(isValidCron("0 9 * *"))      // 4 fields
+        assertFalse(isValidCron("nope"))
+        assertFalse(isValidCron("0 9 * * * *"))  // 6 fields
+    }
+}

--- a/docs/superpowers/plans/2026-07-06-cron-schedule-builder.md
+++ b/docs/superpowers/plans/2026-07-06-cron-schedule-builder.md
@@ -1,0 +1,495 @@
+# Cron Schedule Builder & Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw cron text field with a friendly schedule builder, fix the edit round-trip bug, and add per-row pause/resume/run to the cron list.
+
+**Architecture:** A pure structured `Schedule` model (`toCron`/`describe`/`nextRun`/`parseCron`/`isValidCron`, unit-tested) does the work with no general cron engine; the edit VM holds a `Schedule` and seeds it from the raw expr; the edit UI is a preset builder over it; the list VM/screen gain quick actions. All over the existing cron REST.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, java.time, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** The client builds cron strings and sends them via the existing `createCron`/`updateCron` (`schedule` string) + `pauseCron`/`resumeCron`/`triggerCron`.
+- Multi-tenant isolation: new chrome tints to `LocalProfileAccent.current`, never a hardcoded colour.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `ui/cron/CronEditScreen.kt`: `CronEditState(name, schedule: String, prompt, isNew, loading, saved, message)`; `CronEditViewModel` with `setName/setSchedule/setPrompt`, `load(id)` (`id=="new"`→reset; else `tools.cronJob(id, profile)` seeding `schedule = job.scheduleText`), `save()` (`tools.createCron(prompt, schedule, name, profile)`/`updateCron(jobId, …)`, validation prompt+schedule non-blank). The `CronEditScreen(onDone, vm)` composable renders 3 `OutlinedTextField`s (schedule = raw, label "Schedule (cron, e.g. 0 9 * * *)" + caption "min hour day month weekday").
+- `data/network/Dtos.kt`: `CronJobDto.schedule: CronScheduleDto?(kind, expr, display)`; raw at `job.schedule?.expr`; `scheduleText` getter exists; `isPaused` getter exists.
+- `ui/cron/CronViewModel.kt`: `CronUiState(jobs, profile, loading, error)`; injects `tools: ToolsRepository`, `profileManager`; `load()`. `ToolsRepository.pauseCron/resumeCron/triggerCron(jobId, profile)` exist.
+- `ui/cron/CronScreen.kt`: rows are `ListItem { leadingContent=status icon; overlineContent=scheduleText; headlineContent=name; supportingContent=next-run; modifier=clickable{onOpen(job.id)} }`; a "New" FAB.
+- Patterns: `SingleChoiceSegmentedButtonRow`/`SegmentedButton` (`ui/activity/FeedTabs.kt`, `ui/settings/AppearanceScreen.kt`); `LocalProfileAccent.current.{accent,onAccent,container,onContainer}`; `com.hermes.client.ui.util.formatIso(iso: String)`.
+
+---
+
+### Task 1: Structured `Schedule` model (TDD, pure)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/cron/Schedule.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/cron/ScheduleTest.kt`
+
+**Interfaces:** Produces `Weekday`, `Schedule` (+ 5 subtypes), `Schedule.toCron()`, `Schedule.describe()`, `Schedule.nextRun(nowMs, zone)`, `parseCron(expr)`, `isValidCron(expr)`.
+
+- [ ] **Step 1: Write the failing tests** — create `ScheduleTest.kt`:
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
+
+class ScheduleTest {
+    private val utc = ZoneId.of("UTC")
+    // 2026-07-06 10:30:00 UTC (a Monday)
+    private val now = Instant.parse("2026-07-06T10:30:00Z").toEpochMilli()
+    private fun at(iso: String) = Instant.parse(iso).toEpochMilli()
+
+    @Test fun toCron_all() {
+        assertEquals("5 * * * *", Schedule.Hourly(5).toCron())
+        assertEquals("0 9 * * *", Schedule.Daily(9, 0).toCron())
+        assertEquals("0 2 * * 1", Schedule.Weekly(setOf(Weekday.MON), 2, 0).toCron())
+        assertEquals("0 9 * * 1,3,5", Schedule.Weekly(setOf(Weekday.FRI, Weekday.MON, Weekday.WED), 9, 0).toCron())
+        assertEquals("0 3 15 * *", Schedule.Monthly(15, 3, 0).toCron())
+        assertEquals("*/15 9-17 * * 1-5", Schedule.Advanced("*/15 9-17 * * 1-5").toCron())
+    }
+
+    @Test fun describe_representatives() {
+        assertEquals("Every hour", Schedule.Hourly(0).describe())
+        assertEquals("Every hour at :05", Schedule.Hourly(5).describe())
+        assertEquals("Every day at 09:00", Schedule.Daily(9, 0).describe())
+        assertEquals("Mon at 02:00", Schedule.Weekly(setOf(Weekday.MON), 2, 0).describe())
+        assertEquals("Mon, Wed, Fri at 09:00", Schedule.Weekly(setOf(Weekday.FRI, Weekday.MON, Weekday.WED), 9, 0).describe())
+        assertEquals("Every day at 09:00", Schedule.Weekly(Weekday.values().toSet(), 9, 0).describe())
+        assertEquals("Day 15 of each month at 03:00", Schedule.Monthly(15, 3, 0).describe())
+        assertEquals("*/15 9-17 * * 1-5", Schedule.Advanced("*/15 9-17 * * 1-5").describe())
+    }
+
+    @Test fun nextRun_daily() {
+        // now = Mon 10:30. Daily 09:00 already passed today -> tomorrow 09:00.
+        assertEquals(at("2026-07-07T09:00:00Z"), Schedule.Daily(9, 0).nextRun(now, utc))
+        // Daily 14:00 is later today.
+        assertEquals(at("2026-07-06T14:00:00Z"), Schedule.Daily(14, 0).nextRun(now, utc))
+    }
+    @Test fun nextRun_hourly() {
+        // now = 10:30. Hourly :45 -> today 10:45.
+        assertEquals(at("2026-07-06T10:45:00Z"), Schedule.Hourly(45).nextRun(now, utc))
+        // Hourly :15 already passed this hour -> 11:15.
+        assertEquals(at("2026-07-06T11:15:00Z"), Schedule.Hourly(15).nextRun(now, utc))
+    }
+    @Test fun nextRun_weekly() {
+        // now = Mon 10:30. Weekly {WED} at 09:00 -> Wed 2026-07-08 09:00.
+        assertEquals(at("2026-07-08T09:00:00Z"), Schedule.Weekly(setOf(Weekday.WED), 9, 0).nextRun(now, utc))
+        // Weekly {MON} at 09:00 -> passed today -> next Mon.
+        assertEquals(at("2026-07-13T09:00:00Z"), Schedule.Weekly(setOf(Weekday.MON), 9, 0).nextRun(now, utc))
+    }
+    @Test fun nextRun_monthly() {
+        // now = Jul 6. Monthly day 15 09:00 -> Jul 15 this month.
+        assertEquals(at("2026-07-15T09:00:00Z"), Schedule.Monthly(15, 9, 0).nextRun(now, utc))
+        // Monthly day 3 09:00 -> passed -> Aug 3.
+        assertEquals(at("2026-08-03T09:00:00Z"), Schedule.Monthly(3, 9, 0).nextRun(now, utc))
+    }
+    @Test fun nextRun_advanced_null() {
+        assertNull(Schedule.Advanced("*/15 * * * *").nextRun(now, utc))
+    }
+
+    @Test fun parseCron_presets_and_fallback() {
+        assertEquals(Schedule.Hourly(5), parseCron("5 * * * *"))
+        assertEquals(Schedule.Daily(9, 0), parseCron("0 9 * * *"))
+        assertEquals(Schedule.Weekly(setOf(Weekday.MON), 2, 0), parseCron("0 2 * * 1"))
+        assertEquals(Schedule.Weekly(setOf(Weekday.MON, Weekday.WED, Weekday.FRI), 9, 0), parseCron("0 9 * * 1,3,5"))
+        assertEquals(Schedule.Monthly(15, 3, 0), parseCron("0 3 15 * *"))
+        assertEquals(Schedule.Advanced("*/15 9-17 * * 1-5"), parseCron("*/15 9-17 * * 1-5"))
+        assertEquals(Schedule.Advanced("garbage"), parseCron("garbage"))
+    }
+    @Test fun parseCron_roundtrips_presets() {
+        for (x in listOf("5 * * * *", "0 9 * * *", "0 2 * * 1", "0 9 * * 1,3,5", "0 3 15 * *")) {
+            assertEquals(x, parseCron(x).toCron())
+        }
+    }
+    @Test fun isValidCron_cases() {
+        assertTrue(isValidCron("0 9 * * *"))
+        assertTrue(isValidCron("*/15 9-17 * * 1-5"))
+        assertFalse(isValidCron("0 9 * *"))      // 4 fields
+        assertFalse(isValidCron("nope"))
+        assertFalse(isValidCron("0 9 * * * *"))  // 6 fields
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ScheduleTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved references.
+
+- [ ] **Step 3: Implement `Schedule.kt`**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+enum class Weekday(val cron: Int, val short: String) {
+    SUN(0, "Sun"), MON(1, "Mon"), TUE(2, "Tue"), WED(3, "Wed"), THU(4, "Thu"), FRI(5, "Fri"), SAT(6, "Sat");
+
+    companion object {
+        fun fromCron(v: Int): Weekday? = values().firstOrNull { it.cron == v % 7 }
+    }
+}
+
+sealed interface Schedule {
+    data class Hourly(val minute: Int) : Schedule
+    data class Daily(val hour: Int, val minute: Int) : Schedule
+    data class Weekly(val days: Set<Weekday>, val hour: Int, val minute: Int) : Schedule
+    data class Monthly(val dayOfMonth: Int, val hour: Int, val minute: Int) : Schedule
+    data class Advanced(val expr: String) : Schedule
+}
+
+fun Schedule.toCron(): String = when (this) {
+    is Schedule.Hourly -> "$minute * * * *"
+    is Schedule.Daily -> "$minute $hour * * *"
+    is Schedule.Weekly -> "$minute $hour * * ${days.sortedBy { it.cron }.joinToString(",") { it.cron.toString() }}"
+    is Schedule.Monthly -> "$minute $hour $dayOfMonth * *"
+    is Schedule.Advanced -> expr
+}
+
+private fun hm(h: Int, m: Int) = "%02d:%02d".format(h, m)
+
+fun Schedule.describe(): String = when (this) {
+    is Schedule.Hourly -> if (minute == 0) "Every hour" else "Every hour at :%02d".format(minute)
+    is Schedule.Daily -> "Every day at ${hm(hour, minute)}"
+    is Schedule.Weekly ->
+        if (days.size == 7) "Every day at ${hm(hour, minute)}"
+        else "${days.sortedBy { it.cron }.joinToString(", ") { it.short }} at ${hm(hour, minute)}"
+    is Schedule.Monthly -> "Day $dayOfMonth of each month at ${hm(hour, minute)}"
+    is Schedule.Advanced -> expr
+}
+
+fun Schedule.nextRun(nowMs: Long, zone: ZoneId = ZoneId.systemDefault()): Long? {
+    val now = Instant.ofEpochMilli(nowMs).atZone(zone).toLocalDateTime()
+    fun ms(dt: LocalDateTime) = dt.atZone(zone).toInstant().toEpochMilli()
+    return when (this) {
+        is Schedule.Hourly -> {
+            var c = now.withMinute(minute).withSecond(0).withNano(0)
+            if (!c.isAfter(now)) c = c.plusHours(1)
+            ms(c)
+        }
+        is Schedule.Daily -> {
+            var c = now.toLocalDate().atTime(hour, minute)
+            if (!c.isAfter(now)) c = c.plusDays(1)
+            ms(c)
+        }
+        is Schedule.Weekly -> {
+            if (days.isEmpty()) return null
+            val wanted = days.map { it.cron }.toSet() // 0=Sun..6=Sat
+            var c = now.toLocalDate().atTime(hour, minute)
+            repeat(8) {
+                val dow = c.dayOfWeek.value % 7 // java: Mon=1..Sun=7 -> 0=Sun..6=Sat
+                if (dow in wanted && c.isAfter(now)) return ms(c)
+                c = c.plusDays(1).toLocalDate().atTime(hour, minute)
+            }
+            null
+        }
+        is Schedule.Monthly -> {
+            var date = now.toLocalDate()
+            repeat(13) {
+                if (dayOfMonth <= date.lengthOfMonth()) {
+                    val c = date.withDayOfMonth(dayOfMonth).atTime(hour, minute)
+                    if (c.isAfter(now)) return ms(c)
+                }
+                date = date.plusMonths(1).withDayOfMonth(1)
+            }
+            null
+        }
+        is Schedule.Advanced -> null
+    }
+}
+
+private fun String.toIntOrStar(): Int? = toIntOrNull()
+
+fun parseCron(expr: String): Schedule {
+    val f = expr.trim().split(Regex("\\s+"))
+    if (f.size != 5) return Schedule.Advanced(expr.trim())
+    val (minS, hourS, domS, monS, dowS) = f
+    val min = minS.toIntOrStar()
+    val hour = hourS.toIntOrStar()
+    val dom = domS.toIntOrStar()
+    val star = { s: String -> s == "*" }
+    return when {
+        min != null && star(hourS) && star(domS) && star(monS) && star(dowS) -> Schedule.Hourly(min)
+        min != null && hour != null && star(domS) && star(monS) && star(dowS) -> Schedule.Daily(hour, min)
+        min != null && hour != null && star(domS) && star(monS) && dowIsList(dowS) ->
+            Schedule.Weekly(dowS.split(",").mapNotNull { Weekday.fromCron(it.toInt()) }.toSet(), hour, min)
+        min != null && hour != null && dom != null && star(monS) && star(dowS) -> Schedule.Monthly(dom, hour, min)
+        else -> Schedule.Advanced(expr.trim())
+    }
+}
+
+private fun dowIsList(s: String): Boolean =
+    s != "*" && s.split(",").all { it.toIntOrNull()?.let { n -> n in 0..7 } == true }
+
+fun isValidCron(expr: String): Boolean {
+    val f = expr.trim().split(Regex("\\s+"))
+    if (f.size != 5) return false
+    val token = Regex("^(\\*|(\\d+([-/,]\\d+)*))$")
+    return f.all { token.matches(it) }
+}
+```
+(Note: `parseCron`'s destructuring of a 5-element list uses `component1..5`; if the linter dislikes it, index `f[0]..f[4]`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*ScheduleTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS (all cases). Fix any off-by-one in `nextRun`/`describe` until green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/Schedule.kt app/src/test/java/com/hermes/client/ui/cron/ScheduleTest.kt
+git commit -m "feat(cron): structured Schedule model (toCron/describe/nextRun/parseCron/isValidCron)"
+```
+
+---
+
+### Task 2: `CronEditViewModel` — structured state + round-trip fix
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt`
+
+**Interfaces:** Consumes `Schedule`, `parseCron`, `Schedule.toCron`, `isValidCron` (Task 1). Produces `CronEditState.schedule: Schedule`, `setSchedule(Schedule)`.
+
+- [ ] **Step 1: Change the state + VM**
+
+In `CronEditState`, replace `val schedule: String = ""` with `val schedule: Schedule = Schedule.Daily(9, 0)`. In `CronEditViewModel`:
+- replace `fun setSchedule(v: String)` with `fun setSchedule(v: Schedule) { _state.value = _state.value.copy(schedule = v) }`.
+- `load(id)` edit branch: where it currently sets `schedule = job.scheduleText`, use `schedule = parseCron(job.schedule?.expr ?: job.scheduleText)`.
+- `save()`: replace the blank-schedule check + the `createCron/updateCron(... s.schedule ...)` calls:
+```kotlin
+    fun save() = viewModelScope.launch {
+        val s = _state.value
+        val advancedInvalid = s.schedule is Schedule.Advanced && !isValidCron((s.schedule as Schedule.Advanced).expr)
+        if (s.prompt.isBlank() || advancedInvalid) {
+            _state.value = s.copy(message = if (s.prompt.isBlank()) "Prompt is required" else "Schedule is not a valid cron expression")
+            return@launch
+        }
+        val cron = s.schedule.toCron()
+        runCatching {
+            if (s.isNew) tools.createCron(s.prompt, cron, s.name, profile)
+            else tools.updateCron(jobId, s.prompt, cron, s.name, profile)
+        }.onSuccess { _state.value = s.copy(saved = true) }
+            .onFailure { _state.value = s.copy(message = "Save failed: ${it.message}") }
+    }
+```
+
+- [ ] **Step 2: Compile (UI still references old `schedule` string — Task 3 fixes the composable; keep this task VM-only by leaving the composable temporarily consuming `.describe()`)**
+
+To keep this task independently compilable, in the `CronEditScreen` composable temporarily bind the existing schedule `OutlinedTextField` to `state.schedule.describe()` (read-only) — Task 3 replaces it with the builder. Concretely, change the schedule field's `value =` to `state.schedule.describe()` and its `onValueChange = {}` (no-op) so it compiles; Task 3 removes it.
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+git commit -m "fix(cron): edit seeds schedule from raw expr (structured Schedule state); no round-trip corruption"
+```
+
+---
+
+### Task 3: Schedule builder UI (`CronEditScreen`)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt`
+
+**Interfaces:** Consumes `state.schedule`/`vm.setSchedule` (Task 2), `Schedule.describe/nextRun/toCron`, `isValidCron` (Task 1).
+
+- [ ] **Step 1: Replace the schedule field with a builder**
+
+Remove the temporary schedule `OutlinedTextField` (from Task 2 Step 2) and its caption. Insert a `ScheduleBuilder(schedule = state.schedule, onChange = vm::setSchedule, nowMs = System.currentTimeMillis())` composable (define it private in this file):
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScheduleBuilder(schedule: Schedule, onChange: (Schedule) -> Unit, nowMs: Long) {
+    val accent = com.hermes.client.ui.theme.LocalProfileAccent.current
+    val kinds = listOf("Hourly", "Daily", "Weekly", "Monthly", "Advanced")
+    val current = when (schedule) {
+        is Schedule.Hourly -> 0; is Schedule.Daily -> 1; is Schedule.Weekly -> 2
+        is Schedule.Monthly -> 3; is Schedule.Advanced -> 4
+    }
+    // time carried across kind switches
+    val (h, m) = when (schedule) {
+        is Schedule.Daily -> schedule.hour to schedule.minute
+        is Schedule.Weekly -> schedule.hour to schedule.minute
+        is Schedule.Monthly -> schedule.hour to schedule.minute
+        is Schedule.Hourly -> 9 to schedule.minute
+        is Schedule.Advanced -> 9 to 0
+    }
+    Column(Modifier.fillMaxWidth()) {
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            kinds.forEachIndexed { i, label ->
+                SegmentedButton(
+                    selected = current == i,
+                    onClick = {
+                        onChange(when (i) {
+                            0 -> Schedule.Hourly(m.coerceIn(0, 59))
+                            1 -> Schedule.Daily(h, m)
+                            2 -> Schedule.Weekly(setOf(Weekday.MON), h, m)
+                            3 -> Schedule.Monthly(1, h, m)
+                            else -> Schedule.Advanced(schedule.toCron())
+                        })
+                    },
+                    shape = SegmentedButtonDefaults.itemShape(i, kinds.size),
+                    colors = SegmentedButtonDefaults.colors(activeContainerColor = accent.accent, activeContentColor = accent.onAccent),
+                ) { Text(label, maxLines = 1) }
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        when (schedule) {
+            is Schedule.Hourly -> MinutePicker(schedule.minute) { onChange(schedule.copy(minute = it)) }
+            is Schedule.Daily -> TimeRow(schedule.hour, schedule.minute) { hh, mm -> onChange(schedule.copy(hour = hh, minute = mm)) }
+            is Schedule.Weekly -> {
+                WeekdayChips(schedule.days) { onChange(schedule.copy(days = it)) }
+                Spacer(Modifier.height(8.dp))
+                TimeRow(schedule.hour, schedule.minute) { hh, mm -> onChange(schedule.copy(hour = hh, minute = mm)) }
+            }
+            is Schedule.Monthly -> {
+                DayOfMonthPicker(schedule.dayOfMonth) { onChange(schedule.copy(dayOfMonth = it)) }
+                Spacer(Modifier.height(8.dp))
+                TimeRow(schedule.hour, schedule.minute) { hh, mm -> onChange(schedule.copy(hour = hh, minute = mm)) }
+            }
+            is Schedule.Advanced -> {
+                val valid = isValidCron(schedule.expr)
+                OutlinedTextField(
+                    schedule.expr, { onChange(Schedule.Advanced(it)) },
+                    label = { Text("Schedule (cron, e.g. 0 9 * * *)") }, singleLine = true,
+                    isError = schedule.expr.isNotBlank() && !valid, modifier = Modifier.fillMaxWidth(),
+                )
+                Text(
+                    if (schedule.expr.isNotBlank() && !valid) "Not a valid 5-field cron expression" else "min hour day month weekday",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (schedule.expr.isNotBlank() && !valid) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        val next = schedule.nextRun(nowMs)?.let { epochMs ->
+            " · Next: " + com.hermes.client.ui.util.formatIso(java.time.Instant.ofEpochMilli(epochMs).toString())
+        }.orEmpty()
+        Text(schedule.describe() + next, style = MaterialTheme.typography.bodyMedium, color = accent.accent)
+    }
+}
+```
+Add the helper composables in the same file: `MinutePicker(minute, onPick)` and `DayOfMonthPicker(day, onPick)` as `ExposedDropdownMenuBox`/`DropdownMenu`s (0–59 / 1–28); `WeekdayChips(days, onChange)` as a `FlowRow`/`Row` of `FilterChip`s (enforce ≥1 — ignore a tap that would empty the set); `TimeRow(hour, minute, onPick)` as a clickable "At HH:MM" `OutlinedButton` opening a Material3 `TimePicker` in an `AlertDialog` (`rememberTimePickerState(hour, minute, is24Hour = true)`, apply on confirm). Keep imports tidy.
+
+- [ ] **Step 2: Guard Save on invalid Advanced**
+
+Where the `Button(onClick = { vm.save() }) { Text(if (state.isNew) "Create" else "Save") }` is, set `enabled = state.prompt.isNotBlank() && (state.schedule !is Schedule.Advanced || isValidCron((state.schedule as Schedule.Advanced).expr))`.
+
+- [ ] **Step 3: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head` → `BUILD SUCCESSFUL`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2` → `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+git commit -m "feat(cron): friendly schedule builder (presets + pickers + live summary/next-run + advanced)"
+```
+
+---
+
+### Task 4: List row quick actions (`CronViewModel` + `CronScreen`)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronViewModel.kt`, `app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt`
+
+- [ ] **Step 1: Add actions to `CronViewModel`**
+
+Add `enum class CronAction { PAUSE, RESUME, RUN }`, a `message: String? = null` field to `CronUiState`, `fun clearMessage()`, and:
+```kotlin
+    fun runAction(jobId: String, name: String, action: CronAction) = viewModelScope.launch {
+        val p = _state.value.profile
+        val ok = runCatching {
+            when (action) {
+                CronAction.PAUSE -> tools.pauseCron(jobId, p)
+                CronAction.RESUME -> tools.resumeCron(jobId, p)
+                CronAction.RUN -> tools.triggerCron(jobId, p)
+            }
+        }.isSuccess
+        val verb = when (action) { CronAction.PAUSE -> "Paused"; CronAction.RESUME -> "Resumed"; CronAction.RUN -> "Triggered" }
+        _state.value = _state.value.copy(message = if (ok) "$verb $name" else "Couldn't $verb.lowercase() $name")
+        if (ok) load()
+    }
+    fun clearMessage() { _state.value = _state.value.copy(message = null) }
+```
+
+- [ ] **Step 2: Row overflow menu in `CronScreen`**
+
+Add a `trailingContent` to the row `ListItem`: an `IconButton(onClick = { menuFor = job.id })` with `Icon(Icons.Rounded.MoreVert, contentDescription = "Actions")`, and a `DropdownMenu(expanded = menuFor == job.id, onDismissRequest = { menuFor = null })` with items:
+- `DropdownMenuItem(text = { Text(if (job.isPaused) "Resume" else "Pause") }, onClick = { vm.runAction(job.id, job.name ?: job.id, if (job.isPaused) CronAction.RESUME else CronAction.PAUSE); menuFor = null })`
+- `DropdownMenuItem(text = { Text("Run now") }, onClick = { vm.runAction(job.id, job.name ?: job.id, CronAction.RUN); menuFor = null })`
+
+Hoist `var menuFor by remember { mutableStateOf<String?>(null) }` in the list scope. Show the toast: `val context = LocalContext.current; LaunchedEffect(state.message) { state.message?.let { Toast.makeText(context, it, Toast.LENGTH_SHORT).show(); vm.clearMessage() } }`. Row `clickable { onOpen(job.id) }` stays.
+
+- [ ] **Step 3: Compile + suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronViewModel.kt app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+git commit -m "feat(cron): per-row pause/resume/run overflow menu on the list"
+```
+
+---
+
+### Task 5: Mock endpoints + on-device verification
+
+**Files:** Modify `$CLAUDE_JOB_DIR/tmp/mockgw.py` (test harness only — not committed to the repo).
+
+- [ ] **Step 1: Add the missing cron endpoints to the mock**
+
+In `$CLAUDE_JOB_DIR/tmp/mockgw.py`, add handlers so the edit/create/actions flow works against the mock:
+- `GET /api/cron/jobs/<id>` → return a single job JSON with a nested `"schedule": {"kind": "cron", "expr": "0 9 * * *", "display": "Every day at 09:00"}`, plus `id`, `name`, `prompt`, `next_run_at`, `last_status`, `enabled`.
+- `POST /api/cron/jobs` and `PUT /api/cron/jobs/<id>` → accept the JSON body, return `200` with the created/updated job echoed (include a `schedule.expr` echoing the posted `"schedule"` string).
+- `POST /api/cron/jobs/<id>/{pause,resume,trigger}` → return `200 {}`.
+Restart the mock.
+
+- [ ] **Step 2: Build, install, verify**
+
+`./gradlew :app:assembleBeta`; `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`; connect to `http://10.0.2.2:8899`.
+1. **New cron** (Cron → New FAB): the builder defaults to **Daily 09:00** with a live "Every day at 09:00 · Next: …" summary; switching to Hourly/Weekly/Monthly swaps the controls and updates the summary; Advanced shows the raw field and flags an invalid expression (Save disabled).
+2. **Create** a Daily 08:30 job → it appears in the list overline as "Every day at 08:30".
+3. **Edit** the seeded job (expr `0 9 * * *`) → the builder opens on **Daily 09:00** (not a raw string); changing only the prompt and saving keeps the schedule (round-trip holds).
+4. **List row overflow** (⋮) → **Pause/Resume** and **Run now** show a toast and the row updates — no detail screen needed.
+5. Everything tenant-accent tinted (green acme).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed in app code)**
+
+```bash
+git add -A
+git commit -m "chore(cron): schedule-builder verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Element 1 (Schedule model) → Task 1 (+ full tests) ✓; Element 2 (builder UI) → Task 3 ✓; Element 3 (round-trip fix + structured state) → Task 2 ✓; Element 4 (list quick actions) → Task 4 ✓; on-device (needs mock endpoints) → Task 5 ✓. Deferred items (detail legibility, auto-name, empty-state templates) intentionally have no task, per the spec.
+- **Placeholder scan:** Task 1 has complete code + tests; Tasks 2–4 give concrete code for the VM logic and the builder skeleton (the helper composables `MinutePicker`/`DayOfMonthPicker`/`WeekdayChips`/`TimeRow` are described with their exact controls). No TBD/TODO. The only conditional commit is Task 5 Step 3.
+- **Type consistency:** `Schedule`(+subtypes), `Weekday`, `toCron`/`describe`/`nextRun(nowMs, zone)`/`parseCron`/`isValidCron` (Task 1) are used with the same signatures in Tasks 2–3; `CronEditState.schedule: Schedule` + `setSchedule(Schedule)` (Task 2) consumed by Task 3; `CronAction`/`runAction(jobId, name, action)`/`clearMessage` (Task 4) match between VM and screen. `com.hermes.client.ui.util.formatIso` takes an ISO string.
+
+**Ordering:** Task 1 (pure) first. Task 2 (VM state) consumes Task 1 and keeps the file compilable via a temporary read-only field. Task 3 (builder UI) replaces that field and consumes Tasks 1–2. Task 4 is independent (`CronViewModel`/`CronScreen`). Task 5 verifies (mock + device). `CronEditScreen.kt` is touched by Tasks 2 → 3 in order.

--- a/docs/superpowers/specs/2026-07-06-cron-schedule-builder-design.md
+++ b/docs/superpowers/specs/2026-07-06-cron-schedule-builder-design.md
@@ -1,0 +1,97 @@
+# Cron Schedule Builder & Management — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/cron-schedule-builder`
+**Source:** user ask ("cron should be easier to set up and manage; editing the schedule is very technical") + a UX-specialist review of the cron flow.
+
+## Goal
+
+Make cron **setup** easy (a friendly schedule builder replacing the raw cron field), fix a **genuine bug** (edit re-sends the display string as the cron expression), and make **management** faster (per-row pause/resume/run on the list). Compose-only, **no new gateway endpoints** — the builder emits a standard 5-field cron string into the existing `createCron`/`updateCron` write path.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Reuse existing cron REST (`createCron`/`updateCron` send a flat `"schedule"` string; `pauseCron`/`resumeCron`/`triggerCron`/`cronJob`). Material 3.
+- Multi-tenant isolation: all new chrome tints to `LocalProfileAccent.current` (per-tenant accent).
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Grounding (from exploration)
+
+- **Create/Edit form** (`ui/cron/CronEditScreen.kt` — holds `CronEditViewModel` + `CronEditScreen`): 3 fields (Name, **Schedule** = raw single-line `OutlinedTextField` "Schedule (cron, e.g. 0 9 * * *)", Prompt). `CronEditState(name, schedule: String, prompt, isNew, …)`. `load(id)`: `id=="new"`→reset; else `tools.cronJob(id, profile)` and seeds **`schedule = job.scheduleText`** (the display string — the bug). `save()`: `tools.createCron(prompt, schedule, name, profile)` / `updateCron(jobId, …)`; validation = prompt+schedule non-blank.
+- **DTO** (`data/network/Dtos.kt`): `CronJobDto.schedule: CronScheduleDto?(kind, expr, display)` — raw expr at **`schedule.expr`**; `scheduleText` getter = `scheduleDisplay ?: schedule.display ?: schedule.expr ?: "—"`. Write path sends a flat `"schedule"` string. Cron is standard 5-field `m h dom mon dow`.
+- **List** (`ui/cron/CronScreen.kt` + `CronViewModel`): rows = status icon + `scheduleText` overline + name + next-run; row tap → `cron_detail/$id`; **no per-row actions**. `CronViewModel` has `tools`, `profileManager`, `load()` (no pause/resume/trigger). Detail's VM already has `pause()/resume()/trigger()` via `tools`.
+- No blueprints endpoint; no delivery-targets field (both out of scope — don't invent them).
+
+## Element 1 — Structured `Schedule` model (pure, unit-tested) — the core
+
+New `ui/cron/Schedule.kt`. A structured model that builds/describes/previews **without a general cron engine**; only `parseCron` pattern-matches.
+
+```kotlin
+enum class Weekday(val cron: Int, val short: String) {
+    SUN(0, "Sun"), MON(1, "Mon"), TUE(2, "Tue"), WED(3, "Wed"), THU(4, "Thu"), FRI(5, "Fri"), SAT(6, "Sat")
+}
+
+sealed interface Schedule {
+    data class Hourly(val minute: Int) : Schedule
+    data class Daily(val hour: Int, val minute: Int) : Schedule
+    data class Weekly(val days: Set<Weekday>, val hour: Int, val minute: Int) : Schedule
+    data class Monthly(val dayOfMonth: Int, val hour: Int, val minute: Int) : Schedule
+    data class Advanced(val expr: String) : Schedule
+}
+```
+- **`fun Schedule.toCron(): String`** — the 5-field expr:
+  - `Hourly(m)` → `"$m * * * *"`; `Daily(h,m)` → `"$m $h * * *"`; `Weekly(days,h,m)` → `"$m $h * * ${days.sortedBy{it.cron}.joinToString(","){it.cron.toString()}}"`; `Monthly(dom,h,m)` → `"$m $h $dom * *"`; `Advanced(e)` → `e`.
+- **`fun Schedule.describe(): String`** — human summary:
+  - `Hourly(0)` → "Every hour"; `Hourly(m)` → "Every hour at :%02d".format(m); `Daily(h,m)` → "Every day at %02d:%02d"; `Weekly(days,h,m)` → "%s at %02d:%02d".format(days.sortedBy{it.cron}.joinToString(", "){it.short}, …) (all 7 days → "Every day at HH:MM"); `Monthly(dom,h,m)` → "Day $dom of each month at %02d:%02d"; `Advanced(e)` → e.
+- **`fun Schedule.nextRun(nowMs: Long, zone: ZoneId = systemDefault()): Long?`** — next occurrence via `java.time` from the structured state (Advanced → `null`):
+  - `Daily(h,m)` → today at h:m if strictly after now, else +1 day. `Hourly(m)` → this hour at :m if after now, else +1 hour. `Weekly` → the soonest of the selected weekdays at h:m that is after now. `Monthly(dom,h,m)` → this month's dom at h:m if after now (and dom ≤ month length), else the next month that has that day. Return epoch millis.
+- **`fun parseCron(expr: String): Schedule`** — split into 5 whitespace fields `[min hour dom mon dow]`; match (all numeric fields must be plain integers, `*` literal):
+  - `min=int, hour=*, dom=*, mon=*, dow=*` → `Hourly(min)`; `min,hour=int, dom=*, mon=*, dow=*` → `Daily(hour,min)`; `min,hour=int, dom=*, mon=*, dow=<comma-list of ints>` → `Weekly(days,hour,min)`; `min,hour,dom=int, mon=*, dow=*` → `Monthly(dom,hour,min)`; anything else (ranges, steps, lists in other fields, wrong field count) → `Advanced(expr.trim())`.
+- **`fun isValidCron(expr: String): Boolean`** — exactly 5 whitespace-separated fields, each matching a basic cron token `^(\*|(\d+([-/,]\d+)*))$` (lenient; guards the Advanced field).
+
+## Element 2 — Schedule builder UI (`CronEditScreen`)
+
+Replace the raw schedule `OutlinedTextField` with a builder driven by `state.schedule: Schedule`:
+- **Preset segmented control** (`SingleChoiceSegmentedButtonRow`, accent-tinted like `FeedTabs`): **Hourly · Daily · Weekly · Monthly · Advanced**. Selecting a preset sets `state.schedule` to a sensible default of that kind (Hourly→`Hourly(0)`, Daily→`Daily(9,0)`, Weekly→`Weekly({MON},9,0)`, Monthly→`Monthly(1,9,0)`, Advanced→`Advanced(currentToCron)`), preserving the current time where sensible.
+- **Per-kind controls:**
+  - time (Daily/Weekly/Monthly): an "At HH:MM" row opening a Material3 `TimePicker` dialog (24h). Hourly: a "minute" stepper/dropdown (0–59) shown as ":MM".
+  - Weekly: a row of day `FilterChip`s (Sun…Sat), multi-select (≥1 enforced).
+  - Monthly: a day-of-month dropdown (1–28, plus a note that 29–31 may skip short months — cap the picker at 28 for safety, or 1–31 with a helper caption; **use 1–28** to avoid skipped months).
+  - Advanced: the existing raw `OutlinedTextField` + "min hour day month weekday" caption, with **inline validation** via `isValidCron` (error text + Save disabled when invalid).
+- **Live summary + next-run:** a `Text` under the controls = `state.schedule.describe()` + `state.schedule.nextRun(now)?.let { " · Next: " + formatIso(epochToIso(it)) }` (Advanced → summary only, no next-run). Accent-tinted label.
+- **Save:** unchanged flow, but sends `state.schedule.toCron()` as the schedule string.
+
+## Element 3 — Round-trip fix + structured state (`CronEditViewModel`)
+
+- `CronEditState.schedule` becomes `Schedule` (default `Daily(9, 0)` for new). Setter `setSchedule(Schedule)`.
+- **`load(id)`** (edit path): seed from the **raw expr** — `val expr = job.schedule?.expr ?: job.scheduleText; state.schedule = parseCron(expr)`. Never seed from the display string. (If the server only supplied a display string with no `expr`, `parseCron` falls back to `Advanced`, surfacing it in the raw field — no worse than today, and visible.)
+- **`save()`**: `val schedule = state.schedule.toCron()`; keep the existing `createCron`/`updateCron` calls with that string; validation = prompt non-blank AND (schedule is a preset OR `isValidCron(advancedExpr)`).
+- **Round-trip guarantee:** `parseCron("0 9 * * *")` → `Daily(9,0)` → `toCron()` → `"0 9 * * *"` — editing a job's prompt no longer mutates its schedule.
+
+## Element 4 — List row quick actions (`CronViewModel` + `CronScreen`)
+
+- **`CronViewModel`**: add `fun runAction(jobId: String, action: CronAction)` where `CronAction { PAUSE, RESUME, RUN }` → `runCatching { when(action){ PAUSE->tools.pauseCron(jobId,p); RESUME->tools.resumeCron(jobId,p); RUN->tools.triggerCron(jobId,p) } }` then `load()` (reload) on success; expose a one-shot result for a toast (reuse the `message: String?` + snackbar pattern, or a Toast from the screen).
+- **`CronScreen` row**: add a `trailingContent` overflow `IconButton(Icons.Rounded.MoreVert)` → `DropdownMenu` with **Pause**/**Resume** (by `job.isPaused`) and **Run now**, each calling `vm.runAction(job.id, …)` + a Toast ("Paused"/"Resumed"/"Triggered <name>"). Row tap still → detail. No Edit/Delete on the row (those stay on detail).
+
+## Testing
+
+- **Unit (pure), TDD — `ScheduleTest`:**
+  - `toCron`: each of Hourly/Daily/Weekly/Monthly/Advanced → exact expr.
+  - `describe`: representative strings (Hourly :00 vs :05, Daily, Weekly one-day vs multi vs all-7, Monthly, Advanced passthrough).
+  - `nextRun` (fixed `now` + fixed `ZoneId`): Daily before/after time (today vs tomorrow); Hourly; Weekly (soonest selected day); Monthly (this month vs next); Advanced → null.
+  - `parseCron`: `"0 9 * * *"`→Daily(9,0); `"5 * * * *"`→Hourly(5); `"0 2 * * 1"`→Weekly({MON},2,0); `"0 2 * * 1,3,5"`→Weekly({MON,WED,FRI},2,0); `"0 3 15 * *"`→Monthly(15,3,0); `"*/15 9-17 * * 1-5"`→Advanced (unchanged); round-trip `parseCron(x).toCron() == x` for the preset cases.
+  - `isValidCron`: valid 5-field / step / list vs too few fields / garbage.
+- **On-device** (mock needs `GET /api/cron/jobs/{id}` + accept `POST`/`PUT /api/cron/jobs` — add to the mock for verification):
+  1. New cron → builder defaults to Daily 09:00; switching presets updates controls + the live "Every … · Next: …" summary; Advanced shows the raw field with validation.
+  2. Create a Daily 08:30 job → it appears in the list as "Every day at 08:30".
+  3. Edit an existing job (e.g. "0 9 * * *") → the builder opens on **Daily 09:00** (not a raw string); changing only the prompt and saving keeps the schedule "Every day at 09:00" (round-trip holds).
+  4. On the list, a row's overflow menu → Pause/Resume + Run now work (toast + the row's status updates), without opening detail.
+  5. Everything tenant-accent tinted (green acme / gold globex).
+
+## Not doing (YAGNI / deferred)
+
+- **Deferred (P1/P2, follow-up):** expandable full error + grouped status on the detail screen; auto-name-from-prompt when Name is blank; empty-state quick-start templates.
+- Interval presets ("every N hours/minutes") — Advanced covers them.
+- Day-of-month 29–31 (capped at 28 to avoid skipped-month surprises).
+- Any delivery-targets or blueprints UI (no such data/endpoint exists).
+- Any gateway/API change.


### PR DESCRIPTION
## Promote develop → main (production 0.1.38)

Promotes the cron schedule builder to production. main was last at 0.1.37 (#66).

### What ships to production (0.1.38)
Compose-only, no new gateway endpoints (client builds cron strings; reuses create/update/pause/resume/trigger):
1. **Friendly schedule builder** — preset control (Hourly/Daily/Weekly/Monthly + Advanced) with pickers + a live local-zone next-run preview, replacing the raw cron text field. Backed by a pure, 10-test `Schedule` model.
2. **Round-trip bug fix** — editing a job (even just the prompt) no longer corrupts its schedule (seeds from raw expr, `toCron()` round-trips exactly).
3. **List row quick actions** — per-row Pause/Resume/Run-now overflow menu.

Built via spec → plan → subagent-driven development with per-task + an opus final whole-branch review; on-device verified (builder, round-trip, list actions, tenant accent). No bridge/gateway API changes.
