### PR TITLE
Voice dictation in the chat composer (+ competitive review & roadmap docs)

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.AttachFile
+import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
@@ -124,6 +125,28 @@ fun ChatScreen(
         }
     }
 
+    // Voice dictation: the system speech recognizer returns a transcript we append to the draft.
+    // RecognizerIntent needs no RECORD_AUDIO (the system speech app owns the mic + permission).
+    val speechAvailable = remember { android.speech.SpeechRecognizer.isRecognitionAvailable(context) }
+    val speech = androidx.activity.compose.rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == android.app.Activity.RESULT_OK) {
+            val spoken = result.data
+                ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
+                ?.firstOrNull().orEmpty()
+            draft = appendDictation(draft, spoken)
+        }
+    }
+    fun startDictation() {
+        val intent = android.content.Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, java.util.Locale.getDefault())
+            putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, "Speak your message")
+        }
+        runCatching { speech.launch(intent) }
+    }
+
     // I1: route back to Setup when the server returns 401
     LaunchedEffect(unauthorized) {
         if (unauthorized) onUnauthorized()
@@ -176,6 +199,15 @@ fun ChatScreen(
                 Spacer(Modifier.width(4.dp))
                 IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) {
                     Icon(Icons.Rounded.AttachFile, contentDescription = "Attach image")
+                }
+                if (speechAvailable) {
+                    IconButton(onClick = { startDictation() }) {
+                        Icon(
+                            Icons.Rounded.Mic,
+                            contentDescription = "Voice input",
+                            tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                        )
+                    }
                 }
                 OutlinedTextField(
                     value = draft,

--- a/app/src/main/java/com/hermes/client/ui/chat/Dictation.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/Dictation.kt
@@ -1,0 +1,8 @@
+package com.hermes.client.ui.chat
+
+/** Append dictated [spoken] to the current [current] draft (single-space-joined; blank-safe). */
+fun appendDictation(current: String, spoken: String): String {
+    val s = spoken.trim()
+    if (s.isEmpty()) return current
+    return if (current.isBlank()) s else current.trimEnd() + " " + s
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/DictationTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/DictationTest.kt
@@ -1,0 +1,22 @@
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DictationTest {
+    @Test fun blank_current_returns_spoken() {
+        assertEquals("hello", appendDictation("", "hello"))
+        assertEquals("hello", appendDictation("   ", "  hello  "))
+    }
+    @Test fun appends_with_single_space() {
+        assertEquals("type and speak", appendDictation("type", "and speak"))
+        assertEquals("type more", appendDictation("type ", "  more "))
+    }
+    @Test fun blank_spoken_leaves_current_unchanged() {
+        assertEquals("type", appendDictation("type", ""))
+        assertEquals("type", appendDictation("type", "   "))
+    }
+    @Test fun trims_spoken() {
+        assertEquals("hi there", appendDictation("hi", "  there  "))
+    }
+}

--- a/docs/ideas/competitive-review-2026-07-07.md
+++ b/docs/ideas/competitive-review-2026-07-07.md
@@ -1,0 +1,79 @@
+# Competitive Review — Hermes for Android vs. the field (2026-07-07)
+
+A review of Hermes for Android against (a) the flagship **consumer AI chat apps** (ChatGPT, Claude, Gemini, Perplexity, Copilot) and (b) **self-hosted / power-user AI clients and agent "remotes"** (Open WebUI, LibreChat, Jan, Msty, Enchanted, Chatbox, AnythingLLM; Claude Code/Cursor/Codex mobile companions; Zapier/Make/n8n). Goal: where Hermes is strong, where it lags table stakes, and where it can lead.
+
+## What Hermes is (and the category reality)
+
+Hermes is a **genuinely native Android client for a self-hosted, multi-tenant AI-agent gateway** — "reach everything, act on a few." That framing matters: the self-hosted AI-client category is overwhelmingly **PWA/desktop-only**. Of the major self-hosted front-ends, only Chatbox and AnythingLLM ship real native Android apps, and neither is an *agent-gateway* or *multi-tenant* product; Open WebUI/LibreChat/Jan/Msty/Big-AGI/Ollama are web/desktop; Enchanted is iOS-only. **A polished native Android app in this space is itself a durable, structural advantage.**
+
+## Scorecard — "table stakes on mobile in 2026"
+
+What users now expect from *any* AI app, mapped to Hermes:
+
+| Capability | Hermes | Note |
+|---|---|---|
+| Streaming render, stop generation | ✅ | reducer-based streaming, interrupt |
+| Markdown + code w/ copy | ✅ | `CodeWithCopy`, horizontal scroll |
+| Tool-call + reasoning display | ✅ **(leads)** | `ToolCard` + collapsible `ThinkingCard`; most consumer apps hide this |
+| Model switching (+ per-session) | ✅ **(leads)** | session-scope vs default; favorites |
+| Slash commands / @-path completion | ✅ **(leads)** | full-screen palette + file completion |
+| Approvals / clarify inline | ✅ **(leads)** | approve/deny cards + notification actions |
+| Conversation search / archive / rename | ✅ | list-level search; workspace grouping |
+| Persistent memory / custom instructions | ◑ | memory *settings* exist (toggles/budgets); no front-and-center "custom instructions" |
+| **Regenerate / edit-a-message / branch** | ❌ | absent — regenerate + edit-resend are table stakes; Claude-style branching is a differentiator |
+| **Voice dictation + live voice mode** | ❌ | the single biggest 2026 convergence (ChatGPT/Claude/Gemini/Perplexity/Copilot all have it) |
+| **Image/camera/file/PDF attach** | ◑ | single gallery image only — no camera, no multi-image, no PDF/doc/vision-beyond-image |
+| **Search within an open thread** | ❌ | only list-level + cross-session search |
+| **Push on async task completion** | ❌ | notifications are approvals-only, and only while the foreground service lives (no FCM) |
+| **Home-screen widget** | ❌ | now table stakes (quick-launch: new chat / voice / camera) |
+| **Chat export / share-out** | ❌ | only the diagnostic debug log exports |
+| Cross-device history sync | ✅ | gateway-backed |
+
+## Where Hermes already leads (self-hosted / agent lens)
+
+- **True multi-tenant isolation with a visible identity.** Per-tenant accent colour (deterministic hue or custom) + isolated credentials/history/switcher. Open WebUI is explicitly multi-*user*, not multi-*tenant* (its documented "fix" for isolation is *running separate instances*). TypingMind/BoltAI do desktop-only profiles. **Nobody does fast, isolated, colour-coded tenant switching on native mobile** — this is a real moat.
+- **A friendly cron **schedule builder** with templates, live next-run, run-now, and per-row actions.** This *already beats* the automation incumbents on mobile: Zapier has **no** Zaps-management app (email-only failure alerts); Make's app is trigger-only (users beg for run history in reviews); n8n ships **no** official app. Hermes clears a bar none of them clear.
+- **Activity feed ("Mission Control") + "Needs you" triage** — the "act on a few" pattern, per tenant.
+- **Self-hosted, no third-party relay** — the agent-monitoring cottage industry (ntfy relays, tap-to-tmux, Omnara) all route your output through a third party; Hermes doesn't need to.
+
+## The gaps that matter most (table stakes it's missing)
+
+1. **Voice** — dictation is cheap (native `SpeechRecognizer`; the gateway also has `/api/audio/transcribe` as a fallback). Live voice mode is bigger but is where the whole category went.
+2. **Regenerate / edit-and-resend** — the most-missed chat primitive; branching (Claude-style version arrows) is the stretch goal.
+3. **Attachments** — camera capture, multiple images, and PDF/doc upload; the composer only does one gallery image today.
+4. **Notification coverage** — today it's approvals-only, and only while the socket-holding foreground service survives. Users of *every* agent product report the same #1 pain: *"I keep missing when the agent finished."*
+5. **Search within a thread**, **chat export**, and a **home-screen widget** — all now expected.
+
+## Where Hermes could *lead* (the whitespace)
+
+Ranked by how unclaimed the space is × fit with the existing architecture:
+
+**A. Mobile-native run monitoring + completion push — the single strongest opportunity.**
+"Kick off a long agent task, get pushed when it's done or needs you" is now standard in consumer apps (ChatGPT Tasks/Agent, Gemini, Copilot) and is the #1 repeated pain for *self-hosted* agent users — solved today only by sketchy third-party relays. Hermes is 80% there: it already has the foreground WS + activity feed + approval notifications. Extend notifications beyond approvals to **cron-finished, run-complete, and agent-needs-input**, and lean on the gateway for durable push where possible (the always-connected foreground service is a battery/OS-kill liability — the WS stream reportedly has no cron-finished event, so this may need a gateway assist). Done natively + self-hosted, this beats every competitor because none of the self-hosted ones do it at all.
+
+**B. A touch-native, *tiered* approval UX.**
+The coding-agent field has converged on **allow / ask / deny** tiers (Cursor/Cline/Goose), but *no one* — not even Claude's mobile app — has designed the approval interaction *for a small screen*; they all reuse the desktop modal. Evolve Hermes's existing approval cards into swipe-to-approve + **"always allow this tool for this profile"** + per-tool-type defaults. Clean first-mover territory. (Caveat to state plainly: approval gates are a UX safety-net, not a security boundary — prompt-injection bypasses are well documented; pair with gateway-side scoping, which as a self-hosted product you control.)
+
+**C. Diff / "what did the agent change?" review as a first-class mobile surface.**
+Proven by GitHub Mobile + Cursor iOS for code, but unclaimed for a *general* self-hosted agent client. The gateway already exposes `/api/git/review/diff`, `/api/git/status`, `/api/fs/*`, `/api/files` — a reviewable "changes" surface (diff view, file browser) is a bigger build but a strong differentiator.
+
+**D. A prompt/snippet library with OS-level quick-invoke** (Android App Actions / share-sheet / a widget of pinned prompts). Confirmed unsolved industry-wide; lower urgency than A–C.
+
+## Suggested roadmap (prioritized)
+
+- **P0 — Notification coverage + run-completion push (A).** The highest-leverage gap; extends what's already built; addresses the category's #1 pain. (May need a small gateway-side event/endpoint — worth confirming against the bridge API before scoping.)
+- **P0 — Voice dictation.** Native `SpeechRecognizer` in the composer; cheap, high-frequency, table stakes.
+- **P1 — Regenerate + edit-and-resend** (branching later).
+- **P1 — Richer attachments** (camera, multi-image, PDF).
+- **P1 — Tiered, swipe-native approvals (B)** — evolve the existing approval cards.
+- **P2 — Search-within-thread; chat export/share-out; a quick-launch widget.**
+- **P2 — Agent "changes" review surface (C)** and a **prompt library + widget (D)** — bigger bets.
+- **Hardening backlog** (from the inventory): message-history pagination on long threads; biometric/app-lock (you hold multi-tenant credentials!); real deep-link/App-Link scheme; usage date-range + per-model cost; bulk session actions; offline compose-and-queue.
+
+## One-line takeaway
+
+Hermes is already **ahead of the self-hosted field** on the things that are hard (native, multi-tenant, agent-aware, a real cron builder) and **behind the consumer field** on the things that are now expected (voice, edit/regenerate, richer attachments, completion push, widgets). The winning move is to **close the consumer table-stakes gaps** *and* **plant a flag on run-monitoring push + touch-native approvals + agent-change review** — the whitespace no competitor owns on mobile.
+
+---
+
+*Note: uses generic tenant names (acme/globex/etc.) throughout; real client names deliberately omitted. Comparable-app details are a mid-2026 snapshot — treat exact model/version names as fluid; the durable findings are the feature patterns.*

--- a/docs/ideas/improvement-roadmap-2026-07-07.md
+++ b/docs/ideas/improvement-roadmap-2026-07-07.md
@@ -1,0 +1,101 @@
+# Improvement Roadmap — phased (2026-07-07)
+
+Turns the competitive review (`competitive-review-2026-07-07.md`) into a phased plan. Every item here is a **wave** — it runs the established cycle: brainstorm → spec → plan → subagent-driven development → beta → (approval) → production. Phases are shippable milestones; waves inside a phase can ship independently.
+
+**Baseline:** production & beta at 0.1.39. Standing constraints carry into every wave: no AI attribution; gitleaks before every push; tenant isolation (fake acme/globex names); `main` only via approved PR; **no new gateway endpoints unless explicitly agreed** (flagged per-item below).
+
+## Legend
+- **Effort:** S (1 wave, ~a day) · M (1 wave, meatier) · L (multi-wave)
+- **GW:** `client-only` · `gateway-assist?` (needs a bridge-API check / possible server change — a decision point)
+
+---
+
+## Phase 1 — Chat parity: the daily-use primitives
+*Goal: the chat screen matches what users expect from any 2026 AI app. All client-only, highest-frequency value.*
+
+1. **Voice dictation** — a mic in the composer using native `SpeechRecognizer`; `/api/audio/transcribe` as a server-side fallback if native is unavailable. *(S · client-only)* **[P0]**
+2. **Regenerate + edit-and-resend** — regenerate the last assistant turn; edit a prior user message and resend. (Branching/version-arrows is a Phase-6 stretch.) *(M · client-only — reuses existing send/interrupt + history)* **[P1]**
+3. **Richer attachments** — camera capture, multiple images, and PDF/doc upload in the composer (today: one gallery image). *(M · gateway-assist? — confirm the bridge accepts multi-image / non-image payloads; falls back to images-only if not)* **[P1]**
+4. **Search within an open thread** — in-thread find/highlight. *(S · client-only — the full history is already loaded)* **[P2]**
+
+**Milestone:** Hermes' chat is at consumer table-stakes for input + editing.
+
+---
+
+## Phase 2 — Awareness: run-monitoring & completion push  *(the flagship differentiator)*
+*Goal: "kick off a task, get pushed when it's done or needs you" — the #1 unmet pain for self-hosted agent users, and Hermes is ~80% there (foreground WS + activity feed + approval notifications).*
+
+0. **Bridge-API spike (prerequisite)** — audit the WS/REST surface: `run.*`, `tool.*`, `message.*` exist; the review found **no cron-finished event and no pending-approvals REST list**. Decide client-only scope vs. a small gateway assist. *(S · gateway-assist? — this spike sets the scope)* **[decision point]**
+1. **Notification coverage beyond approvals** — surface **run-complete**, **agent-needs-input**, and (if the spike allows) **cron-finished / cron-failed** as notifications, using the existing foreground service + `NotificationMapper`. *(M–L · depends on the spike)* **[P0]**
+2. **Foreground-service reliability pass** — address the "notifications die when the service is killed" gap (Android 15 FGS caps; consider a gateway-push path if the spike surfaces one). *(M · gateway-assist?)* **[P1]**
+
+**Milestone:** you can leave the app and trust it to tell you when an agent finished or got stuck — no third-party relay, fully self-hosted.
+
+---
+
+## Phase 3 — Touch-native, tiered approvals  *(whitespace lead)*
+*Goal: the approval interaction no competitor has designed for a small screen. Builds on Phase 2 (approvals arrive as pushes).*
+
+1. **Tiered approvals: allow / ask / deny** — replace binary approve/deny with per-tool-type defaults; **"always allow this tool for this profile"** (stored per-tenant); swipe-to-approve cards. *(M · client-only for the UX + local policy; gateway-assist? only if defaults must persist server-side)* **[P1]**
+2. **Approval context** — richer inline context on the card (what the tool will do / touch) so decisions don't require opening the thread. *(S · client-only)* **[P2]**
+
+> Positioning note to keep honest in the UI/spec: approval gates are a **UX safety-net, not a security boundary** (prompt-injection bypasses are documented industry-wide); real scoping lives at the self-hosted gateway you control.
+
+**Milestone:** approving/denying agent actions on a phone feels native, fast, and per-tenant safe.
+
+---
+
+## Phase 4 — Reach: widget, deep links, prompt library
+*Goal: get Hermes off the app-drawer and onto the home screen + OS quick-actions. Deep links are the shared foundation.*
+
+1. **Public deep-link / App-Link scheme** (`hermes://…` + optional `https://` App Links) — routes to chat/cron/etc.; foundation for widget + share + App Actions. *(S–M · client-only)* **[P2]**
+2. **Home-screen widget** (Glance) — quick-launch (new chat / voice / camera) + a "Needs you" glance. *(M · client-only)* **[P2]**
+3. **Prompt / snippet library** — saved prompts, reachable in-composer and via **App Actions / share-sheet** (confirmed unsolved industry-wide). *(M · client-only; local store or a config key)* **[P2/D]**
+
+**Milestone:** one-tap into Hermes from the home screen and OS quick-actions; reusable prompts without typing.
+
+---
+
+## Phase 5 — Review & artifacts  *(bigger bets)*
+*Goal: "what did the agent change?" and get content out of the app.*
+
+1. **Agent-changes review** — a diff view + file browser over the existing `/api/git/review/diff`, `/api/git/status`, `/api/fs/*`, `/api/files` endpoints. Proven for code by GitHub Mobile/Cursor iOS; unclaimed for a general agent client. *(L · gateway-assist? — verify those endpoints against the bridge; likely client-only)* **[P2/C]**
+2. **Chat export / share-out** — share a conversation or a single response as Markdown/text (today only the debug log exports). *(S · client-only)* **[P2]**
+
+**Milestone:** review agent output and share it — without a desktop.
+
+---
+
+## Phase 6 — Chat depth (stretch)
+1. **Conversation branching** — Claude-style edit-and-fork with version arrows (extends Phase 1 edit-resend). *(M–L · gateway-assist? — depends on whether the gateway models branches)* **[stretch]**
+2. **Memory / custom-instructions front-and-center** — surface persistent memory + a "custom instructions" editor prominently (settings exist today but are buried). *(S–M · client-only — existing memory endpoints)* **[P1-ish]**
+
+---
+
+## Continuous track — Hardening & security *(interleave between phases)*
+Not a blocking phase; pull items in when adjacent work touches them, and pull **biometric app-lock forward** given it guards multi-tenant credentials.
+
+- **Biometric / PIN app-lock** on launch — you hold multiple tenants' credentials/tokens. *(S · client-only)* **[pull early]**
+- **Message-history pagination** — long threads fetch the whole history in one shot today. *(M · gateway-assist? — needs a paged history param)*
+- **Offline compose-and-queue** — draft/send while disconnected, flush on reconnect. *(M · client-only)*
+- **Usage: date-range picker + per-model cost breakdown.** *(S · client-only)*
+- **Bulk session actions** — multi-select archive/delete. *(S · client-only)*
+- **API-key reveal/copy** in the Env screen (write-only today). *(S · client-only)*
+
+---
+
+## Sequencing rationale
+- **Phase 1 first** — pure client-side, daily value, no dependencies; ships momentum while the Phase-2 API question is resolved.
+- **Phase 2 next** — highest strategic value (the differentiator) but gated on a bridge-API spike; the spike runs early/in parallel so scope is known before we commit.
+- **Phase 3** rides on Phase 2 (approvals-as-push).
+- **Phases 4–5** are reach/review — valuable, lower urgency, larger surface.
+- **Phase 6** is stretch/depth.
+- **Hardening** interleaves; **biometric app-lock** should jump ahead of most feature work on security grounds.
+
+## Open decisions (need your call as they come up)
+1. **Gateway changes** — the standing rule is "no new gateway endpoints." Phase 2 (cron-finished push), Phase 5 (if any endpoint is missing), and history pagination may want a small gateway assist. Do we (a) stay strictly client-only and scope around gaps, or (b) allow targeted bridge additions for the flagship push feature? *(Recommend: run the Phase-2 spike, then decide with real information.)*
+2. **Voice mode (live two-way)** — deferred beyond dictation; revisit after Phase 1 if wanted (much larger).
+3. **Phase granularity** — happy to split any Phase-1 item into its own wave or bundle two; each is independently shippable.
+
+## Execution
+When you say go, we start **Phase 1 · Wave 1 (voice dictation)** through the normal cycle. Each wave ships to beta on its own, and you approve production promotions as before.

--- a/docs/superpowers/plans/2026-07-07-voice-dictation.md
+++ b/docs/superpowers/plans/2026-07-07-voice-dictation.md
@@ -1,0 +1,189 @@
+# Voice Dictation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a mic to the chat composer that dictates speech into the message draft via the system speech recognizer.
+
+**Architecture:** A pure `appendDictation` helper (unit-tested) merges the transcript into the draft; the composer gains a mic `IconButton` that launches `RecognizerIntent` and appends the result. No `RECORD_AUDIO`, no manifest/gateway change.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, Android `RecognizerIntent`, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes** (no `/api/audio/transcribe`); **no new permission** (`RecognizerIntent` needs no `RECORD_AUDIO`). Material 3.
+- Multi-tenant isolation: the mic tints to the tenant accent (`AccentChrome.fabContainer` / `LocalProfileAccent`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `ui/chat/ChatScreen.kt`: `draft` is `var draft by remember { mutableStateOf("") }` (~line 82); `val context = LocalContext.current` is already bound; image attach uses `val pickImage = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri -> … }` launched from an `IconButton` in the composer `Row` (order: `ProfileAvatar` → attach `IconButton` → `OutlinedTextField` → Stop/Send). `AccentChrome.fabContainer` is the accent tint used by the Send icon.
+
+---
+
+### Task 1: Pure `appendDictation` helper (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/Dictation.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/chat/DictationTest.kt`
+
+**Interfaces:** Produces `fun appendDictation(current: String, spoken: String): String`.
+
+- [ ] **Step 1: Write the failing test** — create `DictationTest.kt`:
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DictationTest {
+    @Test fun blank_current_returns_spoken() {
+        assertEquals("hello", appendDictation("", "hello"))
+        assertEquals("hello", appendDictation("   ", "  hello  "))
+    }
+    @Test fun appends_with_single_space() {
+        assertEquals("type and speak", appendDictation("type", "and speak"))
+        assertEquals("type more", appendDictation("type ", "  more "))
+    }
+    @Test fun blank_spoken_leaves_current_unchanged() {
+        assertEquals("type", appendDictation("type", ""))
+        assertEquals("type", appendDictation("type", "   "))
+    }
+    @Test fun trims_spoken() {
+        assertEquals("hi there", appendDictation("hi", "  there  "))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*DictationTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `appendDictation`.
+
+- [ ] **Step 3: Implement `Dictation.kt`**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+/** Append dictated [spoken] to the current [current] draft (single-space-joined; blank-safe). */
+fun appendDictation(current: String, spoken: String): String {
+    val s = spoken.trim()
+    if (s.isEmpty()) return current
+    return if (current.isBlank()) s else current.trimEnd() + " " + s
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*DictationTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/Dictation.kt app/src/test/java/com/hermes/client/ui/chat/DictationTest.kt
+git commit -m "feat(chat): appendDictation helper for merging speech into the draft"
+```
+
+---
+
+### Task 2: Mic button + `RecognizerIntent` launcher (`ChatScreen`)
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `appendDictation` (Task 1).
+
+- [ ] **Step 1: Add the availability flag + launcher + intent (near the `pickImage` launcher)**
+
+After the existing `pickImage` launcher block, add:
+```kotlin
+    // Voice dictation: the system speech recognizer returns a transcript we append to the draft.
+    // RecognizerIntent needs no RECORD_AUDIO (the system speech app owns the mic + permission).
+    val speechAvailable = remember { android.speech.SpeechRecognizer.isRecognitionAvailable(context) }
+    val speech = rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == android.app.Activity.RESULT_OK) {
+            val spoken = result.data
+                ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
+                ?.firstOrNull().orEmpty()
+            draft = appendDictation(draft, spoken)
+        }
+    }
+    fun startDictation() {
+        val intent = android.content.Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, java.util.Locale.getDefault())
+            putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, "Speak your message")
+        }
+        runCatching { speech.launch(intent) }
+    }
+```
+(`context` and `draft` are already in scope in the composable; `rememberLauncherForActivityResult` is already imported for `pickImage`.)
+
+- [ ] **Step 2: Render the mic between attach and the text field**
+
+In the composer `Row`, immediately after the attach `IconButton { … Icons.Rounded.AttachFile … }` and before the `OutlinedTextField`, add:
+```kotlin
+        if (speechAvailable) {
+            IconButton(onClick = { startDictation() }) {
+                Icon(
+                    Icons.Rounded.Mic,
+                    contentDescription = "Voice input",
+                    tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                )
+            }
+        }
+```
+Add the import `androidx.compose.material.icons.rounded.Mic` (other `Icons.Rounded.*` are already imported). The mic is **not** gated on `connected` (dictation fills the local draft).
+
+- [ ] **Step 3: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 4: Assemble the beta variant**
+
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): voice dictation mic in the composer (RecognizerIntent)"
+```
+
+---
+
+### Task 3: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`; point at the mock (`http://10.0.2.2:8899`) and open a chat.
+
+- [ ] **Step 2: Verify**
+
+- **If the emulator has speech services:** an accent-tinted mic sits between the attach button and the text field; tapping it opens the system speech overlay; a spoken phrase appends to the draft (single space-joined with any existing text); Send works; cancelling the overlay leaves the draft unchanged.
+- **If the emulator lacks speech services** (a plain AVD may — `SpeechRecognizer.isRecognitionAvailable` is false): the mic is **gracefully absent**, the composer is otherwise unchanged (attach + field + Send), and there is **no crash**. This still verifies the availability-gating + placement + that nothing regressed. (Real dictation needs a device/image with Google speech; the `appendDictation` merge logic is covered by the Task-1 unit test.)
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(chat): voice dictation verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** pure helper → Task 1 (`appendDictation` + tests) ✓; mic button + `RecognizerIntent` launcher + availability gate + accent tint + placement + not-gated-on-connected → Task 2 ✓; on-device (incl. graceful-absent path) → Task 3 ✓. Deferred items (in-app `SpeechRecognizer`, server fallback, cursor insertion) intentionally absent, per the spec.
+- **Placeholder scan:** every code step has full code; the only conditional is the Task-3 verification-only commit.
+- **Type consistency:** `appendDictation(current, spoken): String` (Task 1) is called exactly that way in Task 2; `speech.launch(intent)`, `RESULT_OK`, `EXTRA_RESULTS`, `Icons.Rounded.Mic`, `AccentChrome.fabContainer` all match the spec/codebase.
+
+**Ordering:** Task 1 (pure) first; Task 2 consumes it and touches only `ChatScreen.kt`; Task 3 verifies.

--- a/docs/superpowers/specs/2026-07-07-voice-dictation-design.md
+++ b/docs/superpowers/specs/2026-07-07-voice-dictation-design.md
@@ -1,0 +1,86 @@
+# Voice Dictation (chat composer) — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/voice-dictation`
+**Source:** improvement roadmap Phase 1 · Wave 1 (`docs/ideas/improvement-roadmap-2026-07-07.md`).
+
+## Goal
+
+Add a mic to the chat composer so the user can dictate a message into the draft. **Client-only** via the system speech recognizer (`RecognizerIntent`) — no `RECORD_AUDIO` permission, no manifest change, no gateway change. Small, contained.
+
+## Hard constraints
+
+- **No gateway/bridge API changes** (there is no `/api/audio/transcribe` client method — server fallback is out of scope). Material 3.
+- Multi-tenant isolation: the mic tints to `LocalProfileAccent.current`.
+- No AI/assistant attribution in commits, files, or PRs.
+
+## Grounding (from exploration)
+
+- `ui/chat/ChatScreen.kt`: `draft` is a plain `String` in the composable — `var draft by remember { mutableStateOf("") }` (line 82). The composer bottomBar `Row` order: `ProfileAvatar` → attach `IconButton(pickImage.launch("image/*"))` → `OutlinedTextField(value=draft, onValueChange={draft=it})` → Stop/Send.
+- Image attach uses `rememberLauncherForActivityResult(GetContent()) { uri -> … vm.attachImage(...) }` (the launcher-in-composable pattern to mirror).
+- Manifest has only `INTERNET`/`POST_NOTIFICATIONS`/`FOREGROUND_SERVICE*`; **no `RECORD_AUDIO`** (and `RecognizerIntent` doesn't need it). Existing runtime-permission idiom is the POST_NOTIFICATIONS `RequestPermission()` flow — **not needed here**.
+- `LocalContext.current` is already bound in the composer; `LocalHapticFeedback` is used by `submit()`.
+
+## Decision (locked)
+
+**`RecognizerIntent.ACTION_RECOGNIZE_SPEECH`** (the system speech overlay), not in-app `SpeechRecognizer`. The system app owns the mic UI, partial results, and the permission, so this needs no `RECORD_AUDIO` and ~15 lines. (Inline live-transcription via `SpeechRecognizer` is a possible later wave.)
+
+## Design
+
+### Pure helper (unit-tested) — `ui/chat/Dictation.kt`
+```kotlin
+/** Append dictated [spoken] to the current [current] draft (space-joined; blank-safe). */
+fun appendDictation(current: String, spoken: String): String {
+    val s = spoken.trim()
+    if (s.isEmpty()) return current
+    return if (current.isBlank()) s else current.trimEnd() + " " + s
+}
+```
+
+### Mic button + launcher (`ui/chat/ChatScreen.kt`)
+- **Availability (once):** `val speechAvailable = remember { android.speech.SpeechRecognizer.isRecognitionAvailable(context) }`. The mic is rendered **only when `speechAvailable`** (no dead button on devices without speech services).
+- **Launcher:** mirror the image pattern —
+```kotlin
+val speech = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+    if (result.resultCode == android.app.Activity.RESULT_OK) {
+        val spoken = result.data
+            ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
+            ?.firstOrNull().orEmpty()
+        draft = appendDictation(draft, spoken)
+    }
+}
+```
+- **Launch:** on mic tap, build and launch the intent:
+```kotlin
+val intent = android.content.Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+    putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL, android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+    putExtra(android.speech.RecognizerIntent.EXTRA_LANGUAGE, java.util.Locale.getDefault())
+    putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, "Speak your message")
+}
+runCatching { speech.launch(intent) }
+```
+- **Placement + style:** a mic `IconButton` between the attach button and the `OutlinedTextField`:
+```kotlin
+if (speechAvailable) {
+    IconButton(onClick = { runCatching { speech.launch(intent) } }) {
+        Icon(Icons.Rounded.Mic, contentDescription = "Voice input", tint = com.hermes.client.ui.components.AccentChrome.fabContainer)
+    }
+}
+```
+  (Use `Icons.Rounded.Mic`.) **Not gated on `connected`** — dictation fills the local draft, so it works offline; the user sends when connected. The `runCatching` guards the rare `ActivityNotFoundException`.
+- **Errors/cancel:** a cancelled or empty result is a silent no-op (the `RESULT_OK` + `appendDictation` blank-safe handling covers it).
+
+## Testing
+
+- **Unit (pure), TDD — `DictationTest`:** blank current + spoken → spoken; non-blank current + spoken → `"current spoken"` (single space, current trimmed); blank/whitespace spoken → current unchanged; spoken trimmed.
+- **On-device:** build + install; open a chat.
+  - If the emulator/device **has** speech services: the mic renders (accent-tinted) between attach and the field; tapping it opens the system speech overlay; a spoken phrase appends to the draft (space-joined with any existing text); Send works. Cancelling leaves the draft unchanged.
+  - If it **lacks** speech services (a plain AVD may): the mic is gracefully **absent**, the composer is otherwise unchanged, no crash. (Note: real dictation needs a device/emulator image with Google speech; verify at least the availability-gating + no-crash + placement on the AVD, and the append logic via the unit test.)
+
+## Not doing (YAGNI)
+
+- In-app `SpeechRecognizer` live inline transcription (later wave).
+- Server-side `/api/audio/transcribe` fallback (no endpoint).
+- Cursor-aware insertion (`draft` stays a `String`; append only) and TTS playback.
+- Any gateway/API change or new permission.


### PR DESCRIPTION
## Voice dictation (chat composer) — Phase 1 · Wave 1

First wave of the improvement roadmap. Adds a mic to the chat composer that dictates speech into the message draft. **Client-only** via the system speech recognizer — **no `RECORD_AUDIO` permission, no manifest change, no gateway change.**

- A mic `IconButton` in the composer (between attach and the text field), tinted to the tenant accent, `contentDescription = "Voice input"`.
- Rendered **only when** `SpeechRecognizer.isRecognitionAvailable(context)` (no dead button on devices without speech services).
- **Not gated on connection** — dictation fills the local draft, so it works offline; you send when connected.
- Tapping launches `RecognizerIntent.ACTION_RECOGNIZE_SPEECH` (the system speech overlay owns the mic/permission/partials); the transcript is appended to the draft via a pure, unit-tested `appendDictation(current, spoken)` (single-space-joined, blank-safe). Cancel/no-match is a silent no-op.

### Verification
- Unit test: `DictationTest` (4 cases — append/blank/trim). Full suite + `assembleBeta` green; gitleaks clean.
- Built via Subagent-Driven Development (per-task reviews clean).
- On-device (emulator): the accent mic sits between attach and the field; tapping opens the Google speech overlay showing our "Speak your message" prompt + the device locale, **with no permission prompt and no crash**; cancelling leaves the draft unchanged.

Deferred to later waves (per the roadmap): in-app `SpeechRecognizer` live inline transcription; server `/api/audio/transcribe` fallback (no endpoint); cursor-aware insertion; TTS.

Also brings the two planning docs committed to develop: `docs/ideas/competitive-review-2026-07-07.md` and `docs/ideas/improvement-roadmap-2026-07-07.md`.

Spec/plan: `docs/superpowers/specs/2026-07-07-voice-dictation-design.md`, `docs/superpowers/plans/2026-07-07-voice-dictation.md`.
