### PR TITLE
Chat: richer attachments (camera + multi-image staging)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,5 +47,15 @@
         <receiver
             android:name=".notifications.NotificationActionReceiver"
             android:exported="false" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/app/src/main/java/com/hermes/client/ui/chat/Attachments.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/Attachments.kt
@@ -1,0 +1,17 @@
+package com.hermes.client.ui.chat
+
+/** A picked-but-unsent attachment, held locally until Send. Identity is [id] (bytes excluded). */
+class PendingAttachment(val id: String, val bytes: ByteArray, val mimeType: String) {
+    override fun equals(other: Any?) = other is PendingAttachment && other.id == id
+    override fun hashCode() = id.hashCode()
+}
+
+const val ATTACH_CAP = 6
+
+/** Add [a] unless already at [cap]; returns the list unchanged when full. */
+fun List<PendingAttachment>.plusCapped(a: PendingAttachment, cap: Int = ATTACH_CAP): List<PendingAttachment> =
+    if (size >= cap) this else this + a
+
+/** True when a message may be sent: connected, has text or an attachment, and not mid-generation. */
+fun canSend(connected: Boolean, hasText: Boolean, hasAttachments: Boolean, isGenerating: Boolean): Boolean =
+    connected && (hasText || hasAttachments) && !isGenerating

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
 import java.io.File
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -24,13 +25,17 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.AttachFile
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.AlertDialog
@@ -58,8 +63,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -111,7 +119,7 @@ fun ChatScreen(
         draft = base + text + (if (text.endsWith(":")) "" else " ")
     }
     val connected = connState is ConnectionState.Connected
