### PR TITLE
Promote to production: 0.1.41 (regenerate + edit-and-resend)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 36
-        versionCode = 41
-        versionName = "0.1.40"
+        versionCode = 42
+        versionName = "0.1.41"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -31,6 +31,8 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import com.hermes.client.ui.theme.LocalProfileAccent
@@ -76,8 +78,14 @@ fun ChatMessageList(
     sessionId: String,
     modifier: Modifier = Modifier,
     listState: androidx.compose.foundation.lazy.LazyListState = rememberLazyListState(),
+    isGenerating: Boolean = false,
+    onEditResend: (String) -> Unit = {},
+    onRegenerate: () -> Unit = {},
 ) {
     val lastIndex = state.messages.lastIndex
+    // Only the most recent assistant turn can be regenerated — regenerating an earlier one
+    // would silently drop everything the user and agent said after it.
+    val lastAssistantId = state.messages.lastOrNull { it.role == Role.ASSISTANT }?.id
     // Length of the last (streaming) message: changes on every delta so we follow the stream.
     val tailLen = state.messages.lastOrNull()?.text?.length ?: 0
 
@@ -154,7 +162,10 @@ fun ChatMessageList(
         itemsIndexed(
             state.messages,
             key = { index, msg -> "$index:${msg.id}" },
-        ) { _, msg -> MessageBubble(msg) }
+        ) { _, msg ->
+            val canRegenerate = msg.id == lastAssistantId && !isGenerating
+            MessageBubble(msg, canRegenerate, onEditResend, onRegenerate)
+        }
     }
 }
 
