### PR TITLE
Promote to production: 0.1.39 (cron follow-ups)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 39
-        versionName = "0.1.38"
+        versionCode = 40
+        versionName = "0.1.39"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -1,11 +1,13 @@
 package com.hermes.client.ui.cron
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -17,6 +19,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -29,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -86,19 +90,31 @@ fun CronDetailScreen(
                     item {
                         Column(Modifier.padding(16.dp)) {
                             Field("Schedule", job.scheduleText)
-                            Field("Status", if (job.isPaused) "Paused" else if (job.enabled) "Enabled" else "Disabled")
-                            Field("Next run", formatIso(job.nextRunAt))
-                            Field("Last run", formatIso(job.lastRunAt) +
-                                (job.lastStatus?.let { " · $it" } ?: ""))
-                            job.lastError?.takeIf { it.isNotBlank() }?.let {
-                                Spacer(Modifier.width(4.dp))
-                                Text(
-                                    it,
-                                    color = MaterialTheme.colorScheme.error,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    maxLines = 3,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
+                            Spacer(Modifier.height(8.dp))
+                            Surface(shape = MaterialTheme.shapes.medium, color = MaterialTheme.colorScheme.surfaceVariant) {
+                                Column(Modifier.padding(12.dp)) {
+                                    Field("Status", if (job.isPaused) "Paused" else if (job.enabled) "Enabled" else "Disabled")
+                                    Field("Next run", formatIso(job.nextRunAt))
+                                    Field("Last run", formatIso(job.lastRunAt) + (job.lastStatus?.let { " · $it" } ?: ""))
+                                    job.lastError?.takeIf { it.isNotBlank() }?.let { err ->
+                                        var errorExpanded by rememberSaveable { mutableStateOf(false) }
+                                        Spacer(Modifier.height(6.dp))
+                                        Text(
+                                            err,
+                                            color = MaterialTheme.colorScheme.error,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            maxLines = if (errorExpanded) Int.MAX_VALUE else 3,
+                                            overflow = TextOverflow.Ellipsis,
+                                            modifier = Modifier.clickable { errorExpanded = !errorExpanded },
+                                        )
+                                        Text(
+                                            if (errorExpanded) "Show less" else "Show more",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = LocalProfileAccent.current.accent,
+                                            modifier = Modifier.clickable { errorExpanded = !errorExpanded }.padding(top = 2.dp),
+                                        )
+                                    }
+                                }
                             }
                             Spacer(Modifier.padding(top = 12.dp))
                             Row {

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -64,7 +64,7 @@ fun CronDetailScreen(
     Scaffold(
         topBar = {
             com.hermes.client.ui.components.HermesTopBar(
-                title = state.job?.name ?: "Cron job",
+                title = state.job?.let { cronDisplayName(it.name, it.prompt, it.id) } ?: "Cron job",
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         androidx.compose.material3.Icon(

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -97,7 +97,7 @@ fun CronDetailScreen(
                                     Field("Next run", formatIso(job.nextRunAt))
                                     Field("Last run", formatIso(job.lastRunAt) + (job.lastStatus?.let { " · $it" } ?: ""))
                                     job.lastError?.takeIf { it.isNotBlank() }?.let { err ->
-                                        var errorExpanded by rememberSaveable { mutableStateOf(false) }
+                                        var errorExpanded by rememberSaveable(err) { mutableStateOf(false) }
                                         Spacer(Modifier.height(6.dp))
                                         Text(
                                             err,
@@ -111,7 +111,7 @@ fun CronDetailScreen(
                                             if (errorExpanded) "Show less" else "Show more",
                                             style = MaterialTheme.typography.labelSmall,
                                             color = LocalProfileAccent.current.accent,
-                                            modifier = Modifier.clickable { errorExpanded = !errorExpanded }.padding(top = 2.dp),
+                                            modifier = Modifier.padding(top = 2.dp).clickable { errorExpanded = !errorExpanded },
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDisplay.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDisplay.kt
@@ -1,0 +1,10 @@
+package com.hermes.client.ui.cron
+
+/** List/display name for a cron job: its name, else a one-line prompt snippet, else its id. */
+fun cronDisplayName(name: String?, prompt: String?, id: String, maxLen: Int = 40): String {
+    name?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+    prompt?.replace("\n", " ")?.trim()?.takeIf { it.isNotEmpty() }?.let {
+        return if (it.length <= maxLen) it else it.take(maxLen).trimEnd() + "…"
+    }
+    return id
+}

--- a/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
@@ -79,7 +79,15 @@ class CronEditViewModel @Inject constructor(
 
     fun load(id: String) {
         jobId = id
-        if (id == "new") { _state.value = CronEditState(isNew = true); return }
+        val template = cronTemplate(id)
+        if (id == "new" || template != null) {
+            _state.value = if (template != null) {
+                CronEditState(schedule = template.schedule, prompt = template.prompt, isNew = true)
+            } else {
+                CronEditState(isNew = true)
+            }
+            return
+        }
         _state.value = _state.value.copy(loading = true, isNew = false)
         viewModelScope.launch {
             runCatching { tools.cronJob(id, profile) }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -121,7 +121,12 @@ fun CronScreen(
                                 headlineContent = { Text(cronDisplayName(job.name, job.prompt, job.id)) },
                                 supportingContent = {
                                     val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
-                                    Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())
+                                    // Prompt snippet is only useful here when the headline is the name; when the job is
+                                    // unnamed the headline already shows the prompt (via cronDisplayName), so don't repeat it.
+                                    val fallback = job.name?.takeIf { it.isNotBlank() }?.let {
+                                        job.prompt?.replace("\n", " ")?.trim()?.take(100)
+                                    }
+                                    Text(next ?: fallback.orEmpty())
                                 },
                                 trailingContent = {
                                     Box {

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -111,7 +111,7 @@ fun CronScreen(
                                         else MaterialTheme.colorScheme.error,
                                     )
                                 },
-                                headlineContent = { Text(job.name ?: job.id) },
+                                headlineContent = { Text(cronDisplayName(job.name, job.prompt, job.id)) },
                                 supportingContent = {
                                     val next = job.nextRunAt?.let { "Next: " + com.hermes.client.ui.util.formatIso(it) }
                                     Text(next ?: job.prompt?.replace("\n", " ")?.trim()?.take(100).orEmpty())

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -2,9 +2,15 @@ package com.hermes.client.ui.cron
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -13,6 +19,8 @@ import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.PauseCircleOutline
 import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -21,6 +29,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.OutlinedButton
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -29,6 +38,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -41,7 +51,7 @@ import android.widget.Toast
 fun CronScreen(
     onMenu: () -> Unit,
     onOpen: (String) -> Unit = {},
-    onNew: () -> Unit = {},
+    onNew: (String) -> Unit = {},
     vm: CronViewModel = hiltViewModel(),
 ) {
     val state by vm.state.collectAsStateWithLifecycle()
@@ -58,7 +68,7 @@ fun CronScreen(
         },
         floatingActionButton = {
             androidx.compose.material3.ExtendedFloatingActionButton(
-                onClick = onNew,
+                onClick = { onNew("new") },
                 text = { Text("New") },
                 icon = { Icon(androidx.compose.material.icons.Icons.Rounded.Add, contentDescription = null) },
                 containerColor = com.hermes.client.ui.components.AccentChrome.fabContainer,
@@ -72,10 +82,7 @@ fun CronScreen(
                 state.error != null -> com.hermes.client.ui.components.ErrorState(
                     message = state.error!!, onRetry = { vm.load() },
                 )
-                state.jobs.isEmpty() -> com.hermes.client.ui.components.EmptyState(
-                    title = "No cron jobs",
-                    subtitle = "Scheduled jobs for this profile will show up here.",
-                )
+                state.jobs.isEmpty() -> CronEmpty(onNew = onNew)
                 else -> {
                     val nowMs = remember(state.jobs) { System.currentTimeMillis() }
                     val menuFor = remember { mutableStateOf<String?>(null) }
@@ -147,5 +154,29 @@ fun CronScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun CronEmpty(onNew: (String) -> Unit) {
+    val accent = com.hermes.client.ui.theme.LocalProfileAccent.current
+    Column(
+        Modifier.fillMaxSize().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(Icons.Rounded.Schedule, contentDescription = null, tint = accent.accent, modifier = Modifier.size(40.dp))
+        Spacer(Modifier.height(12.dp))
+        Text("No cron jobs", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(4.dp))
+        Text("Start from a template:", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(16.dp))
+        CRON_TEMPLATES.forEach { t ->
+            OutlinedButton(onClick = { onNew(t.id) }, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                Text(t.label)
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Button(onClick = { onNew("new") }) { Text("New cron job") }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/cron/CronTemplates.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronTemplates.kt
@@ -3,6 +3,8 @@ package com.hermes.client.ui.cron
 /** A one-tap starting point for a new cron job (a preset schedule + a starter prompt). */
 data class CronTemplate(val id: String, val label: String, val schedule: Schedule, val prompt: String)
 
+// Template ids (new_daily, new_weekly, etc.) are a distinct namespace from server job ids (c1, etc.),
+// so cronTemplate(id) matching in the edit VM can't collide with a real job.
 val CRON_TEMPLATES = listOf(
     CronTemplate(
         "new_daily", "Daily summary · 9:00", Schedule.Daily(9, 0),

--- a/app/src/main/java/com/hermes/client/ui/cron/CronTemplates.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronTemplates.kt
@@ -1,0 +1,21 @@
+package com.hermes.client.ui.cron
+
+/** A one-tap starting point for a new cron job (a preset schedule + a starter prompt). */
+data class CronTemplate(val id: String, val label: String, val schedule: Schedule, val prompt: String)
+
+val CRON_TEMPLATES = listOf(
+    CronTemplate(
+        "new_daily", "Daily summary · 9:00", Schedule.Daily(9, 0),
+        "Summarize what happened across my projects yesterday — deploys, incidents, and anything that needs my attention.",
+    ),
+    CronTemplate(
+        "new_weekly", "Weekly audit · Mon 2:00", Schedule.Weekly(setOf(Weekday.MON), 2, 0),
+        "Run a dependency and security audit and list anything that needs attention.",
+    ),
+    CronTemplate(
+        "new_hourly", "Hourly check", Schedule.Hourly(0),
+        "Check for anything urgent that needs my attention and summarize it.",
+    ),
+)
+
+fun cronTemplate(id: String): CronTemplate? = CRON_TEMPLATES.firstOrNull { it.id == id }

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -159,7 +159,7 @@ fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsu
                 CronScreen(
                     onMenu = back,
                     onOpen = { id -> nav.navigate("cron_detail/$id") },
-                    onNew = { nav.navigate("cron_edit/new") },
+                    onNew = { seed -> nav.navigate("cron_edit/$seed") },
                 )
             }
             composable("cron_detail/{id}") { entry ->

--- a/app/src/test/java/com/hermes/client/ui/cron/CronFollowupsTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/cron/CronFollowupsTest.kt
@@ -1,0 +1,37 @@
+package com.hermes.client.ui.cron
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CronFollowupsTest {
+    @Test fun displayName_uses_name_when_present() {
+        assertEquals("Nightly summary", cronDisplayName("  Nightly summary  ", "some prompt", "c1"))
+    }
+    @Test fun displayName_falls_back_to_prompt_snippet() {
+        assertEquals("Back up the DB", cronDisplayName("", "Back up the DB", "c1"))
+        assertEquals("Back up the DB", cronDisplayName(null, "Back up the DB", "c1"))
+    }
+    @Test fun displayName_flattens_and_truncates_long_prompt() {
+        val long = "Summarize yesterday's deploys\nand open incidents across all of my projects"
+        val out = cronDisplayName(null, long, "c1", maxLen = 20)
+        assertTrue(out.endsWith("…"))
+        assertTrue(out.length <= 21)
+        assertTrue(!out.contains("\n"))
+    }
+    @Test fun displayName_falls_back_to_id() {
+        assertEquals("c9", cronDisplayName(null, null, "c9"))
+        assertEquals("c9", cronDisplayName("  ", "  ", "c9"))
+    }
+    @Test fun cronTemplate_lookup() {
+        assertEquals(Schedule.Daily(9, 0), cronTemplate("new_daily")?.schedule)
+        assertEquals(Schedule.Weekly(setOf(Weekday.MON), 2, 0), cronTemplate("new_weekly")?.schedule)
+        assertEquals(Schedule.Hourly(0), cronTemplate("new_hourly")?.schedule)
+        assertNull(cronTemplate("new"))
+        assertNull(cronTemplate("nope"))
+    }
+    @Test fun all_templates_emit_valid_cron() {
+        CRON_TEMPLATES.forEach { assertTrue(it.id, isValidCron(it.schedule.toCron())) }
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-cron-followups.md
+++ b/docs/superpowers/plans/2026-07-07-cron-followups.md
@@ -1,0 +1,319 @@
+# Cron Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cron polish — a legible detail status card + expandable error, a prompt-derived list name (no opaque ids), and empty-state quick-start templates.
+
+**Architecture:** A pure `cronDisplayName` helper and a `CronTemplate` list (unit-tested) back the display fallback and the templates; the templates pre-fill the create form by branching a distinguishable `id` in `CronEditViewModel.load` (no new nav route). All over the existing cron REST.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing cron REST/DTOs only.
+- Multi-tenant isolation: new chrome tints to `LocalProfileAccent.current`, never hardcoded.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `ui/cron/Schedule.kt`: `Schedule.Daily(hour,minute)` / `Weekly(days:Set<Weekday>,hour,minute)` / `Hourly(minute)`; `Weekday.MON`; `Schedule.toCron()`; `isValidCron(expr)`.
+- `ui/cron/CronScreen.kt`: `CronScreen(onMenu, onOpen, onNew: () -> Unit, vm)`; row `headlineContent = { Text(job.name ?: job.id) }`; empty branch `EmptyState(title="No cron jobs", subtitle=…)`; the New FAB `onClick = onNew`; `CronViewModel` gives `state.jobs`. `LocalProfileAccent.current.accent`.
+- `ui/cron/CronEditScreen.kt`: `CronEditState(name, schedule: Schedule = Schedule.Daily(9,0), prompt, isNew, loading, saved, message)`; `CronEditViewModel.load(id)` (`id=="new"` → `CronEditState(isNew=true)`; else fetch via `tools.cronJob`).
+- `ui/cron/CronDetailScreen.kt`: private `Field(label,value)` (a `Row` of two `Text`s); Schedule/Status/Next-run/Last-run are 4 `Field`s; `lastError` = `Text(it, color=error, style=bodySmall, maxLines=3, overflow=Ellipsis)`; then the action Row + PROMPT + RUN HISTORY.
+- `ui/nav/HermesNav.kt`: `composable("cron") { CronScreen(onMenu=back, onOpen={id->nav.navigate("cron_detail/$id")}, onNew={ nav.navigate("cron_edit/new") }) }`; `composable("cron_edit/{id}")` accepts any `{id}` string.
+- `CronJobDto.prompt: String?` (on the list payload). `EmptyState` (`ui/components/ScreenStates.kt`) supports only a single action button.
+
+---
+
+### Task 1: Pure helpers — `cronDisplayName` + `CronTemplates` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/cron/CronDisplay.kt`, `app/src/main/java/com/hermes/client/ui/cron/CronTemplates.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/cron/CronFollowupsTest.kt`
+
+**Interfaces:** Produces `cronDisplayName(name, prompt, id, maxLen=40): String`; `data class CronTemplate(id, label, schedule, prompt)`; `val CRON_TEMPLATES: List<CronTemplate>`; `cronTemplate(id): CronTemplate?`.
+
+- [ ] **Step 1: Write the failing tests** — create `CronFollowupsTest.kt`:
+
+```kotlin
+package com.hermes.client.ui.cron
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CronFollowupsTest {
+    @Test fun displayName_uses_name_when_present() {
+        assertEquals("Nightly summary", cronDisplayName("  Nightly summary  ", "some prompt", "c1"))
+    }
+    @Test fun displayName_falls_back_to_prompt_snippet() {
+        assertEquals("Back up the DB", cronDisplayName("", "Back up the DB", "c1"))
+        assertEquals("Back up the DB", cronDisplayName(null, "Back up the DB", "c1"))
+    }
+    @Test fun displayName_flattens_and_truncates_long_prompt() {
+        val long = "Summarize yesterday's deploys\nand open incidents across all of my projects"
+        val out = cronDisplayName(null, long, "c1", maxLen = 20)
+        assertTrue(out.endsWith("…"))
+        assertTrue(out.length <= 21)
+        assertTrue(!out.contains("\n"))
+    }
+    @Test fun displayName_falls_back_to_id() {
+        assertEquals("c9", cronDisplayName(null, null, "c9"))
+        assertEquals("c9", cronDisplayName("  ", "  ", "c9"))
+    }
+    @Test fun cronTemplate_lookup() {
+        assertEquals(Schedule.Daily(9, 0), cronTemplate("new_daily")?.schedule)
+        assertEquals(Schedule.Weekly(setOf(Weekday.MON), 2, 0), cronTemplate("new_weekly")?.schedule)
+        assertEquals(Schedule.Hourly(0), cronTemplate("new_hourly")?.schedule)
+        assertNull(cronTemplate("new"))
+        assertNull(cronTemplate("nope"))
+    }
+    @Test fun all_templates_emit_valid_cron() {
+        CRON_TEMPLATES.forEach { assertTrue(it.id, isValidCron(it.schedule.toCron())) }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronFollowupsTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `cronDisplayName`/`cronTemplate`/`CRON_TEMPLATES`.
+
+- [ ] **Step 3: Create `CronDisplay.kt`**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+/** List/display name for a cron job: its name, else a one-line prompt snippet, else its id. */
+fun cronDisplayName(name: String?, prompt: String?, id: String, maxLen: Int = 40): String {
+    name?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+    prompt?.replace("\n", " ")?.trim()?.takeIf { it.isNotEmpty() }?.let {
+        return if (it.length <= maxLen) it else it.take(maxLen).trimEnd() + "…"
+    }
+    return id
+}
+```
+
+- [ ] **Step 4: Create `CronTemplates.kt`**
+
+```kotlin
+package com.hermes.client.ui.cron
+
+/** A one-tap starting point for a new cron job (a preset schedule + a starter prompt). */
+data class CronTemplate(val id: String, val label: String, val schedule: Schedule, val prompt: String)
+
+val CRON_TEMPLATES = listOf(
+    CronTemplate(
+        "new_daily", "Daily summary · 9:00", Schedule.Daily(9, 0),
+        "Summarize what happened across my projects yesterday — deploys, incidents, and anything that needs my attention.",
+    ),
+    CronTemplate(
+        "new_weekly", "Weekly audit · Mon 2:00", Schedule.Weekly(setOf(Weekday.MON), 2, 0),
+        "Run a dependency and security audit and list anything that needs attention.",
+    ),
+    CronTemplate(
+        "new_hourly", "Hourly check", Schedule.Hourly(0),
+        "Check for anything urgent that needs my attention and summarize it.",
+    ),
+)
+
+fun cronTemplate(id: String): CronTemplate? = CRON_TEMPLATES.firstOrNull { it.id == id }
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*CronFollowupsTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronDisplay.kt app/src/main/java/com/hermes/client/ui/cron/CronTemplates.kt app/src/test/java/com/hermes/client/ui/cron/CronFollowupsTest.kt
+git commit -m "feat(cron): cronDisplayName + CronTemplates pure helpers"
+```
+
+---
+
+### Task 2: List name fallback (`CronScreen`)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt`
+
+**Interfaces:** Consumes `cronDisplayName` (Task 1).
+
+- [ ] **Step 1: Use `cronDisplayName` in the row headline**
+
+Change `headlineContent = { Text(job.name ?: job.id) }` to `headlineContent = { Text(cronDisplayName(job.name, job.prompt, job.id)) }`.
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+git commit -m "feat(cron): list rows show a prompt-derived name instead of the job id"
+```
+
+---
+
+### Task 3: Empty-state quick-start templates
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt`, `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt`, `app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt`
+
+**Interfaces:** Consumes `CRON_TEMPLATES`, `cronTemplate` (Task 1). Produces `onNew: (String) -> Unit`.
+
+- [ ] **Step 1: `CronScreen` — `onNew: (String) -> Unit` + custom empty layout**
+
+Change the `CronScreen` signature `onNew: () -> Unit` → `onNew: (String) -> Unit`. The New FAB's `onClick` → `{ onNew("new") }`. Replace the `state.jobs.isEmpty()` branch's `EmptyState(...)` call with `CronEmpty(onNew = onNew)`, and add:
+```kotlin
+@Composable
+private fun CronEmpty(onNew: (String) -> Unit) {
+    val accent = com.hermes.client.ui.theme.LocalProfileAccent.current
+    Column(
+        Modifier.fillMaxSize().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(Icons.Rounded.Schedule, contentDescription = null, tint = accent.accent, modifier = Modifier.size(40.dp))
+        Spacer(Modifier.height(12.dp))
+        Text("No cron jobs", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(4.dp))
+        Text("Start from a template:", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(16.dp))
+        CRON_TEMPLATES.forEach { t ->
+            OutlinedButton(onClick = { onNew(t.id) }, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                Text(t.label)
+            }
+        }
+        Spacer(Modifier.height(12.dp))
+        Button(onClick = { onNew("new") }) { Text("New cron job") }
+    }
+}
+```
+Add imports as needed (`androidx.compose.foundation.layout.*`, `Arrangement`, `Alignment`, `Icons.Rounded.Schedule`, `androidx.compose.material3.{OutlinedButton,Button,Icon,Text}`, `size`).
+
+- [ ] **Step 2: `HermesNav` — forward the seed**
+
+Change the cron `composable` block: `onNew = { seed -> nav.navigate("cron_edit/$seed") }`.
+
+- [ ] **Step 3: `CronEditViewModel.load` — seed from a template**
+
+At the top of `load(id)`, before the existing `if (id == "new")` handling, replace that guard with:
+```kotlin
+    fun load(id: String) {
+        jobId = id
+        val template = cronTemplate(id)
+        if (id == "new" || template != null) {
+            _state.value = if (template != null) {
+                CronEditState(schedule = template.schedule, prompt = template.prompt, isNew = true)
+            } else {
+                CronEditState(isNew = true)
+            }
+            return
+        }
+        // …existing fetch-for-edit path (unchanged)…
+    }
+```
+
+- [ ] **Step 4: Compile + suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head` → `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2` → `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+git commit -m "feat(cron): empty-state quick-start templates (pre-fill the builder)"
+```
+
+---
+
+### Task 4: Detail status card + expandable error
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt`
+
+- [ ] **Step 1: Group Status/Next-run/Last-run in a tonal card + expandable error**
+
+Keep `Field("Schedule", job.scheduleText)` as-is above. Replace the three `Field("Status"…)`/`Field("Next run"…)`/`Field("Last run"…)` calls and the `lastError` block with:
+```kotlin
+            Spacer(Modifier.height(8.dp))
+            Surface(shape = MaterialTheme.shapes.medium, color = MaterialTheme.colorScheme.surfaceVariant) {
+                Column(Modifier.padding(12.dp)) {
+                    Field("Status", if (job.isPaused) "Paused" else if (job.enabled) "Enabled" else "Disabled")
+                    Field("Next run", formatIso(job.nextRunAt))
+                    Field("Last run", formatIso(job.lastRunAt) + (job.lastStatus?.let { " · $it" } ?: ""))
+                    job.lastError?.takeIf { it.isNotBlank() }?.let { err ->
+                        var errorExpanded by androidx.compose.runtime.saveable.rememberSaveable { androidx.compose.runtime.mutableStateOf(false) }
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            err,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = if (errorExpanded) Int.MAX_VALUE else 3,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.clickable { errorExpanded = !errorExpanded },
+                        )
+                        Text(
+                            if (errorExpanded) "Show less" else "Show more",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = LocalProfileAccent.current.accent,
+                            modifier = Modifier.clickable { errorExpanded = !errorExpanded }.padding(top = 2.dp),
+                        )
+                    }
+                }
+            }
+```
+Add imports if missing: `androidx.compose.material3.Surface`, `androidx.compose.foundation.clickable`, `androidx.compose.foundation.layout.height`. Leave the action `Row`, PROMPT preview, and RUN HISTORY unchanged.
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+git commit -m "feat(cron): grouped status card + tap-to-expand error on detail"
+```
+
+---
+
+### Task 5: Mock unnamed job + on-device verification
+
+**Files:** Modify `$CLAUDE_JOB_DIR/tmp/mockgw.py` (test harness only — not committed).
+
+- [ ] **Step 1: Add an unnamed cron job to the mock**
+
+In `$CLAUDE_JOB_DIR/tmp/mockgw.py`'s `cron_jobs(profile)` list, add one entry with `name=None` and a real `prompt` (e.g. `dict(id="c5", name=None, schedule_display="Every day at 06:00", enabled=True, next_run_at=iso(12*HOUR), last_status="success", profile="acme", model="opus", prompt="Post the daily standup digest to the team channel.")`). Restart the mock.
+
+- [ ] **Step 2: Build, install, verify**
+
+`./gradlew :app:assembleBeta`; `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`; connect to `http://10.0.2.2:8899`.
+1. **Detail of a failed cron** (acme → "Nightly DB backup", status error): Status / Next run / Last run render inside one **tonal card**; the error shows **"Show more"** → tap expands the full text → **"Show less"**.
+2. **Unnamed job** (c5): the cron list shows a **prompt-derived headline** ("Post the daily standup digest…"), not "c5".
+3. **Empty state** (switch to **globex**, which has no crons): the empty layout shows the three template buttons + "New cron job"; tapping **"Daily summary · 9:00"** opens the builder **pre-filled** on Daily 09:00 with the starter prompt; tapping **"New cron job"** opens a blank Daily default.
+4. Everything **tenant-accent** tinted (green acme / gold globex).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed in app code)**
+
+```bash
+git add -A
+git commit -m "chore(cron): follow-ups verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Item 1 (detail legibility) → Task 4 ✓; Item 2 (name fallback) → Task 1 (`cronDisplayName` + test) + Task 2 (wire) ✓; Item 3 (empty-state templates) → Task 1 (`CRON_TEMPLATES` + test) + Task 3 (empty layout + nav + `load` branch) ✓; on-device (mock unnamed job) → Task 5 ✓. Deferred items (persisted name, error dialog) intentionally absent, per the spec.
+- **Placeholder scan:** every code step has full code; the only conditional commit is Task 5 Step 3.
+- **Type consistency:** `cronDisplayName(name, prompt, id, maxLen)`, `CronTemplate(id,label,schedule,prompt)`, `CRON_TEMPLATES`, `cronTemplate(id)` (Task 1) consumed by Tasks 2–3; `onNew: (String) -> Unit` consistent across `CronScreen`/`HermesNav`; `CronEditState(schedule, prompt, isNew)` matches the existing state; `Schedule.Daily/Weekly/Hourly`, `Weekday.MON`, `toCron()`, `isValidCron` match `Schedule.kt`.
+
+**Ordering:** Task 1 (pure) first. Tasks 2 and 3 both touch `CronScreen.kt` — run 2 then 3. Task 3 also touches `HermesNav.kt` + `CronEditScreen.kt`. Task 4 is independent (`CronDetailScreen.kt`). Task 5 verifies (mock).

--- a/docs/superpowers/specs/2026-07-07-cron-followups-design.md
+++ b/docs/superpowers/specs/2026-07-07-cron-followups-design.md
@@ -1,0 +1,99 @@
+# Cron Follow-ups — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/cron-followups`
+**Source:** the deferred P1/P2 items from `docs/superpowers/specs/2026-07-06-cron-schedule-builder-design.md` ("Not doing") + the cron UX review.
+
+## Goal
+
+Three follow-up polish items for cron: make the detail screen's status/error legible (P1), stop showing opaque job ids in the list (P2), and lower activation energy with empty-state quick-start templates (P2). Compose-only, **no new gateway endpoints**, reusing the `Schedule` model.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Compose UI + existing cron REST/DTOs only. Material 3.
+- Multi-tenant isolation: new chrome tints to `LocalProfileAccent.current`, never hardcoded.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Grounding (from exploration)
+
+- `CronDetailScreen.kt`: body is a `LazyColumn`; `Field(label, value)` is a bare 2-`Text` `Row` (96 dp label + value), no grouping. Schedule/Status/Next-run/Last-run are 4 consecutive `Field`s. `lastError` renders as `Text(it, color = error, style = bodySmall, maxLines = 3, overflow = Ellipsis)` — hard-truncated. Then the action `Row`, PROMPT preview, RUN HISTORY list. `CronDetailUiState(job, runs, loading, error, message, deleted)`.
+- `CronScreen.kt`: row `headlineContent = Text(job.name ?: job.id)`; `supportingContent` already falls back to a prompt snippet (`job.prompt?.replace("\n"," ")?.trim()?.take(100)`) when no next-run. Empty branch: `EmptyState(title = "No cron jobs", subtitle = …)`. `onNew: () -> Unit` (nav `"cron_edit/new"`). Row `trailingContent` = the overflow menu (Pause/Resume/Run now).
+- `CronJobDto.prompt: String?` — same DTO for list + detail (present on the list payload; the client already reads it).
+- Nav (`ui/nav/HermesNav.kt`): `composable("cron_edit/{id}")` reads `entry.arguments?.getString("id") ?: "new"` → `CronEditScreen(jobId)` → `LaunchedEffect(jobId){ vm.load(jobId) }`. `CronEditViewModel.load(id)`: `if (id=="new") { CronEditState(isNew=true); return }` else fetch. No `SavedStateHandle`. **Any `{id}` string is accepted — so a template id like `new_daily` needs zero new route registration, only a branch in `load()`.**
+- `EmptyState` (`ui/components/ScreenStates.kt`) supports a single `actionLabel`/`onAction` button — not multiple; multiple template affordances need a small custom layout.
+- `Schedule` model (`ui/cron/Schedule.kt`): `Schedule.Daily/Weekly/Hourly/...`, `Weekday`, `toCron()`, `describe()`.
+
+## Item 1 — Detail status card + expandable error (P1)
+
+*File: `ui/cron/CronDetailScreen.kt`.*
+- **Group the run-status trio.** Keep `Field("Schedule", job.scheduleText)` as a header field. Wrap `Status` / `Next run` / `Last run` in a tonal container: a `Surface(shape = MaterialTheme.shapes.medium, color = MaterialTheme.colorScheme.surfaceVariant)` holding a `Column(padding 12dp)` of the three `Field`s, so the "when/did-it-run" info reads as one scannable block distinct from the schedule.
+- **Expandable error.** Replace the hard `maxLines = 3` error with a tap-to-expand block: hoist `var errorExpanded by rememberSaveable { mutableStateOf(false) }`; render the error inside the status card (or directly under it) as `Text(lastError, color = error, style = bodySmall, maxLines = if (errorExpanded) Int.MAX_VALUE else 3, overflow = Ellipsis, modifier = Modifier.clickable { errorExpanded = !errorExpanded })`, with a small trailing hint `Text(if (errorExpanded) "Show less" else "Show more", style = labelSmall, color = accent)` shown only when the text is long enough to truncate (approximate: show the hint whenever `lastError` is non-blank — cheap and harmless). Tapping the error or the hint toggles.
+
+## Item 2 — Display-time name fallback (P2)
+
+*Files: create `ui/cron/CronDisplay.kt` (pure) + test; modify `ui/cron/CronScreen.kt`.*
+- **Pure helper (unit-tested):**
+```kotlin
+/** List/display name for a cron job: its name, else a one-line prompt snippet, else its id. */
+fun cronDisplayName(name: String?, prompt: String?, id: String, maxLen: Int = 40): String {
+    name?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+    prompt?.replace("\n", " ")?.trim()?.takeIf { it.isNotEmpty() }?.let {
+        return if (it.length <= maxLen) it else it.take(maxLen).trimEnd() + "…"
+    }
+    return id
+}
+```
+- **Use it** in `CronScreen`'s row: `headlineContent = { Text(cronDisplayName(job.name, job.prompt, job.id)) }` (replacing `job.name ?: job.id`). The supportingContent stays as-is (it shows next-run, or the prompt snippet only when there's no next-run — so a name derived from the prompt won't duplicate the subtitle in the common next-run case).
+
+## Item 3 — Empty-state quick-start templates (P2)
+
+*Files: create `ui/cron/CronTemplates.kt` (pure) + test; modify `ui/cron/CronScreen.kt`, `ui/cron/CronEditScreen.kt`, `ui/nav/HermesNav.kt`.*
+- **Templates model (pure, unit-tested):**
+```kotlin
+data class CronTemplate(val id: String, val label: String, val schedule: Schedule, val prompt: String)
+
+val CRON_TEMPLATES = listOf(
+    CronTemplate("new_daily", "Daily summary · 9:00", Schedule.Daily(9, 0),
+        "Summarize what happened across my projects yesterday — deploys, incidents, and anything that needs my attention."),
+    CronTemplate("new_weekly", "Weekly audit · Mon 2:00", Schedule.Weekly(setOf(Weekday.MON), 2, 0),
+        "Run a dependency and security audit and list anything that needs attention."),
+    CronTemplate("new_hourly", "Hourly check", Schedule.Hourly(0),
+        "Check for anything urgent that needs my attention and summarize it."),
+)
+
+fun cronTemplate(id: String): CronTemplate? = CRON_TEMPLATES.firstOrNull { it.id == id }
+```
+- **Pre-fill via the existing route.** `onNew` becomes `onNew: (String) -> Unit` (the seed id). In `HermesNav`: `onNew = { seed -> nav.navigate("cron_edit/$seed") }`. In `CronEditViewModel.load(id)`, before the existing logic:
+```kotlin
+    fun load(id: String) {
+        jobId = id
+        val template = cronTemplate(id)
+        if (id == "new" || template != null) {
+            _state.value = if (template != null) CronEditState(schedule = template.schedule, prompt = template.prompt, isNew = true)
+                           else CronEditState(isNew = true)
+            return
+        }
+        // …existing fetch-for-edit path…
+    }
+```
+(`isNew = true` for templates, so `save()` calls `createCron` — `jobId = "new_daily"` is never used for an update.)
+- **Custom empty layout** (`EmptyState` only has one button slot): a small private `CronEmpty(onNew: (String) -> Unit)` in `CronScreen.kt` — the inbox icon + "No cron jobs" + a "Start from a template:" caption + a column of `OutlinedButton`s (one per `CRON_TEMPLATES`, `onClick = { onNew(it.id) }`, tenant-accent), then a filled `Button("New cron job", onClick = { onNew("new") })`. The `state.jobs.isEmpty()` branch renders `CronEmpty(onNew)` instead of the shared `EmptyState`. The `New` FAB continues to call `onNew("new")`.
+
+## Testing
+
+- **Unit (pure), TDD:**
+  - `cronDisplayName`: name present → name (trimmed); blank name → prompt snippet (single line, `take(40)` + "…" when long); blank prompt → id.
+  - `cronTemplate` / `CRON_TEMPLATES`: `cronTemplate("new_daily")` → the Daily(9,0) template; unknown id → null; every template's `schedule.toCron()` is a valid 5-field expr (`isValidCron`).
+- **On-device:**
+  1. Detail of a FAILED cron (mock `c3` "Nightly DB backup") — Status/Next-run/Last-run render as a grouped card; the error is tap-to-expand (Show more → full text → Show less).
+  2. A cron with no name (add one to the mock, or verify the fallback) shows a prompt-derived headline, not an opaque id.
+  3. A profile with no crons (e.g. globex) shows the empty layout with the three template buttons + "New cron job"; tapping "Daily summary · 9:00" opens the builder pre-filled with Daily 09:00 + the starter prompt; tapping "New cron job" opens a blank Daily default.
+  4. Everything tenant-accent tinted.
+
+## Not doing (YAGNI)
+
+- Persisting a derived name at create (display-time fallback covers it without mutation).
+- A dialog/bottom-sheet for the error (in-place expand is lighter).
+- Editable template management or server-side blueprints (no endpoint).
+- Any gateway/API change.


### PR DESCRIPTION
## Promote develop → main (production 0.1.39)

Promotes the cron follow-ups to production. main was last at 0.1.38 (#68).

### What ships to production (0.1.39)
Compose-only, no gateway changes:
1. Detail-screen status card (grouped Status/Next-run/Last-run) + tap-to-expand error.
2. Prompt-derived list names (unnamed jobs show a readable name, not an opaque id).
3. Empty-state quick-start templates that open the builder pre-filled (via the existing route).

Built via spec → plan → subagent-driven development with per-task + a final whole-branch review; on-device verified. 6 new unit tests. No bridge/gateway API changes.