-    val canSend = connected && draft.isNotBlank() && !state.isGenerating
+    val canSend = canSend(connected, draft.isNotBlank(), state.pendingAttachments.isNotEmpty(), state.isGenerating)
     val haptic = LocalHapticFeedback.current
 
     fun submit() {
@@ -209,71 +217,110 @@ fun ChatScreen(
             )
         },
         bottomBar = {
-            Row(
+            Column(
                 // targetSdk 35+ forces edge-to-edge on Android 15+, so the window no
                 // longer resizes for the keyboard — the composer must inset itself.
                 // union() takes max(ime, navBars) so it lifts above the keyboard when
                 // open and clears the nav bar when closed, without double-padding.
                 Modifier
                     .fillMaxWidth()
-                    .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars))
-                    .padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+                    .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars)),
             ) {
-                com.hermes.client.ui.components.ProfileAvatar(activeProfile)
-                Spacer(Modifier.width(4.dp))
-                var attachMenu by remember { mutableStateOf(false) }
-                Box {
-                    IconButton(onClick = { attachMenu = true }, enabled = connected) {
-                        Icon(Icons.Rounded.AttachFile, contentDescription = "Attach")
-                    }
-                    DropdownMenu(expanded = attachMenu, onDismissRequest = { attachMenu = false }) {
-                        DropdownMenuItem(
-                            text = { Text("Camera") },
-                            onClick = { attachMenu = false; launchCamera() },
-                        )
-                        DropdownMenuItem(
-                            text = { Text("Photo library") },
-                            onClick = {
-                                attachMenu = false
-                                pickPhotos.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
-                                )
-                            },
-                        )
+                if (state.pendingAttachments.isNotEmpty()) {
+                    LazyRow(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(state.pendingAttachments, key = { it.id }) { a ->
+                            val thumb = remember(a.id) {
+                                android.graphics.BitmapFactory.decodeByteArray(a.bytes, 0, a.bytes.size)?.asImageBitmap()
+                            }
+                            Box(Modifier.size(56.dp)) {
+                                if (thumb != null) {
+                                    Image(
+                                        bitmap = thumb,
+                                        contentDescription = "Attachment",
+                                        modifier = Modifier.size(56.dp).clip(RoundedCornerShape(10.dp)),
+                                        contentScale = ContentScale.Crop,
+                                    )
+                                } else {
+                                    Box(Modifier.size(56.dp).clip(RoundedCornerShape(10.dp)).background(MaterialTheme.colorScheme.surfaceVariant))
+                                }
+                                IconButton(
+                                    onClick = { vm.removeAttachment(a.id) },
+                                    modifier = Modifier.align(Alignment.TopEnd).size(20.dp),
+                                ) {
+                                    Icon(
+                                        Icons.Rounded.Close,
+                                        contentDescription = "Remove attachment",
+                                        tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
-                if (speechAvailable) {
-                    IconButton(onClick = { startDictation() }) {
-                        Icon(
-                            Icons.Rounded.Mic,
-                            contentDescription = "Voice input",
-                            tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
-                        )
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    com.hermes.client.ui.components.ProfileAvatar(activeProfile)
+                    Spacer(Modifier.width(4.dp))
+                    var attachMenu by remember { mutableStateOf(false) }
+                    Box {
+                        IconButton(onClick = { attachMenu = true }, enabled = connected) {
+                            Icon(Icons.Rounded.AttachFile, contentDescription = "Attach")
+                        }
+                        DropdownMenu(expanded = attachMenu, onDismissRequest = { attachMenu = false }) {
+                            DropdownMenuItem(
+                                text = { Text("Camera") },
+                                onClick = { attachMenu = false; launchCamera() },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Photo library") },
+                                onClick = {
+                                    attachMenu = false
+                                    pickPhotos.launch(
+                                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                                    )
+                                },
+                            )
+                        }
                     }
-                }
-                OutlinedTextField(
-                    value = draft,
-                    onValueChange = { draft = it },
-                    modifier = Modifier.weight(1f).focusRequester(focusRequester),
-                    placeholder = { Text("Message Hermes…") },
-                    maxLines = 5,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
-                    keyboardActions = KeyboardActions(onSend = { submit() }),
-                )
-                Spacer(Modifier.width(8.dp))
-                if (state.isGenerating) {
-                    IconButton(onClick = { vm.stop() }) {
-                        Icon(Icons.Rounded.Stop, contentDescription = "Stop")
+                    if (speechAvailable) {
+                        IconButton(onClick = { startDictation() }) {
+                            Icon(
+                                Icons.Rounded.Mic,
+                                contentDescription = "Voice input",
+                                tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                            )
+                        }
                     }
-                } else {
-                    IconButton(onClick = { submit() }, enabled = canSend) {
-                        Icon(
-                            Icons.AutoMirrored.Rounded.Send,
-                            contentDescription = "Send",
-                            tint = if (canSend) com.hermes.client.ui.components.AccentChrome.fabContainer
-                            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                        )
+                    OutlinedTextField(
+                        value = draft,
+                        onValueChange = { draft = it },
+                        modifier = Modifier.weight(1f).focusRequester(focusRequester),
+                        placeholder = { Text("Message Hermes…") },
+                        maxLines = 5,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                        keyboardActions = KeyboardActions(onSend = { submit() }),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    if (state.isGenerating) {
+                        IconButton(onClick = { vm.stop() }) {
+                            Icon(Icons.Rounded.Stop, contentDescription = "Stop")
+                        }
+                    } else {
+                        IconButton(onClick = { submit() }, enabled = canSend) {
+                            Icon(
+                                Icons.AutoMirrored.Rounded.Send,
+                                contentDescription = "Send",
+                                tint = if (canSend) com.hermes.client.ui.components.AccentChrome.fabContainer
+                                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -145,7 +145,9 @@ fun ChatScreen(
     }
 
     // Camera: capture into a FileProvider cache uri, then read it back. No CAMERA permission (delegates).
-    var captureUri by remember { mutableStateOf<Uri?>(null) }
+    // rememberSaveable (Uri is Parcelable): survive process death while the camera app is foregrounded,
+    // so the captured photo isn't dropped when we return.
+    var captureUri by rememberSaveable { mutableStateOf<Uri?>(null) }
     val takePhoto = androidx.activity.compose.rememberLauncherForActivityResult(
         ActivityResultContracts.TakePicture(),
     ) { ok ->

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -154,6 +154,9 @@ fun ChatScreen(
         if (ok) captureUri?.let { uri -> readBytes(uri)?.let { vm.stageAttachment(it, "image/jpeg") } }
     }
     fun launchCamera() {
+        // Prior captures are already staged in-memory, so their temp files are disposable —
+        // sweep them so cacheDir doesn't grow unbounded across captures.
+        context.cacheDir.listFiles { f -> f.name.startsWith("capture_") }?.forEach { it.delete() }
         val file = File(context.cacheDir, "capture_${System.currentTimeMillis()}.jpg")
         val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
         captureUri = uri
@@ -234,9 +237,7 @@ fun ChatScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(state.pendingAttachments, key = { it.id }) { a ->
-                            val thumb = remember(a.id) {
-                                android.graphics.BitmapFactory.decodeByteArray(a.bytes, 0, a.bytes.size)?.asImageBitmap()
-                            }
+                            val thumb = remember(a.id) { decodeThumbnail(a.bytes, reqPx = 200)?.asImageBitmap() }
                             Box(Modifier.size(56.dp)) {
                                 if (thumb != null) {
                                     Image(
@@ -459,3 +460,17 @@ private fun ConnectionBanner(state: ConnectionState, onRetry: () -> Unit) {
     }
 }
 
+
+/**
+ * Decode [bytes] to a Bitmap downsampled so its largest side is roughly [reqPx] px — a chip thumbnail
+ * never needs full resolution, and decoding a 12MP photo at full size (×ATTACH_CAP) risks OOM/jank.
+ */
+private fun decodeThumbnail(bytes: ByteArray, reqPx: Int): android.graphics.Bitmap? {
+    val bounds = android.graphics.BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+    var sample = 1
+    val maxDim = maxOf(bounds.outWidth, bounds.outHeight)
+    while (maxDim > 0 && maxDim / sample > reqPx * 2) sample *= 2
+    val opts = android.graphics.BitmapFactory.Options().apply { inSampleSize = sample }
+    return android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
+}

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -1,11 +1,17 @@
 package com.hermes.client.ui.chat
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 
+import android.net.Uri
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
+import java.io.File
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.WindowInsets
@@ -29,6 +35,8 @@ import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -113,18 +121,33 @@ fun ChatScreen(
         draft = ""
     }
 
-    // Image attach: pick an image, base64-encode its bytes, attach to the session.
+    // Image attach: read picked/captured bytes and stage them onto the session.
     val context = androidx.compose.ui.platform.LocalContext.current
-    val pickImage = androidx.activity.compose.rememberLauncherForActivityResult(
-        androidx.activity.result.contract.ActivityResultContracts.GetContent(),
-    ) { uri ->
-        if (uri != null) {
-            runCatching {
-                val mime = context.contentResolver.getType(uri) ?: "image/*"
-                val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() } ?: return@runCatching
-                vm.stageAttachment(bytes, mime)
-            }
+
+    fun readBytes(uri: Uri): ByteArray? =
+        runCatching { context.contentResolver.openInputStream(uri)?.use { it.readBytes() } }.getOrNull()
+
+    // Photo library: multi-select via the system photo picker (no permission).
+    val pickPhotos = androidx.activity.compose.rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia(ATTACH_CAP),
+    ) { uris ->
+        uris.forEach { uri ->
+            readBytes(uri)?.let { vm.stageAttachment(it, context.contentResolver.getType(uri) ?: "image/*") }
         }
+    }
+
+    // Camera: capture into a FileProvider cache uri, then read it back. No CAMERA permission (delegates).
+    var captureUri by remember { mutableStateOf<Uri?>(null) }
+    val takePhoto = androidx.activity.compose.rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture(),
+    ) { ok ->
+        if (ok) captureUri?.let { uri -> readBytes(uri)?.let { vm.stageAttachment(it, "image/jpeg") } }
+    }
+    fun launchCamera() {
+        val file = File(context.cacheDir, "capture_${System.currentTimeMillis()}.jpg")
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        captureUri = uri
+        runCatching { takePhoto.launch(uri) }
     }
 
     // Voice dictation: the system speech recognizer returns a transcript we append to the draft.
@@ -199,8 +222,26 @@ fun ChatScreen(
             ) {
                 com.hermes.client.ui.components.ProfileAvatar(activeProfile)
                 Spacer(Modifier.width(4.dp))
-                IconButton(onClick = { pickImage.launch("image/*") }, enabled = connected) {
-                    Icon(Icons.Rounded.AttachFile, contentDescription = "Attach image")
+                var attachMenu by remember { mutableStateOf(false) }
+                Box {
+                    IconButton(onClick = { attachMenu = true }, enabled = connected) {
+                        Icon(Icons.Rounded.AttachFile, contentDescription = "Attach")
+                    }
+                    DropdownMenu(expanded = attachMenu, onDismissRequest = { attachMenu = false }) {
+                        DropdownMenuItem(
+                            text = { Text("Camera") },
+                            onClick = { attachMenu = false; launchCamera() },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Photo library") },
+                            onClick = {
+                                attachMenu = false
+                                pickPhotos.launch(
+                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                                )
+                            },
+                        )
+                    }
                 }
                 if (speechAvailable) {
                     IconButton(onClick = { startDictation() }) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -248,14 +248,23 @@ fun ChatScreen(
                                 } else {
                                     Box(Modifier.size(56.dp).clip(RoundedCornerShape(10.dp)).background(MaterialTheme.colorScheme.surfaceVariant))
                                 }
-                                IconButton(
-                                    onClick = { vm.removeAttachment(a.id) },
-                                    modifier = Modifier.align(Alignment.TopEnd).size(20.dp),
+                                // Remove badge: a dark circular scrim + white ✕ for contrast over any
+                                // thumbnail, with a comfortably tappable target (a 20.dp icon was too small).
+                                Box(
+                                    Modifier
+                                        .align(Alignment.TopEnd)
+                                        .padding(2.dp)
+                                        .size(26.dp)
+                                        .clip(androidx.compose.foundation.shape.CircleShape)
+                                        .background(androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.55f))
+                                        .clickable { vm.removeAttachment(a.id) },
+                                    contentAlignment = Alignment.Center,
                                 ) {
                                     Icon(
                                         Icons.Rounded.Close,
                                         contentDescription = "Remove attachment",
-                                        tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                                        tint = androidx.compose.ui.graphics.Color.White,
+                                        modifier = Modifier.size(16.dp),
                                     )
                                 }
                             }
@@ -272,7 +281,9 @@ fun ChatScreen(
                     Spacer(Modifier.width(4.dp))
                     var attachMenu by remember { mutableStateOf(false) }
                     Box {
-                        IconButton(onClick = { attachMenu = true }, enabled = connected) {
+                        // Not gated on connection: attaching only stages locally now; the upload
+                        // happens on Send, which canSend() already gates on being connected.
+                        IconButton(onClick = { attachMenu = true }) {
                             Icon(Icons.Rounded.AttachFile, contentDescription = "Attach")
                         }
                         DropdownMenu(expanded = attachMenu, onDismissRequest = { attachMenu = false }) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material3.minimumInteractiveComponentSize
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import kotlinx.coroutines.launch
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -131,16 +132,20 @@ fun ChatScreen(
 
     // Image attach: read picked/captured bytes and stage them onto the session.
     val context = androidx.compose.ui.platform.LocalContext.current
+    val attachScope = androidx.compose.runtime.rememberCoroutineScope()
 
     fun readBytes(uri: Uri): ByteArray? =
         runCatching { context.contentResolver.openInputStream(uri)?.use { it.readBytes() } }.getOrNull()
 
     // Photo library: multi-select via the system photo picker (no permission).
+    // Read bytes off the main thread (large images would otherwise jank/ANR the UI).
     val pickPhotos = androidx.activity.compose.rememberLauncherForActivityResult(
         ActivityResultContracts.PickMultipleVisualMedia(ATTACH_CAP),
     ) { uris ->
-        uris.forEach { uri ->
-            readBytes(uri)?.let { vm.stageAttachment(it, context.contentResolver.getType(uri) ?: "image/*") }
+        attachScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            uris.forEach { uri ->
+                readBytes(uri)?.let { vm.stageAttachment(it, context.contentResolver.getType(uri) ?: "image/*") }
+            }
         }
     }
 
@@ -151,7 +156,11 @@ fun ChatScreen(
     val takePhoto = androidx.activity.compose.rememberLauncherForActivityResult(
         ActivityResultContracts.TakePicture(),
     ) { ok ->
-        if (ok) captureUri?.let { uri -> readBytes(uri)?.let { vm.stageAttachment(it, "image/jpeg") } }
+        if (ok) captureUri?.let { uri ->
+            attachScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                readBytes(uri)?.let { vm.stageAttachment(it, "image/jpeg") }
+            }
+        }
     }
     fun launchCamera() {
         // Prior captures are already staged in-memory, so their temp files are disposable —
@@ -237,11 +246,17 @@ fun ChatScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(state.pendingAttachments, key = { it.id }) { a ->
-                            val thumb = remember(a.id) { decodeThumbnail(a.bytes, reqPx = 200)?.asImageBitmap() }
+                            // Decode off the main thread (produceState) — bitmap decode is CPU-heavy.
+                            val thumb by androidx.compose.runtime.produceState<androidx.compose.ui.graphics.ImageBitmap?>(null, a.id) {
+                                value = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                    decodeThumbnail(a.bytes, reqPx = 200)?.asImageBitmap()
+                                }
+                            }
                             Box(Modifier.size(56.dp)) {
-                                if (thumb != null) {
+                                val bmp = thumb
+                                if (bmp != null) {
                                     Image(
-                                        bitmap = thumb,
+                                        bitmap = bmp,
                                         contentDescription = "Attachment",
                                         modifier = Modifier.size(56.dp).clip(RoundedCornerShape(10.dp)),
                                         contentScale = ContentScale.Crop,

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -122,8 +122,7 @@ fun ChatScreen(
             runCatching {
                 val mime = context.contentResolver.getType(uri) ?: "image/*"
                 val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() } ?: return@runCatching
-                val b64 = android.util.Base64.encodeToString(bytes, android.util.Base64.NO_WRAP)
-                vm.attachImage(b64, mime)
+                vm.stageAttachment(bytes, mime)
             }
         }
     }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -15,6 +15,7 @@ data class ChatUiState(
     val pendingApproval: ApprovalRequest? = null,
     val pendingClarify: ClarifyRequest? = null,
     val isGenerating: Boolean = false,
+    val pendingAttachments: List<PendingAttachment> = emptyList(),
 ) {
     companion object { fun empty() = ChatUiState() }
 }
@@ -114,3 +115,9 @@ fun ChatUiState.markInterrupted(): ChatUiState {
     }
     return copy(messages = newMessages, isGenerating = false)
 }
+
+fun ChatUiState.withAttachment(a: PendingAttachment): ChatUiState =
+    copy(pendingAttachments = pendingAttachments.plusCapped(a))
+
+fun ChatUiState.withoutAttachment(id: String): ChatUiState =
+    copy(pendingAttachments = pendingAttachments.filterNot { it.id == id })

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -191,7 +191,9 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 atts.forEach { a ->
-                    val b64 = android.util.Base64.encodeToString(a.bytes, android.util.Base64.NO_WRAP)
+                    // java.util.Base64 (minSdk 26): consistent with the share-decode path and,
+                    // unlike android.util.Base64, not stubbed to null under JVM unit tests.
+                    val b64 = java.util.Base64.getEncoder().encodeToString(a.bytes)
                     runCatching { chat.attachImageBytes(sessionId, b64, a.mimeType) }
                         .onFailure { appendError("Attach failed: ${it.message}") }
                 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -120,13 +121,19 @@ class ChatViewModel @Inject constructor(
             val handle = runCatching { chat.resume(id, profileManager.active.value) }.getOrNull()
             handle?.let { sessionId = it }
             com.hermes.client.data.diagnostics.DebugLog.log("session", "resume($id) → handle=${handle ?: "none"}")
-            // A share may have handed off an image; attach it now that the session handle is live.
+            // A share may have handed off an image; stage it so it shows as a chip and is
+            // flushed to the gateway on the next send (rather than attaching immediately).
             ps?.let { share ->
                 val imgB64 = share.imageBase64
                 val imgMime = share.imageMime
                 if (imgB64 != null && imgMime != null) {
-                    runCatching { chat.attachImageBytes(sessionId, imgB64, imgMime) }
-                        .onSuccess { appendSystem("📎 Image attached — it will be sent with your next message.") }
+                    // java.util.Base64 (not android.util.Base64): the latter is stubbed to a
+                    // no-op returning null in the JVM unit-test environment (no Robolectric),
+                    // which would silently drop every shared image under test. java.util.Base64
+                    // is a real JDK class (available since API 26, our minSdk) so it decodes
+                    // correctly both on-device and under test.
+                    runCatching { java.util.Base64.getDecoder().decode(imgB64) }
+                        .onSuccess { bytes -> stageAttachment(bytes, imgMime) }
                         .onFailure { e ->
                             if (e is kotlinx.coroutines.CancellationException) throw e
                             appendError("Attach failed: ${e.message}")
@@ -169,12 +176,25 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    private var attachSeq = 0
+    fun stageAttachment(bytes: ByteArray, mimeType: String) {
+        _state.update { it.withAttachment(PendingAttachment("att-${attachSeq++}", bytes, mimeType)) }
+    }
+    fun removeAttachment(id: String) { _state.update { it.withoutAttachment(id) } }
+
     fun send(text: String) {
-        if (text.isBlank()) return
+        val atts = _state.value.pendingAttachments
+        if (text.isBlank() && atts.isEmpty()) return
         val isSlash = text.trimStart().startsWith("/")
-        _state.value = _state.value.withUserMessage(text)
+        val shown = text.ifBlank { "📎 ${atts.size} image${if (atts.size > 1) "s" else ""}" }
+        _state.value = _state.value.withUserMessage(shown).copy(pendingAttachments = emptyList())
         viewModelScope.launch {
             try {
+                atts.forEach { a ->
+                    val b64 = android.util.Base64.encodeToString(a.bytes, android.util.Base64.NO_WRAP)
+                    runCatching { chat.attachImageBytes(sessionId, b64, a.mimeType) }
+                        .onFailure { appendError("Attach failed: ${it.message}") }
+                }
                 // A leading "/" is a slash command — execute it (the gateway strips the slash)
                 // rather than prompting the model.
                 if (isSlash) chat.slashExec(sessionId, text.trim())
@@ -194,13 +214,6 @@ class ChatViewModel @Inject constructor(
     }
 
     fun stop() { viewModelScope.launch { runCatching { chat.interrupt(sessionId) } } }
-
-    /** Attach an image (base64) to the session; surfaces a system note when done. */
-    fun attachImage(dataBase64: String, mimeType: String) = viewModelScope.launch {
-        runCatching { chat.attachImageBytes(sessionId, dataBase64, mimeType) }
-            .onSuccess { appendSystem("📎 Image attached — it will be sent with your next message.") }
-            .onFailure { appendError("Attach failed: ${it.message}") }
-    }
 
     private fun appendSystem(text: String) {
         _state.value = _state.value.copy(

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="captures" path="." />
+</paths>

--- a/app/src/test/java/com/hermes/client/ui/chat/AttachmentsTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/AttachmentsTest.kt
@@ -1,0 +1,30 @@
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttachmentsTest {
+    private fun att(id: String) = PendingAttachment(id, byteArrayOf(1, 2, 3), "image/jpeg")
+
+    @Test fun canSend_requires_connection_content_and_not_generating() {
+        assertFalse(canSend(connected = true, hasText = false, hasAttachments = false, isGenerating = false))
+        assertTrue(canSend(connected = true, hasText = true, hasAttachments = false, isGenerating = false))
+        assertTrue(canSend(connected = true, hasText = false, hasAttachments = true, isGenerating = false))
+        assertFalse(canSend(connected = false, hasText = true, hasAttachments = true, isGenerating = false))
+        assertFalse(canSend(connected = true, hasText = true, hasAttachments = true, isGenerating = true))
+    }
+
+    @Test fun plusCapped_adds_under_cap_and_noops_at_cap() {
+        val four = (0 until 4).map { att("a$it") }
+        assertEquals(5, four.plusCapped(att("a4")).size)
+        val six = (0 until ATTACH_CAP).map { att("a$it") }
+        assertEquals(ATTACH_CAP, six.plusCapped(att("aX")).size) // no-op at cap
+    }
+
+    @Test fun pendingAttachment_equality_by_id() {
+        assertEquals(PendingAttachment("x", byteArrayOf(1), "image/png"), PendingAttachment("x", byteArrayOf(9, 9), "image/jpeg"))
+        assertFalse(PendingAttachment("x", byteArrayOf(1), "image/png") == PendingAttachment("y", byteArrayOf(1), "image/png"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -106,26 +106,24 @@ class ChatViewModelTest {
     }
 
     /**
-     * Highest-risk share invariant: a pending image share must be attached AFTER resume,
-     * using the LIVE post-resume session handle returned by chat.resume() — not the id
-     * open() was called with — since the gateway may hand back a different live handle
-     * and the attach must target the session it actually knows about.
+     * A pending image share must be staged as a local attachment chip (not attached to the
+     * gateway immediately) — it's flushed on the next send() using whatever the live
+     * post-resume sessionId is at that time.
      */
-    @Test fun open_attaches_pending_image_using_live_resumed_sessionId() = runTest {
+    @Test fun open_stages_pending_share_image_as_attachment() = runTest {
         coEvery { chatRepo.resume("s1", null) } returns "s1-live"
         pendingShareStore.put(
             "s1",
-            com.hermes.client.share.PendingShare(imageBase64 = "abc", imageMime = "image/png"),
+            // Valid base64 (decodes to "abc") — real decode logic runs in unit tests.
+            com.hermes.client.share.PendingShare(imageBase64 = "YWJj", imageMime = "image/png"),
         )
         val vm = buildVm()
         vm.open("s1")
         advanceUntilIdle()
 
-        coVerify { chatRepo.attachImageBytes("s1-live", "abc", "image/png") }
-        assertTrue(
-            "an 'Image attached' system message must land in state",
-            vm.state.value.messages.any { it.text.contains("Image attached") },
-        )
+        coVerify(exactly = 0) { chatRepo.attachImageBytes(any(), any(), any()) }
+        assertEquals(1, vm.state.value.pendingAttachments.size)
+        assertEquals("image/png", vm.state.value.pendingAttachments.first().mimeType)
     }
 
     /** A text-only pending share (no image) must not trigger an attach call at all. */

--- a/docs/superpowers/plans/2026-07-07-richer-attachments.md
+++ b/docs/superpowers/plans/2026-07-07-richer-attachments.md
@@ -1,0 +1,428 @@
+# Richer Attachments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Camera capture + multi-image in the chat composer, staged locally as removable thumbnail chips and sent on Send.
+
+**Architecture:** Picked images stage into `ChatUiState.pendingAttachments` (bytes held locally); `send()` flushes them via the existing `image.attach_bytes` RPC right before `prompt.submit`, then clears. Camera uses `TakePicture` + a `FileProvider` (no `CAMERA` permission); multi-image uses the system Photo Picker.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, AndroidX ActivityResult (`TakePicture`, `PickMultipleVisualMedia`), `FileProvider`, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes** — reuse `image.attach_bytes`. **PDF deferred**; multi-image is **best-effort** (degrades to last-wins if the gateway replaces).
+- **No `CAMERA` permission** — `TakePicture` delegates to the camera app.
+- Material 3; per-tenant accent (`AccentChrome`/`LocalProfileAccent`).
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `ChatRepository.attachImageBytes(sessionId, dataBase64, mimeType)` → `image.attach_bytes {session_id, data, mime_type}`. `submit(sessionId, text)` → `prompt.submit`.
+- `ChatViewModel`: `send(text)` adds `withUserMessage(text)` then `chat.slashExec`/`chat.submit`; `attachImage(b64, mime)` (to be removed) calls `attachImageBytes` + `appendSystem`. Share-intent image currently attaches directly. `_state` is a `MutableStateFlow<ChatUiState>` (uses `_state.value` and `_state.update { }`).
+- `ChatScreen`: `var draft by remember { mutableStateOf("") }`; `val context = LocalContext.current`; the `pickImage = rememberLauncherForActivityResult(GetContent()) { … vm.attachImage(...) }` launcher + the `AttachFile` `IconButton(onClick = { pickImage.launch("image/*") })`; `canSend = connected && draft.isNotBlank() && !state.isGenerating`; `submit()`.
+- `DropdownMenu` pattern: `CronScreen.kt`. Pure-test pattern: `MessageActionsTest`/`ScheduleTest`.
+
+---
+
+### Task 1: Pure model + helpers (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/Attachments.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/chat/AttachmentsTest.kt`
+
+**Interfaces:** Produces `class PendingAttachment(id, bytes, mimeType)`, `const val ATTACH_CAP`, `fun List<PendingAttachment>.plusCapped(a, cap)`, `fun canSend(connected, hasText, hasAttachments, isGenerating): Boolean`.
+
+- [ ] **Step 1: Write the failing test** — create `AttachmentsTest.kt`:
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttachmentsTest {
+    private fun att(id: String) = PendingAttachment(id, byteArrayOf(1, 2, 3), "image/jpeg")
+
+    @Test fun canSend_requires_connection_content_and_not_generating() {
+        assertFalse(canSend(connected = true, hasText = false, hasAttachments = false, isGenerating = false))
+        assertTrue(canSend(connected = true, hasText = true, hasAttachments = false, isGenerating = false))
+        assertTrue(canSend(connected = true, hasText = false, hasAttachments = true, isGenerating = false))
+        assertFalse(canSend(connected = false, hasText = true, hasAttachments = true, isGenerating = false))
+        assertFalse(canSend(connected = true, hasText = true, hasAttachments = true, isGenerating = true))
+    }
+
+    @Test fun plusCapped_adds_under_cap_and_noops_at_cap() {
+        val four = (0 until 4).map { att("a$it") }
+        assertEquals(5, four.plusCapped(att("a4")).size)
+        val six = (0 until ATTACH_CAP).map { att("a$it") }
+        assertEquals(ATTACH_CAP, six.plusCapped(att("aX")).size) // no-op at cap
+    }
+
+    @Test fun pendingAttachment_equality_by_id() {
+        assertEquals(PendingAttachment("x", byteArrayOf(1), "image/png"), PendingAttachment("x", byteArrayOf(9, 9), "image/jpeg"))
+        assertFalse(PendingAttachment("x", byteArrayOf(1), "image/png") == PendingAttachment("y", byteArrayOf(1), "image/png"))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*AttachmentsTest*' --console=plain 2>&1 | tail -6`
+Expected: FAIL — unresolved references.
+
+- [ ] **Step 3: Implement `Attachments.kt`**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+/** A picked-but-unsent attachment, held locally until Send. Identity is [id] (bytes excluded). */
+class PendingAttachment(val id: String, val bytes: ByteArray, val mimeType: String) {
+    override fun equals(other: Any?) = other is PendingAttachment && other.id == id
+    override fun hashCode() = id.hashCode()
+}
+
+const val ATTACH_CAP = 6
+
+/** Add [a] unless already at [cap]; returns the list unchanged when full. */
+fun List<PendingAttachment>.plusCapped(a: PendingAttachment, cap: Int = ATTACH_CAP): List<PendingAttachment> =
+    if (size >= cap) this else this + a
+
+/** True when a message may be sent: connected, has text or an attachment, and not mid-generation. */
+fun canSend(connected: Boolean, hasText: Boolean, hasAttachments: Boolean, isGenerating: Boolean): Boolean =
+    connected && (hasText || hasAttachments) && !isGenerating
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*AttachmentsTest*' --console=plain 2>&1 | tail -6`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/Attachments.kt app/src/test/java/com/hermes/client/ui/chat/AttachmentsTest.kt
+git commit -m "feat(chat): PendingAttachment model + canSend/plusCapped helpers"
+```
+
+---
+
+### Task 2: `ChatUiState` staging field + reducers
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt`
+
+**Interfaces:** Consumes `PendingAttachment`, `plusCapped` (Task 1). Produces `ChatUiState.pendingAttachments`, `ChatUiState.withAttachment(a)`, `ChatUiState.withoutAttachment(id)`.
+
+- [ ] **Step 1: Add the field to `ChatUiState`**
+
+Add to the `data class ChatUiState(...)` constructor (after `isGenerating`):
+```kotlin
+    val pendingAttachments: List<PendingAttachment> = emptyList(),
+```
+
+- [ ] **Step 2: Add the pure reducer helpers** (top-level in the same file, next to the other `ChatUiState.` extensions)
+
+```kotlin
+fun ChatUiState.withAttachment(a: PendingAttachment): ChatUiState =
+    copy(pendingAttachments = pendingAttachments.plusCapped(a))
+
+fun ChatUiState.withoutAttachment(id: String): ChatUiState =
+    copy(pendingAttachments = pendingAttachments.filterNot { it.id == id })
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+git commit -m "feat(chat): pendingAttachments state + reducers"
+```
+
+---
+
+### Task 3: `ChatViewModel` — stage / remove / send-flush + share path
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt`
+
+**Interfaces:** Consumes `withAttachment`/`withoutAttachment` (Task 2), `PendingAttachment` (Task 1). Produces `fun stageAttachment(bytes: ByteArray, mimeType: String)`, `fun removeAttachment(id: String)`, and a rewritten `fun send(text: String)`.
+
+- [ ] **Step 1: Add staging methods** (near `send()`)
+
+```kotlin
+    private var attachSeq = 0
+    fun stageAttachment(bytes: ByteArray, mimeType: String) {
+        _state.update { it.withAttachment(PendingAttachment("att-${attachSeq++}", bytes, mimeType)) }
+    }
+    fun removeAttachment(id: String) { _state.update { it.withoutAttachment(id) } }
+```
+
+- [ ] **Step 2: Rewrite `send(text)` to flush staged attachments before submit**
+
+Replace the existing `send(text)` body with:
+```kotlin
+    fun send(text: String) {
+        val atts = _state.value.pendingAttachments
+        if (text.isBlank() && atts.isEmpty()) return
+        val isSlash = text.trimStart().startsWith("/")
+        val shown = text.ifBlank { "📎 ${atts.size} image${if (atts.size > 1) "s" else ""}" }
+        _state.value = _state.value.withUserMessage(shown).copy(pendingAttachments = emptyList())
+        viewModelScope.launch {
+            try {
+                atts.forEach { a ->
+                    val b64 = android.util.Base64.encodeToString(a.bytes, android.util.Base64.NO_WRAP)
+                    runCatching { chat.attachImageBytes(sessionId, b64, a.mimeType) }
+                        .onFailure { appendError("Attach failed: ${it.message}") }
+                }
+                if (isSlash) chat.slashExec(sessionId, text.trim()) else chat.submit(sessionId, text)
+            } catch (e: Exception) {
+                appendError(e.message ?: "Failed to send message")
+            }
+        }
+    }
+```
+(Note: `withUserMessage` is called with `shown` so an attachment-only send shows a "📎 N images" bubble rather than a blank one.)
+
+- [ ] **Step 3: Reroute the share-intent image path + remove `attachImage`**
+
+Read the file for the share-intent handling (where a shared image's bytes/base64 were passed to `attachImageBytes`/`attachImage`) and the old `attachImage(dataBase64, mimeType)` method. Change the share path so the shared image is **staged** instead of directly attached: decode the shared image to a `ByteArray` and call `stageAttachment(bytes, mime)` (if the share currently carries base64, decode with `android.util.Base64.decode(b64, android.util.Base64.NO_WRAP)` to get the bytes). Then **delete** the now-unused `fun attachImage(...)` method. Confirm no other caller of `attachImage` remains (grep).
+
+- [ ] **Step 4: Compile + full suite**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head`
+Expected: `BUILD SUCCESSFUL`, no `FAILED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+git commit -m "feat(chat): stage attachments locally, flush on send; share stages too"
+```
+
+---
+
+### Task 4: FileProvider + camera/photo-picker launchers
+
+**Files:**
+- Modify: `app/src/main/AndroidManifest.xml`
+- Create: `app/src/main/res/xml/file_paths.xml`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `vm.stageAttachment(bytes, mimeType)` (Task 3), `ATTACH_CAP` (Task 1).
+
+- [ ] **Step 1: Declare the FileProvider** — inside `<application>` in `AndroidManifest.xml`:
+
+```xml
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+```
+
+- [ ] **Step 2: Create `res/xml/file_paths.xml`**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="captures" path="." />
+</paths>
+```
+
+- [ ] **Step 3: Add the pick launchers + a read helper in `ChatScreen`**
+
+Near the existing image launcher, add (and a local `readBytes` helper):
+```kotlin
+    fun readBytes(uri: android.net.Uri): ByteArray? =
+        runCatching { context.contentResolver.openInputStream(uri)?.use { it.readBytes() } }.getOrNull()
+
+    // Photo library: multi-select via the system photo picker (no permission).
+    val pickPhotos = rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia(ATTACH_CAP),
+    ) { uris ->
+        uris.forEach { uri ->
+            readBytes(uri)?.let { vm.stageAttachment(it, context.contentResolver.getType(uri) ?: "image/*") }
+        }
+    }
+
+    // Camera: capture into a FileProvider cache uri, then read it back. No CAMERA permission (delegates).
+    var captureUri by remember { mutableStateOf<android.net.Uri?>(null) }
+    val takePhoto = rememberLauncherForActivityResult(
+        androidx.activity.result.contract.ActivityResultContracts.TakePicture(),
+    ) { ok ->
+        if (ok) captureUri?.let { uri -> readBytes(uri)?.let { vm.stageAttachment(it, "image/jpeg") } }
+    }
+    fun launchCamera() {
+        val file = java.io.File(context.cacheDir, "capture_${System.currentTimeMillis()}.jpg")
+        val uri = androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        captureUri = uri
+        runCatching { takePhoto.launch(uri) }
+    }
+```
+
+- [ ] **Step 4: Replace the single attach button with a Camera / Photo library menu**
+
+Remove the old `pickImage` (`GetContent`) launcher and its `IconButton(onClick = { pickImage.launch("image/*") })`. In its place, in the composer `Row`, add:
+```kotlin
+        var attachMenu by remember { mutableStateOf(false) }
+        Box {
+            IconButton(onClick = { attachMenu = true }, enabled = connected) {
+                Icon(Icons.Rounded.AttachFile, contentDescription = "Attach")
+            }
+            androidx.compose.material3.DropdownMenu(expanded = attachMenu, onDismissRequest = { attachMenu = false }) {
+                androidx.compose.material3.DropdownMenuItem(
+                    text = { Text("Camera") },
+                    onClick = { attachMenu = false; launchCamera() },
+                )
+                androidx.compose.material3.DropdownMenuItem(
+                    text = { Text("Photo library") },
+                    onClick = {
+                        attachMenu = false
+                        pickPhotos.launch(
+                            androidx.activity.result.PickVisualMediaRequest(
+                                androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly,
+                            ),
+                        )
+                    },
+                )
+            }
+        }
+```
+
+- [ ] **Step 5: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/AndroidManifest.xml app/src/main/res/xml/file_paths.xml app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): camera + photo-picker attach via FileProvider (no CAMERA perm)"
+```
+
+---
+
+### Task 5: Staging chips UI + send gate wiring
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `canSend` (Task 1), `state.pendingAttachments` (Task 2), `vm.removeAttachment` + `vm.send` (Task 3).
+
+- [ ] **Step 1: Render the staging chips above the input row**
+
+In the composer's bottomBar, wrap the input `Row` in a `Column` and, above the input `Row`, add:
+```kotlin
+        if (state.pendingAttachments.isNotEmpty()) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(state.pendingAttachments, key = { it.id }) { a ->
+                    val thumb = remember(a.id) {
+                        android.graphics.BitmapFactory.decodeByteArray(a.bytes, 0, a.bytes.size)?.asImageBitmap()
+                    }
+                    Box(Modifier.size(56.dp)) {
+                        if (thumb != null) {
+                            Image(
+                                bitmap = thumb,
+                                contentDescription = "Attachment",
+                                modifier = Modifier.size(56.dp).clip(RoundedCornerShape(10.dp)),
+                                contentScale = ContentScale.Crop,
+                            )
+                        } else {
+                            Box(Modifier.size(56.dp).clip(RoundedCornerShape(10.dp)).background(MaterialTheme.colorScheme.surfaceVariant))
+                        }
+                        IconButton(
+                            onClick = { vm.removeAttachment(a.id) },
+                            modifier = Modifier.align(Alignment.TopEnd).size(20.dp),
+                        ) {
+                            Icon(
+                                Icons.Rounded.Close,
+                                contentDescription = "Remove attachment",
+                                tint = com.hermes.client.ui.components.AccentChrome.fabContainer,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+```
+Add imports as needed: `androidx.compose.foundation.Image`, `androidx.compose.foundation.lazy.LazyRow`, `androidx.compose.foundation.lazy.items`, `androidx.compose.ui.graphics.asImageBitmap`, `androidx.compose.ui.layout.ContentScale`, `androidx.compose.material.icons.rounded.Close`, `androidx.compose.foundation.background`, `androidx.compose.foundation.shape.RoundedCornerShape`, `androidx.compose.foundation.clip`/`androidx.compose.ui.draw.clip`.
+
+- [ ] **Step 2: Update the send gate + submit**
+
+Change `canSend` to use the pure helper and make `submit()` clear the draft after `vm.send`:
+```kotlin
+    val canSend = canSend(connected, draft.isNotBlank(), state.pendingAttachments.isNotEmpty(), state.isGenerating)
+```
+Ensure `submit()` is:
+```kotlin
+    fun submit() {
+        if (!canSend) return
+        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        vm.send(draft)
+        draft = ""
+    }
+```
+
+- [ ] **Step 3: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head` → `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2` → `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat(chat): staging thumbnail chips with remove; attachment-aware send gate"
+```
+
+---
+
+### Task 6: On-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + install**
+
+`./gradlew :app:assembleBeta` then `adb -e install -r app/build/outputs/apk/beta/app-beta.apk`; point at the mock (`http://10.0.2.2:8899`) and open a chat.
+
+- [ ] **Step 2: Verify**
+
+1. Attach button → menu shows **Camera** + **Photo library**.
+2. **Photo library** → pick 2 images → two thumbnail chips appear above the composer.
+3. Tap a chip's **remove-✕** → that chip disappears (one remains).
+4. **Camera** → capture → a chip is added (accent-tinted remove badge).
+5. Type text + **Send** → attaches fire (no crash), chips clear, the message (or "📎 N images" bubble) appears.
+6. **Attachment-only send** (blank composer, one chip staged) → Send is enabled and works.
+7. Tenant accent preserved on the menu + chip badges.
+
+(Real multi-image delivery depends on the gateway accumulating — verify against the live gateway; the mock verifies the calls fire + all UI behavior + no crash.)
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(chat): richer-attachments verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Element 1 (model + helpers) → Task 1 ✓; Element 2 (state) → Task 2 ✓; Element 3 (VM stage/remove/send-flush + share) → Task 3 ✓; Element 4 (FileProvider + camera/photo launchers + menu) → Task 4 ✓; Element 5 (chips UI + send gate) → Task 5 ✓; on-device → Task 6 ✓. PDF deferral + no-CAMERA-permission honored (nothing adds `CAMERA` or a file-attach RPC).
+- **Placeholder scan:** every code step has full code; the only "read the file" is Task 3 Step 3 (share-path location is discovered on read; the transformation + method removal are fully specified). Task-6 commit is conditional.
+- **Type consistency:** `PendingAttachment(id, bytes, mimeType)`, `plusCapped`, `canSend(connected, hasText, hasAttachments, isGenerating)`, `withAttachment`/`withoutAttachment`, `stageAttachment(bytes, mimeType)`/`removeAttachment(id)`, `state.pendingAttachments` — all consistent across tasks and with the codebase (`AccentChrome.fabContainer`, `withUserMessage`, `chat.attachImageBytes`).
+
+**Ordering:** Task 1 pure → Task 2 state → Task 3 VM → Task 4 manifest+launchers → Task 5 chips+gate → Task 6 verify.

--- a/docs/superpowers/specs/2026-07-07-richer-attachments-design.md
+++ b/docs/superpowers/specs/2026-07-07-richer-attachments-design.md
@@ -1,0 +1,118 @@
+# Richer Attachments (chat composer) — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/richer-attachments`
+**Source:** improvement roadmap Phase 1 · Wave 3 (`docs/ideas/improvement-roadmap-2026-07-07.md`).
+
+## Goal
+
+Camera capture + multiple images in the chat composer, with a **local staging area** (thumbnail chips + remove) sent on Send. Replaces today's single fire-and-forget gallery image.
+
+## The gateway reality (drives scope)
+
+The only attach path is one WS RPC — `image.attach_bytes {session_id, data(base64), mime_type}` (no filename, no generic file-attach, no REST upload), and it's **fire-and-forget** (no detach RPC). Consequences:
+- **PDF/doc is deferred** — needs a gateway `file.attach` (or confirmation `image.attach_bytes` accepts non-image bytes). Out of scope; noted as a follow-up.
+- **Multi-image is best-effort** — we send all staged images (sequential `attachImageBytes`) right before `prompt.submit`. If the gateway *replaces* rather than *accumulates* pending attachments, it degrades to last-image-wins (no worse than today). **Verify on the real gateway.**
+- **Remove requires local staging** — since there's no detach RPC, the only way to support remove-✕ is to hold picked bytes locally and attach on Send (not on pick).
+
+## Hard constraints
+
+- **No gateway/bridge API changes** — reuse `image.attach_bytes`. Material 3; per-tenant accent (`AccentChrome`/`LocalProfileAccent`).
+- **No `CAMERA` permission** — `TakePicture` delegates to the camera app; only a `FileProvider` is needed. No AI/assistant attribution.
+
+## Grounding (from exploration)
+
+- `ChatRepository.attachImageBytes(sessionId, dataBase64, mimeType)` → `client.call("image.attach_bytes", {session_id, data, mime_type})`. `submit(sessionId, text)` → `prompt.submit {session_id, text}` (attachments bind server-side to the next prompt).
+- `ChatViewModel.attachImage(b64, mime)` currently calls `attachImageBytes` once + `appendSystem("📎 Image attached …")`. `ChatScreen` `pickImage = rememberLauncherForActivityResult(GetContent()) { … vm.attachImage(b64, mime) }`, launched `pickImage.launch("image/*")`.
+- `ChatUiState(messages, pendingApproval, pendingClarify, isGenerating)` — **no** attachment state today. `send(text)` adds an optimistic user bubble (`withUserMessage`) + `submit`/`slashExec`. `canSend = connected && draft.isNotBlank() && !isGenerating`.
+- Share-intent (`ACTION_SEND` image) currently attaches directly. Manifest: no `<provider>`, no `CAMERA`. Camera/FileProvider/multi-select are greenfield.
+
+## Element 1 — Model + pure helpers (`ui/chat/Attachments.kt`, unit-tested)
+```kotlin
+/** A picked-but-unsent attachment, held locally until Send. Identity is [id] (bytes excluded). */
+class PendingAttachment(val id: String, val bytes: ByteArray, val mimeType: String) {
+    override fun equals(other: Any?) = other is PendingAttachment && other.id == id
+    override fun hashCode() = id.hashCode()
+}
+
+const val ATTACH_CAP = 6
+
+/** Add [a] unless already at [cap]; returns the list unchanged when full. */
+fun List<PendingAttachment>.plusCapped(a: PendingAttachment, cap: Int = ATTACH_CAP): List<PendingAttachment> =
+    if (size >= cap) this else this + a
+
+/** True when a message may be sent: connected, has text or an attachment, and not mid-generation. */
+fun canSend(connected: Boolean, hasText: Boolean, hasAttachments: Boolean, isGenerating: Boolean): Boolean =
+    connected && (hasText || hasAttachments) && !isGenerating
+```
+
+## Element 2 — `ChatUiState` staging
+Add `val pendingAttachments: List<PendingAttachment> = emptyList()`. Pure reducer helpers:
+```kotlin
+fun ChatUiState.withAttachment(a: PendingAttachment) = copy(pendingAttachments = pendingAttachments.plusCapped(a))
+fun ChatUiState.withoutAttachment(id: String) = copy(pendingAttachments = pendingAttachments.filterNot { it.id == id })
+```
+(Clearing on send is inline: `copy(pendingAttachments = emptyList())`.)
+
+## Element 3 — `ChatViewModel`
+```kotlin
+private var attachSeq = 0
+fun stageAttachment(bytes: ByteArray, mimeType: String) {
+    _state.update { it.withAttachment(PendingAttachment("att-${attachSeq++}", bytes, mimeType)) }
+}
+fun removeAttachment(id: String) { _state.update { it.withoutAttachment(id) } }
+```
+`send(text)` changes to flush staged attachments **before** submit:
+```kotlin
+fun send(text: String) {
+    val atts = _state.value.pendingAttachments
+    if (text.isBlank() && atts.isEmpty()) return
+    val isSlash = text.trimStart().startsWith("/")
+    val shown = text.ifBlank { "📎 ${atts.size} image${if (atts.size > 1) "s" else ""}" }
+    _state.value = _state.value.withUserMessage(shown).copy(pendingAttachments = emptyList())
+    viewModelScope.launch {
+        try {
+            atts.forEach { a ->
+                val b64 = android.util.Base64.encodeToString(a.bytes, android.util.Base64.NO_WRAP)
+                runCatching { chat.attachImageBytes(sessionId, b64, a.mimeType) }
+                    .onFailure { appendError("Attach failed: ${it.message}") }
+            }
+            if (isSlash) chat.slashExec(sessionId, text.trim()) else chat.submit(sessionId, text)
+        } catch (e: Exception) { appendError(e.message ?: "Failed to send message") }
+    }
+}
+```
+The **share-intent image** path is rerouted to `stageAttachment(bytes, mime)` (so a shared image appears as a chip) instead of the old direct `attachImageBytes`. The old `attachImage(b64, mime)` method is removed (replaced by staging).
+
+## Element 4 — Manifest FileProvider + pick launchers (`AndroidManifest.xml`, `res/xml/file_paths.xml`, `ChatScreen.kt`)
+- **Manifest** (inside `<application>`):
+```xml
+<provider
+    android:name="androidx.core.content.FileProvider"
+    android:authorities="${applicationId}.fileprovider"
+    android:exported="false"
+    android:grantUriPermissions="true">
+    <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
+</provider>
+```
+- **`res/xml/file_paths.xml`:** `<paths><cache-path name="captures" path="." /></paths>`.
+- **Attach button → menu:** replace the single `AttachFile` `IconButton` with one that opens a `DropdownMenu`: **Camera** · **Photo library**.
+  - **Photo library:** `rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(ATTACH_CAP)) { uris -> uris.forEach { readBytes(it)?.let { b -> vm.stageAttachment(b, contentResolver.getType(it) ?: "image/*") } } }`; launch `PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)`. No permission.
+  - **Camera:** hold `var captureUri by remember { mutableStateOf<Uri?>(null) }` + a cache temp file via `FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", File(context.cacheDir, "capture_<seq>.jpg"))`; `rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { ok -> if (ok) captureUri?.let { readBytes(it)?.let { b -> vm.stageAttachment(b, "image/jpeg") } } }`; launch with the FileProvider uri. No `CAMERA` permission.
+  - `readBytes(uri) = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }` (a local helper), inside `runCatching`.
+
+## Element 5 — Staging chips UI + send wiring (`ChatScreen.kt`)
+- Above the composer input row: `if (state.pendingAttachments.isNotEmpty())` a horizontal `LazyRow` of chips. Each chip: a small (~56.dp) rounded thumbnail decoded from bytes (`remember(a.id) { BitmapFactory.decodeByteArray(a.bytes, 0, a.bytes.size)?.asImageBitmap() }`, downsampled is fine) with a remove-✕ badge (accent-tinted) → `vm.removeAttachment(a.id)`.
+- **Send gate:** `val canSend = canSend(connected, draft.isNotBlank(), state.pendingAttachments.isNotEmpty(), state.isGenerating)`; `submit()` calls `vm.send(draft)` (which flushes attachments) then `draft = ""`.
+
+## Testing
+
+- **Unit (pure), TDD — `AttachmentsTest`:** `canSend` truth table (blank+no-attach→false; text→true; attach-only→true; disconnected→false; generating→false); `plusCapped` (adds under cap; no-op at cap=6); `withoutAttachment` removes by id, leaves others.
+- **On-device:** pick 2 from Photo library → 2 thumbnail chips; remove one → 1 chip; Camera → capture → chip added; type text + Send → attaches fire (system/no-crash), chips clear, message sent; Send with only an attachment (blank text) works; tenant accent on menu/chips. (Real multi-delivery depends on the gateway — verify against the live gateway; the mock verifies the calls fire + UI behavior.)
+
+## Not doing (YAGNI) / deferred
+
+- **PDF/doc** — gateway follow-up (`file.attach` or confirmed non-image `image.attach_bytes`).
+- Reordering staged items; >6 images; video; drag-and-drop; editing a captured photo.
+- Any gateway/API change; `CAMERA` permission (not needed for `TakePicture`).


### PR DESCRIPTION
## Richer attachments (chat composer) — Phase 1 · Wave 3

Camera capture + multiple images in the composer, staged locally as removable thumbnail chips and sent on Send. Replaces the old single fire-and-forget gallery image. **Client-only** — reuses the existing `image.attach_bytes` RPC.

- **Attach menu** (paperclip → dropdown): **Camera** (`TakePicture` + `FileProvider`, **no `CAMERA` permission** — delegates to the camera app) · **Photo library** (`PickMultipleVisualMedia`, system photo picker, no permission).
- **Local staging:** picks go into `ChatUiState.pendingAttachments` (bytes held locally) and render as **thumbnail chips with a remove-✕**. On **Send**, each is base64-encoded and attached (awaited) before `prompt.submit`, then cleared. Attaching now works **offline** (it only stages; `canSend` still gates the actual send on being connected).
- Send is enabled with attachments even when the text is blank (image-only message).

### Honest scope (per the spec)
- **PDF/doc deferred** — the only attach RPC is `image.attach_bytes` (no generic file-attach); PDF is a gateway follow-up.
- **Multi-image is best-effort** — all staged images are attached before submit; if the gateway *replaces* rather than *accumulates* pending attachments, it degrades to last-image-wins. **Verify on the live gateway.**

### Verification
- Unit tests: `AttachmentsTest` (canSend / plusCapped / equality). Full suite + `assembleBeta` green; gitleaks clean.
- Built via subagent-driven development: per-task reviews + an opus whole-branch review. Applied fixes: base64 unify (`java.util.Base64`, testable), `rememberSaveable` captureUri (survive process death), **downsampled thumbnail decode** (avoid OOM from full-res ×6), larger high-contrast remove badge, un-gated attach, camera temp-file sweep.
- On-device (emulator): attach menu; photo-picker multi-select → 2 chips; remove-✕; **camera capture → chip** via FileProvider (no crash); tenant accent preserved.

Known minor (backlog): picking beyond the 6-image cap silently drops extras (no toast).

Spec/plan: `docs/superpowers/specs/2026-07-07-richer-attachments-design.md`, `docs/superpowers/plans/2026-07-07-richer-attachments.md`.