@@ -163,74 +174,107 @@ fun ChatMessageList(
 // code, and tool traces have room to breathe and read as a transcript rather than an SMS thread.
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun MessageBubble(msg: ChatMessage) {
+private fun MessageBubble(
+    msg: ChatMessage,
+    canRegenerate: Boolean,
+    onEditResend: (String) -> Unit,
+    onRegenerate: () -> Unit,
+) {
     when (msg.role) {
-        Role.USER -> UserBubble(msg)
-        else -> AssistantTurn(msg)
+        Role.USER -> UserBubble(msg, onEditResend)
+        else -> AssistantTurn(msg, canRegenerate, onRegenerate)
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun UserBubble(msg: ChatMessage) {
+private fun UserBubble(msg: ChatMessage, onEditResend: (String) -> Unit) {
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
+    var menuOpen by remember { mutableStateOf(false) }
     val bg = if (msg.isError) MaterialTheme.colorScheme.errorContainer
     else MaterialTheme.colorScheme.primaryContainer
     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-        Column(
-            Modifier
-                .widthIn(max = 320.dp)
-                // Asymmetric corners (a small "tail" corner) mark this as the sender's bubble.
-                .clip(RoundedCornerShape(20.dp, 20.dp, 6.dp, 20.dp))
-                .background(bg)
-                .combinedClickable(onClick = {}, onLongClick = { copyToClipboard(msg.text, clipboard, context) })
-                .padding(horizontal = 14.dp, vertical = 10.dp),
-        ) {
-            if (msg.text.isNotBlank()) Text(msg.text, style = MaterialTheme.typography.bodyLarge)
+        Box {
+            Column(
+                Modifier
+                    .widthIn(max = 320.dp)
+                    // Asymmetric corners (a small "tail" corner) mark this as the sender's bubble.
+                    .clip(RoundedCornerShape(20.dp, 20.dp, 6.dp, 20.dp))
+                    .background(bg)
+                    .combinedClickable(onClick = {}, onLongClick = { menuOpen = true })
+                    .padding(horizontal = 14.dp, vertical = 10.dp),
+            ) {
+                if (msg.text.isNotBlank()) Text(msg.text, style = MaterialTheme.typography.bodyLarge)
+            }
+            DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("Copy") },
+                    onClick = { copyToClipboard(msg.text, clipboard, context); menuOpen = false },
+                )
+                DropdownMenuItem(
+                    text = { Text("Edit & resend") },
+                    onClick = { onEditResend(msg.text); menuOpen = false },
+                )
+            }
         }
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun AssistantTurn(msg: ChatMessage) {
+private fun AssistantTurn(msg: ChatMessage, canRegenerate: Boolean, onRegenerate: () -> Unit) {
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
-    Column(
-        Modifier
-            .fillMaxWidth()
-            .combinedClickable(onClick = {}, onLongClick = { copyToClipboard(msg.text, clipboard, context) })
-            .padding(vertical = 2.dp),
-    ) {
-        if (msg.thinking.isNotBlank()) ThinkingCard(msg.thinking)
-        msg.tools.forEach { ToolCard(it) }
-        if (msg.text.isNotBlank()) {
-            if (msg.isError) {
-                Surface(
-                    color = MaterialTheme.colorScheme.errorContainer,
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        msg.text,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(12.dp),
+    var menuOpen by remember { mutableStateOf(false) }
+    Box {
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .combinedClickable(onClick = {}, onLongClick = { menuOpen = true })
+                .padding(vertical = 2.dp),
+        ) {
+            if (msg.thinking.isNotBlank()) ThinkingCard(msg.thinking)
+            msg.tools.forEach { ToolCard(it) }
+            if (msg.text.isNotBlank()) {
+                if (msg.isError) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            msg.text,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(12.dp),
+                        )
+                    }
+                } else {
+                    val mdComponents = remember { chatMarkdownComponents() }
+                    Markdown(
+                        content = msg.text,
+                        colors = markdownColor(),
+                        typography = markdownTypography(),
+                        components = mdComponents,
                     )
                 }
-            } else {
-                val mdComponents = remember { chatMarkdownComponents() }
-                Markdown(
-                    content = msg.text,
-                    colors = markdownColor(),
-                    typography = markdownTypography(),
-                    components = mdComponents,
-                )
+            }
+            if (msg.isStreaming && msg.text.isBlank() && msg.tools.isEmpty()) {
+                TypingIndicator()
             }
         }
-        if (msg.isStreaming && msg.text.isBlank() && msg.tools.isEmpty()) {
-            TypingIndicator()
+        DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+            DropdownMenuItem(
+                text = { Text("Copy") },
+                onClick = { copyToClipboard(msg.text, clipboard, context); menuOpen = false },
+            )
+            if (canRegenerate) {
+                DropdownMenuItem(
+                    text = { Text("Regenerate") },
+                    onClick = { onRegenerate(); menuOpen = false },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -202,8 +202,8 @@ private fun UserBubble(msg: ChatMessage, onEditResend: (String) -> Unit) {
                     // Asymmetric corners (a small "tail" corner) mark this as the sender's bubble.
                     .clip(RoundedCornerShape(20.dp, 20.dp, 6.dp, 20.dp))
                     .background(bg)
-                    .combinedClickable(onClick = {}, onLongClick = { menuOpen = true })
-                    .padding(horizontal = 14.dp, vertical = 10.dp),
+                    .padding(horizontal = 14.dp, vertical = 10.dp)
+                    .combinedClickable(onClick = {}, onLongClick = { menuOpen = true }),
             ) {
                 if (msg.text.isNotBlank()) Text(msg.text, style = MaterialTheme.typography.bodyLarge)
             }
@@ -231,8 +231,8 @@ private fun AssistantTurn(msg: ChatMessage, canRegenerate: Boolean, onRegenerate
         Column(
             Modifier
                 .fillMaxWidth()
-                .combinedClickable(onClick = {}, onLongClick = { menuOpen = true })
-                .padding(vertical = 2.dp),
+                .padding(vertical = 2.dp)
+                .combinedClickable(onClick = {}, onLongClick = { menuOpen = true }),
         ) {
             if (msg.thinking.isNotBlank()) ThinkingCard(msg.thinking)
             msg.tools.forEach { ToolCard(it) }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -81,6 +83,7 @@ fun ChatScreen(
     val commands by vm.commands.collectAsStateWithLifecycle()
     val pathItems by vm.pathItems.collectAsStateWithLifecycle()
     var draft by remember { mutableStateOf("") }
+    val focusRequester = remember { FocusRequester() }
     val initialDraft by vm.initialDraft.collectAsStateWithLifecycle()
     androidx.compose.runtime.LaunchedEffect(initialDraft) {
         initialDraft?.takeIf { it.isNotEmpty() }?.let { draft = it; vm.clearInitialDraft() }
@@ -212,7 +215,7 @@ fun ChatScreen(
                 OutlinedTextField(
                     value = draft,
                     onValueChange = { draft = it },
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).focusRequester(focusRequester),
                     placeholder = { Text("Message Hermes…") },
                     maxLines = 5,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
@@ -275,7 +278,14 @@ fun ChatScreen(
                     }
                 }
             } else {
-                ChatMessageList(state = state, sessionId = sessionId, modifier = Modifier.weight(1f))
+                ChatMessageList(
+                    state = state,
+                    sessionId = sessionId,
+                    modifier = Modifier.weight(1f),
+                    isGenerating = state.isGenerating,
+                    onRegenerate = { vm.regenerate() },
+                    onEditResend = { text -> draft = text; focusRequester.requestFocus() },
+                )
             }
         }
     }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -186,6 +186,13 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    /** Re-ask: re-submit the last user prompt (appends a new answer; the gateway can't replace). */
+    fun regenerate() {
+        if (_state.value.isGenerating) return
+        val prompt = lastUserMessageText(_state.value.messages) ?: return
+        send(prompt)
+    }
+
     fun stop() { viewModelScope.launch { runCatching { chat.interrupt(sessionId) } } }
 
     /** Attach an image (base64) to the session; surfaces a system note when done. */

--- a/app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt
@@ -1,0 +1,8 @@
+package com.hermes.client.ui.chat
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+
+/** The text of the most recent USER message, or null if there is none (used to re-ask). */
+fun lastUserMessageText(messages: List<ChatMessage>): String? =
+    messages.lastOrNull { it.role == Role.USER }?.text?.takeIf { it.isNotBlank() }

--- a/app/src/test/java/com/hermes/client/ui/chat/MessageActionsTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/MessageActionsTest.kt
@@ -1,0 +1,32 @@
+package com.hermes.client.ui.chat
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MessageActionsTest {
+    private fun m(id: String, role: Role, text: String) = ChatMessage(id = id, role = role, text = text)
+
+    @Test fun returns_last_user_text_ignoring_trailing_assistant() {
+        val msgs = listOf(
+            m("u0", Role.USER, "first"),
+            m("a0", Role.ASSISTANT, "answer 0"),
+            m("u1", Role.USER, "second"),
+            m("a1", Role.ASSISTANT, "answer 1"),
+        )
+        assertEquals("second", lastUserMessageText(msgs))
+    }
+    @Test fun null_when_no_user_message() {
+        assertNull(lastUserMessageText(listOf(m("a0", Role.ASSISTANT, "hi"), m("s0", Role.SYSTEM, "sys"))))
+        assertNull(lastUserMessageText(emptyList()))
+    }
+    @Test fun blank_last_user_returns_null() {
+        assertNull(lastUserMessageText(listOf(m("u0", Role.USER, "   "))))
+    }
+    @Test fun picks_the_last_user_when_several() {
+        val msgs = listOf(m("u0", Role.USER, "a"), m("u1", Role.USER, "b"), m("u2", Role.USER, "c"))
+        assertEquals("c", lastUserMessageText(msgs))
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-regenerate-edit-resend.md
+++ b/docs/superpowers/plans/2026-07-07-regenerate-edit-resend.md
@@ -1,0 +1,220 @@
+# Regenerate + Edit-and-Resend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-message action menu to chat — Copy, Edit & resend (user), Regenerate (last answer) — reusing the existing `send()`.
+
+**Architecture:** A pure `lastUserMessageText` helper + a `ChatViewModel.regenerate()` that re-submits it; a per-bubble `DropdownMenu` extends the current long-press-copy; `ChatScreen` wires Edit & resend to prefill+focus the composer. Both actions **append** (the gateway can't truncate).
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes.** Reuse `send()` → `chat.submit` (`prompt.submit`); both actions append, they cannot replace/truncate. Material 3.
+- Multi-tenant isolation preserved (accent unchanged).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `domain/Models.kt`: `data class ChatMessage(id: String, role: Role, text: String, tools, thinking, isStreaming, isError, interrupted)`; `enum class Role { USER, ASSISTANT, SYSTEM }`.
+- `ui/chat/ChatViewModel.kt`: `fun send(text: String)` (appends a user message + `chat.submit`); `_state.value.isGenerating`; `_state.value.messages: List<ChatMessage>`.
+- `ui/chat/ChatComponents.kt`: `UserBubble`/`AssistantTurn` each wrap a `Column` with `Modifier.combinedClickable(onClick = {}, onLongClick = { copyToClipboard(msg.text, clipboard, context) })`; `copyToClipboard(text, clipboard, context)` sets the clipboard + Toast. The message-list composable renders these per `msg`.
+- `ui/chat/ChatScreen.kt`: `var draft by remember { mutableStateOf("") }`; the composer `OutlinedTextField(value = draft, …)`.
+- `DropdownMenu` pattern: `CronScreen.kt`'s row overflow menu.
+
+---
+
+### Task 1: Pure `lastUserMessageText` (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/chat/MessageActionsTest.kt`
+
+**Interfaces:** Produces `fun lastUserMessageText(messages: List<ChatMessage>): String?`.
+
+- [ ] **Step 1: Write the failing test** — create `MessageActionsTest.kt`:
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MessageActionsTest {
+    private fun m(id: String, role: Role, text: String) = ChatMessage(id = id, role = role, text = text)
+
+    @Test fun returns_last_user_text_ignoring_trailing_assistant() {
+        val msgs = listOf(
+            m("u0", Role.USER, "first"),
+            m("a0", Role.ASSISTANT, "answer 0"),
+            m("u1", Role.USER, "second"),
+            m("a1", Role.ASSISTANT, "answer 1"),
+        )
+        assertEquals("second", lastUserMessageText(msgs))
+    }
+    @Test fun null_when_no_user_message() {
+        assertNull(lastUserMessageText(listOf(m("a0", Role.ASSISTANT, "hi"), m("s0", Role.SYSTEM, "sys"))))
+        assertNull(lastUserMessageText(emptyList()))
+    }
+    @Test fun blank_last_user_returns_null() {
+        assertNull(lastUserMessageText(listOf(m("u0", Role.USER, "   "))))
+    }
+    @Test fun picks_the_last_user_when_several() {
+        val msgs = listOf(m("u0", Role.USER, "a"), m("u1", Role.USER, "b"), m("u2", Role.USER, "c"))
+        assertEquals("c", lastUserMessageText(msgs))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MessageActionsTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved `lastUserMessageText`.
+
+- [ ] **Step 3: Implement `MessageActions.kt`**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+
+/** The text of the most recent USER message, or null if there is none (used to re-ask). */
+fun lastUserMessageText(messages: List<ChatMessage>): String? =
+    messages.lastOrNull { it.role == Role.USER }?.text?.takeIf { it.isNotBlank() }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MessageActionsTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt app/src/test/java/com/hermes/client/ui/chat/MessageActionsTest.kt
+git commit -m "feat(chat): lastUserMessageText helper for regenerate"
+```
+
+---
+
+### Task 2: `ChatViewModel.regenerate()`
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt`
+
+**Interfaces:** Consumes `lastUserMessageText` (Task 1). Produces `fun regenerate()`.
+
+- [ ] **Step 1: Add `regenerate()`** (near `send()`)
+
+```kotlin
+    /** Re-ask: re-submit the last user prompt (appends a new answer; the gateway can't replace). */
+    fun regenerate() {
+        if (_state.value.isGenerating) return
+        val prompt = lastUserMessageText(_state.value.messages) ?: return
+        send(prompt)
+    }
+```
+
+- [ ] **Step 2: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+git commit -m "feat(chat): regenerate() re-asks the last prompt"
+```
+
+---
+
+### Task 3: Per-message action menu + composer wiring
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt`, `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `vm.regenerate()` (Task 2).
+
+- [ ] **Step 1: Thread action params through the message list + bubbles (`ChatComponents.kt`)**
+
+Read the file first. The message-list composable (the one that iterates `messages` and renders `UserBubble`/`AssistantTurn`) gains parameters: `isGenerating: Boolean`, `onEditResend: (String) -> Unit`, `onRegenerate: () -> Unit`. Compute once inside it: `val lastAssistantId = messages.lastOrNull { it.role == Role.ASSISTANT }?.id`. Pass down to each bubble: `isGenerating`, `lastAssistantId`, `onEditResend`, `onRegenerate` (or pass the already-resolved booleans `canRegenerate = msg.id == lastAssistantId && !isGenerating`).
+
+- [ ] **Step 2: Replace the long-press-copy with a `DropdownMenu` on each bubble**
+
+For **both** `UserBubble` and `AssistantTurn`, wrap the bubble `Column` in a `Box`, hoist `var menuFor by remember { mutableStateOf(false) }` (per-bubble), change `onLongClick = { menuFor = true }`, and add the menu as a sibling in the Box:
+```kotlin
+        androidx.compose.material3.DropdownMenu(expanded = menuFor, onDismissRequest = { menuFor = false }) {
+            androidx.compose.material3.DropdownMenuItem(
+                text = { Text("Copy") },
+                onClick = { copyToClipboard(msg.text, clipboard, context); menuFor = false },
+            )
+            if (msg.role == Role.USER) {
+                androidx.compose.material3.DropdownMenuItem(
+                    text = { Text("Edit & resend") },
+                    onClick = { onEditResend(msg.text); menuFor = false },
+                )
+            }
+            if (msg.id == lastAssistantId && !isGenerating) {
+                androidx.compose.material3.DropdownMenuItem(
+                    text = { Text("Regenerate") },
+                    onClick = { onRegenerate(); menuFor = false },
+                )
+            }
+        }
+```
+(Keep `onClick = {}` on the bubble; only `onLongClick` changes to open the menu. `clipboard`/`context` are already in scope where `copyToClipboard` is called today; if a bubble doesn't have them, add `val context = LocalContext.current` / `val clipboard = LocalClipboardManager.current` as the existing copy call uses.)
+
+- [ ] **Step 3: Wire the callbacks in `ChatScreen.kt`**
+
+Read the composer. Add `val focusRequester = remember { androidx.compose.ui.focus.FocusRequester() }` and attach `Modifier.focusRequester(focusRequester)` to the composer `OutlinedTextField` (merge with its existing `Modifier.weight(1f)` etc). Pass to the message-list composable: `isGenerating = state.isGenerating`, `onRegenerate = { vm.regenerate() }`, `onEditResend = { text -> draft = text; focusRequester.requestFocus() }`.
+
+- [ ] **Step 4: Compile + suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head` → `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2` → `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): per-message menu — Copy / Edit & resend / Regenerate"
+```
+
+---
+
+### Task 4: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`; point at the mock (`http://10.0.2.2:8899`) and open a chat with history (the mock's `s2` has a user + assistant turn).
+
+- [ ] **Step 2: Verify**
+
+1. **Long-press a user bubble** → menu with **Copy** + **Edit & resend**; tapping **Edit & resend** loads that text into the composer (focused); editing + Send appends a new turn.
+2. **Long-press the last assistant turn** → menu with **Copy** + **Regenerate**; tapping **Regenerate** appends a fresh answer to the last prompt. An **older** assistant turn's menu shows **only Copy**. While generating, **Regenerate is absent**.
+3. **Copy** works from the menu on any bubble.
+4. Tenant accent preserved.
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(chat): regenerate/edit-resend verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Element 1 (`lastUserMessageText`) → Task 1 (+ tests) ✓; Element 2 (`regenerate()`) → Task 2 ✓; Element 3 (per-message menu + Edit & resend prefill/focus + Regenerate gated to last-assistant-not-generating) → Task 3 ✓; on-device → Task 4 ✓. Deferred (true in-place edit/branch, gateway follow-up) intentionally absent, per the spec.
+- **Placeholder scan:** every code step shows full code; the one soft spot ("the message-list composable — read the file") is unavoidable (the exact composable name is discovered on read) but the params + menu code are fully specified; only the Task-4 verification commit is conditional.
+- **Type consistency:** `lastUserMessageText(messages): String?` (Task 1) consumed by `regenerate()` (Task 2); `regenerate()` wired as `onRegenerate` (Task 3); `onEditResend: (String) -> Unit`, `isGenerating`, `lastAssistantId`, `Role.USER/ASSISTANT`, `copyToClipboard(text, clipboard, context)` all match the codebase.
+
+**Ordering:** Task 1 (pure) → Task 2 (VM, consumes it) → Task 3 (`ChatComponents` + `ChatScreen`, consumes `regenerate`) → Task 4 verifies.

--- a/docs/superpowers/specs/2026-07-07-regenerate-edit-resend-design.md
+++ b/docs/superpowers/specs/2026-07-07-regenerate-edit-resend-design.md
@@ -1,0 +1,77 @@
+# Regenerate + Edit-and-Resend (chat) — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/regenerate-edit-resend`
+**Source:** improvement roadmap Phase 1 · Wave 2 (`docs/ideas/improvement-roadmap-2026-07-07.md`).
+
+## Goal
+
+Two chat ergonomics — **Regenerate** the last answer, and **Edit & resend** a prior user message — via a per-message action menu. **Client-only**, reusing the existing `send()`/`submit()`.
+
+## The gateway reality (drives the design — read this)
+
+The gateway has **no** message truncate / delete / edit / regenerate capability. The only chat send is the WS RPC `prompt.submit {session_id, text}`, which **always appends a new turn**. So true in-place edit/replace/branch is **not possible client-only**. This wave ships the honest "append" version:
+- **Regenerate = re-ask.** Re-submits the last user prompt → a fresh answer appended below (the old one stays).
+- **Edit & resend = reuse the prompt.** Prefills the composer with a user message's text to tweak and send as a new turn.
+
+Both are the ergonomic 80% (re-ask without retyping; reuse-and-tweak). **True in-place edit + branching is deferred to a gateway follow-up** (a `session.rewind` / `message.delete` endpoint) — noted below.
+
+## Hard constraints
+
+- **No gateway/bridge API changes.** Reuse `ChatViewModel.send(text)` → `ChatRepository.submit` (`prompt.submit`). Material 3.
+- Multi-tenant isolation preserved. No AI/assistant attribution in commits, files, or PRs.
+
+## Grounding (from exploration)
+
+- `ChatViewModel.send(text: String)` appends a client user message (`withUserMessage`) + calls `chat.submit(sessionId, text)` (or `slashExec` for `/`). `stop()`/`interrupt`. `state.isGenerating`. `ChatUiState.messages: List<ChatMessage>`.
+- `ChatMessage(id, role: Role{USER,ASSISTANT,SYSTEM}, text, tools, thinking, isStreaming, isError, interrupted)` (`domain/Models.kt`). No stable server id.
+- `ChatComponents.kt`: `UserBubble` + `AssistantTurn` each wrap a `Column` with `Modifier.combinedClickable(onClick = {}, onLongClick = { copyToClipboard(msg.text, …) })` — the long-press-copy is the only per-message affordance today; `onClick` is a no-op (free real estate). `copyToClipboard` + Toast.
+- `draft` is `var draft by remember { mutableStateOf("") }` in `ChatScreen` (a `String`).
+
+## Element 1 — Pure helper (`ui/chat/MessageActions.kt`, unit-tested)
+```kotlin
+/** The text of the most recent USER message, or null if there is none (used to re-ask). */
+fun lastUserMessageText(messages: List<ChatMessage>): String? =
+    messages.lastOrNull { it.role == Role.USER }?.text?.takeIf { it.isNotBlank() }
+```
+
+## Element 2 — `ChatViewModel.regenerate()`
+```kotlin
+/** Re-ask: re-submit the last user prompt (appends a new answer; the gateway can't replace). */
+fun regenerate() {
+    if (_state.value.isGenerating) return
+    val prompt = lastUserMessageText(_state.value.messages) ?: return
+    send(prompt)
+}
+```
+(No new network call — `send()` already appends the user turn + streams the reply.)
+
+## Element 3 — Per-message action menu (`ChatComponents.kt` + `ChatScreen.kt`)
+
+Extend the long-press affordance from "copy toast" to a small **`DropdownMenu`** per bubble:
+- Wrap each bubble in a `Box`; hoist `var menuFor by remember { mutableStateOf<String?>(null) }` in the message-list scope. `onLongClick = { menuFor = msg.id }` opens it (`DropdownMenu(expanded = menuFor == msg.id, onDismissRequest = { menuFor = null })`).
+- **Items (contextual):**
+  - **Copy** — all bubbles → `copyToClipboard(msg.text, …)` (keep the existing helper); `menuFor = null`.
+  - **Edit & resend** — only `role == USER` → `onEditResend(msg.text)`; `menuFor = null`.
+  - **Regenerate** — only when `msg.id == lastAssistantId` **and** `!isGenerating` → `onRegenerate()`; `menuFor = null`.
+- The message list computes `val lastAssistantId = messages.lastOrNull { it.role == Role.ASSISTANT }?.id` and threads `isGenerating`, `onEditResend: (String) -> Unit`, `onRegenerate: () -> Unit` down to the bubbles.
+- **`ChatScreen` wiring:**
+  - `onRegenerate = { vm.regenerate() }`.
+  - `onEditResend = { text -> draft = text; focusRequester.requestFocus() }` — add a `val focusRequester = remember { FocusRequester() }` on the composer `OutlinedTextField` (`Modifier.focusRequester(focusRequester)`), so tapping Edit & resend loads the text into the composer and focuses it for editing. (`draft` is replaced, not appended — this is "load this message to edit"; the rare unsent-draft case is acceptable.)
+
+## Testing
+
+- **Unit (pure), TDD — `MessageActionsTest`:** `lastUserMessageText` — last user's text with trailing user/assistant/system mix; null when there is no user message; skips a blank user message → null; picks the LAST user when several exist.
+- **On-device:**
+  1. Long-press a **user** bubble → menu shows **Copy** + **Edit & resend**; tapping Edit & resend prefills the composer with that text (editable, focused); editing + Send appends a new turn.
+  2. Long-press the **last assistant** turn → menu shows **Copy** + **Regenerate**; tapping Regenerate appends a fresh answer to the same last prompt. An **older** assistant turn's menu shows only Copy (no Regenerate). Regenerate is absent while generating.
+  3. Copy still works from the menu on any bubble.
+  4. Tenant accent preserved.
+
+## Not doing (YAGNI) / deferred
+
+- **True in-place edit + branching / replacing the old answer** — needs a gateway `session.rewind` / `message.delete` endpoint (a **Phase-6 / gateway-assist follow-up**). This wave is the honest append version.
+- Version arrows / multi-response navigation.
+- Editing an assistant message; deleting a message.
+- Any gateway/API change.


### PR DESCRIPTION
## Promote develop → main (production 0.1.41)

Promotes regenerate + edit-and-resend (roadmap Phase 1 · Wave 2) to production. main was last at 0.1.40 (#72).

### What ships to production (0.1.41)
Client-only, no gateway changes:
- A per-message chat menu (long-press) — **Copy** (all bubbles), **Edit & resend** (user bubbles → prefills+focuses the composer), **Regenerate** (last assistant turn → re-asks the last prompt).
- Both actions **append** (the gateway can't truncate); true in-place edit/branch is a documented gateway follow-up.

Built via spec → plan → subagent-driven development with per-task reviews; on-device verified (menu gating + Edit & resend prefill). 4 new unit tests. No bridge/gateway API changes.
