### PR TITLE
Notifications: run-finished (bg) + clarify (Phase 2 · Wave 1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(libs.lifecycle.runtime)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.lifecycle.process)
     implementation(libs.activity.compose)
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)

--- a/app/src/main/java/com/hermes/client/data/repository/NotificationSettings.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/NotificationSettings.kt
@@ -10,18 +10,21 @@ import kotlinx.coroutines.flow.map
 
 private val Context.notificationDataStore by preferencesDataStore(name = "notifications")
 
-/** Device-local notification preferences (master toggle + approvals). Off by default. */
+/** Device-local notification preferences (master toggle + approvals + run-finished). Off by default. */
 class NotificationSettings(private val context: Context) {
     private val kEnabled = booleanPreferencesKey("enabled")
     private val kApprovals = booleanPreferencesKey("approvals")
+    private val kRunFinished = booleanPreferencesKey("runFinished")
 
     val prefs: Flow<NotificationPrefs> = context.notificationDataStore.data.map { p ->
         NotificationPrefs(
             enabled = p[kEnabled] ?: false,
             approvals = p[kApprovals] ?: true,
+            runFinished = p[kRunFinished] ?: true,
         )
     }
 
     suspend fun setEnabled(v: Boolean) = context.notificationDataStore.edit { it[kEnabled] = v }
     suspend fun setApprovals(v: Boolean) = context.notificationDataStore.edit { it[kApprovals] = v }
+    suspend fun setRunFinished(v: Boolean) = context.notificationDataStore.edit { it[kRunFinished] = v }
 }

--- a/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
@@ -29,11 +29,29 @@ class GatewayConnectionService : Service() {
     // DataStore. @Volatile for cross-thread visibility (scope has no single-thread dispatcher).
     @Volatile private var latestPrefs = NotificationPrefs()
 
+    // Whether the app process is currently in the foreground, kept current by a
+    // ProcessLifecycleOwner observer so the event loop can suppress notifications the user is
+    // already looking at. @Volatile for cross-thread visibility (scope has no single-thread
+    // dispatcher).
+    @Volatile private var appInForeground = false
+
     override fun onCreate() {
         super.onCreate()
         notifier.ensureChannels()
         startForeground(HermesNotifier.SERVICE_NOTIFICATION_ID, notifier.serviceNotification())
         client.connect()
+        // ProcessLifecycleOwner must be observed from the main thread.
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(
+                androidx.lifecycle.LifecycleEventObserver { _, e ->
+                    when (e) {
+                        androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
+                        androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
+                        else -> {}
+                    }
+                },
+            )
+        }
         // Track the latest prefs reactively so the event loop reads a cached value instead of
         // collecting DataStore per event. Started first so its replayed value is in place before
         // events arrive; also picks up mid-run toggles (e.g. approvals turned off).
@@ -43,9 +61,7 @@ class GatewayConnectionService : Service() {
                 // One malformed/unexpected event must not crash the process — mirror the guard
                 // ChatViewModel's reduce() uses around event handling.
                 runCatching {
-                    // TODO(later task): thread real foreground state through; for now this service
-                    // only runs the background event loop, so treat it as always-backgrounded.
-                    toNotificationSpec(event, latestPrefs, appInForeground = false)?.let { notifier.post(it) }
+                    toNotificationSpec(event, latestPrefs, appInForeground)?.let { notifier.post(it) }
                 }
             }
         }

--- a/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
@@ -38,7 +38,6 @@ class GatewayConnectionService : Service() {
     // ProcessLifecycleOwner is a process-lifetime singleton; hold the observer so onDestroy can
     // remove it — otherwise each stop/start of this service (e.g. toggling notifications) would
     // leak the retired Service instance (and its injected WS client) forever.
-    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
     private var lifecycleObserver: androidx.lifecycle.LifecycleEventObserver? = null
 
     override fun onCreate() {
@@ -46,18 +45,17 @@ class GatewayConnectionService : Service() {
         notifier.ensureChannels()
         startForeground(HermesNotifier.SERVICE_NOTIFICATION_ID, notifier.serviceNotification())
         client.connect()
-        // ProcessLifecycleOwner must be observed from the main thread.
-        mainHandler.post {
-            val obs = androidx.lifecycle.LifecycleEventObserver { _, e ->
-                when (e) {
-                    androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
-                    androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
-                    else -> {}
-                }
+        // Service.onCreate() runs on the main thread — where ProcessLifecycleOwner must be observed —
+        // so register synchronously (addObserver replays the current state immediately, no race).
+        val obs = androidx.lifecycle.LifecycleEventObserver { _, e ->
+            when (e) {
+                androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
+                androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
+                else -> {}
             }
-            lifecycleObserver = obs
-            androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(obs)
         }
+        lifecycleObserver = obs
+        androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(obs)
         // Track the latest prefs reactively so the event loop reads a cached value instead of
         // collecting DataStore per event. Started first so its replayed value is in place before
         // events arrive; also picks up mid-run toggles (e.g. approvals turned off).
@@ -90,11 +88,10 @@ class GatewayConnectionService : Service() {
 
     override fun onDestroy() {
         scope.cancel()
-        // Remove the process-lifecycle observer (main thread) so this Service instance isn't retained.
-        mainHandler.post {
-            lifecycleObserver?.let { androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.removeObserver(it) }
-            lifecycleObserver = null
-        }
+        // onDestroy() runs on the main thread — remove the observer synchronously so this Service
+        // instance isn't retained (and no event can hit a defunct instance in a deferred window).
+        lifecycleObserver?.let { androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.removeObserver(it) }
+        lifecycleObserver = null
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
@@ -35,22 +35,28 @@ class GatewayConnectionService : Service() {
     // dispatcher).
     @Volatile private var appInForeground = false
 
+    // ProcessLifecycleOwner is a process-lifetime singleton; hold the observer so onDestroy can
+    // remove it — otherwise each stop/start of this service (e.g. toggling notifications) would
+    // leak the retired Service instance (and its injected WS client) forever.
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+    private var lifecycleObserver: androidx.lifecycle.LifecycleEventObserver? = null
+
     override fun onCreate() {
         super.onCreate()
         notifier.ensureChannels()
         startForeground(HermesNotifier.SERVICE_NOTIFICATION_ID, notifier.serviceNotification())
         client.connect()
         // ProcessLifecycleOwner must be observed from the main thread.
-        android.os.Handler(android.os.Looper.getMainLooper()).post {
-            androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(
-                androidx.lifecycle.LifecycleEventObserver { _, e ->
-                    when (e) {
-                        androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
-                        androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
-                        else -> {}
-                    }
-                },
-            )
+        mainHandler.post {
+            val obs = androidx.lifecycle.LifecycleEventObserver { _, e ->
+                when (e) {
+                    androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
+                    androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
+                    else -> {}
+                }
+            }
+            lifecycleObserver = obs
+            androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(obs)
         }
         // Track the latest prefs reactively so the event loop reads a cached value instead of
         // collecting DataStore per event. Started first so its replayed value is in place before
@@ -84,6 +90,11 @@ class GatewayConnectionService : Service() {
 
     override fun onDestroy() {
         scope.cancel()
+        // Remove the process-lifecycle observer (main thread) so this Service instance isn't retained.
+        mainHandler.post {
+            lifecycleObserver?.let { androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.removeObserver(it) }
+            lifecycleObserver = null
+        }
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
+++ b/app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
@@ -43,7 +43,9 @@ class GatewayConnectionService : Service() {
                 // One malformed/unexpected event must not crash the process — mirror the guard
                 // ChatViewModel's reduce() uses around event handling.
                 runCatching {
-                    toNotificationSpec(event, latestPrefs)?.let { notifier.post(it) }
+                    // TODO(later task): thread real foreground state through; for now this service
+                    // only runs the background event loop, so treat it as always-backgrounded.
+                    toNotificationSpec(event, latestPrefs, appInForeground = false)?.let { notifier.post(it) }
                 }
             }
         }

--- a/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+++ b/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
@@ -25,6 +25,9 @@ class HermesNotifier(private val context: Context) {
         sys.createNotificationChannel(
             NotificationChannel(Notif.CHANNEL_SERVICE, "Connection", NotificationManager.IMPORTANCE_MIN),
         )
+        sys.createNotificationChannel(
+            NotificationChannel(Notif.CHANNEL_ACTIVITY, "Activity", NotificationManager.IMPORTANCE_DEFAULT),
+        )
     }
 
     fun serviceNotification(): Notification =

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -4,11 +4,13 @@ import com.hermes.client.data.network.ServerEvent
 import com.hermes.client.data.network.str
 
 /**
- * Pure mapping from a gateway event to a notification (or null). Only `approval.request` is a
- * notifiable event on the app's WebSocket (see the note on [Notif]); everything else returns null.
- * A stable id is derived from the session so repeats of the same event update rather than stack.
+ * Pure mapping from a gateway event to a notification (or null). `approval.request` and
+ * `clarify.request` always notify (they need the user's input regardless of whether the app is
+ * foregrounded); `run.completed`/`run.failed` only notify when the app is backgrounded — see the
+ * note on [Notif]. A stable id is derived from the session so repeats of the same event update
+ * rather than stack.
  */
-fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs): NotificationSpec? {
+fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForeground: Boolean): NotificationSpec? {
     if (!prefs.enabled) return null
     val sid = event.sessionId ?: return null
     var id = (event.type + sid).hashCode()
@@ -27,6 +29,21 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs): Notificati
                 NotifAction("Deny", Notif.ACTION_DENY, sid),
             ),
             groupKey = "approval",
+        )
+        // Needs-you: always notify (ignores foreground); tap opens the chat to answer.
+        Notif.EVENT_CLARIFY -> if (!prefs.approvals) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Needs your input",
+            body = event.str("question") ?: "The agent has a question.",
+            route = "chat/$sid", actions = emptyList(), groupKey = "approval",
+        )
+        // Run finished: only when backgrounded; generic body (no showable payload fields client-side).
+        Notif.EVENT_RUN_COMPLETED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run finished",
+            body = "Your agent finished — tap to view.", route = "chat/$sid", actions = emptyList(), groupKey = "run",
+        )
+        Notif.EVENT_RUN_FAILED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run failed",
+            body = "The agent run failed — tap to view.", route = "chat/$sid", actions = emptyList(), groupKey = "run",
         )
         else -> null
     }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -4,6 +4,7 @@ package com.hermes.client.notifications
 data class NotificationPrefs(
     val enabled: Boolean = false,
     val approvals: Boolean = true,
+    val runFinished: Boolean = true,
 )
 
 /** An inline notification action (Approve/Deny) carrying the target session. */
@@ -24,12 +25,16 @@ data class NotificationSpec(
 object Notif {
     const val CHANNEL_APPROVALS = "approvals"
     const val CHANNEL_SERVICE = "service"
+    const val CHANNEL_ACTIVITY = "activity"
 
     // `approval.request` is the only notifiable event on the app's WebSocket (/api/ws). Verified
     // against the gateway source: it broadcasts approval + run/tool/message-stream lifecycle events,
     // but NOT cron-finished (cron delivers to messaging platforms) or a messaging-inbound event —
     // so those aren't offered here. See docs/superpowers/specs/2026-07-03-notifications-approvals-only.
     const val EVENT_APPROVAL = "approval.request"
+    const val EVENT_RUN_COMPLETED = "run.completed"
+    const val EVENT_RUN_FAILED = "run.failed"
+    const val EVENT_CLARIFY = "clarify.request"
 
     const val ACTION_APPROVE = "approve"
     const val ACTION_DENY = "deny"

--- a/app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
@@ -46,6 +46,7 @@ class NotificationsViewModel @Inject constructor(
 
     fun setEnabled(v: Boolean) = viewModelScope.launch { settings.setEnabled(v) }
     fun setApprovals(v: Boolean) = viewModelScope.launch { settings.setApprovals(v) }
+    fun setRunFinished(v: Boolean) = viewModelScope.launch { settings.setRunFinished(v) }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -92,6 +93,13 @@ fun NotificationsScreen(onBack: () -> Unit, vm: NotificationsViewModel = hiltVie
             ) { on -> if (on) enable() else { vm.setEnabled(false); GatewayConnectionService.stop(context) } }
             HorizontalDivider()
             ToggleRow("Approval requests", "When the agent needs you to approve an action", prefs.approvals, enabled = prefs.enabled) { vm.setApprovals(it) }
+            HorizontalDivider()
+            ToggleRow(
+                "Run finished",
+                "Notify when an agent run completes (while the app is in the background)",
+                prefs.runFinished,
+                enabled = prefs.enabled,
+            ) { vm.setRunFinished(it) }
         }
     }
 }

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -4,18 +4,19 @@ import com.hermes.client.data.network.ServerEvent
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NotificationMapperTest {
-    private val on = NotificationPrefs(enabled = true)
+    private val on = NotificationPrefs(enabled = true, approvals = true, runFinished = true)
 
     private fun event(type: String, sid: String? = "s1", vararg pairs: Pair<String, String>) =
         ServerEvent(type, sid, buildJsonObject { pairs.forEach { (k, v) -> put(k, v) } })
 
     @Test fun approval_makes_high_priority_spec_with_actions() {
-        val spec = toNotificationSpec(event(Notif.EVENT_APPROVAL, "s1", "prompt" to "Delete file?"), on)!!
+        val spec = toNotificationSpec(event(Notif.EVENT_APPROVAL, "s1", "prompt" to "Delete file?"), on, appInForeground = false)!!
         assertEquals(Notif.CHANNEL_APPROVALS, spec.channelId)
         assertEquals("chat/s1", spec.route)
         assertTrue(spec.body.contains("Delete file?"))
@@ -23,16 +24,65 @@ class NotificationMapperTest {
         assertTrue(spec.actions.all { it.sessionId == "s1" })
     }
 
+    @Test fun approval_notifies_regardless_of_foreground() {
+        val e = event(Notif.EVENT_APPROVAL, "c1", "prompt" to "May I run rm?")
+        assertNotNull(toNotificationSpec(e, on, appInForeground = false))
+        assertNotNull(toNotificationSpec(e, on, appInForeground = true))
+    }
+
     @Test fun approvals_toggle_and_master_toggle_suppress() {
-        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL), on.copy(approvals = false)))
-        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL), NotificationPrefs(enabled = false)))
+        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL), on.copy(approvals = false), appInForeground = false))
+        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL), NotificationPrefs(enabled = false), appInForeground = false))
+    }
+
+    @Test fun approval_off_when_pref_off() {
+        val e = event(Notif.EVENT_APPROVAL, "c1", "prompt" to "x")
+        assertNull(toNotificationSpec(e, on.copy(approvals = false), appInForeground = false))
+    }
+
+    @Test fun clarify_notifies_with_question_regardless_of_foreground() {
+        val e = event(Notif.EVENT_CLARIFY, "c1", "question" to "Which repo?")
+        val spec = toNotificationSpec(e, on, appInForeground = true)!!
+        assertEquals("Needs your input", spec.title)
+        assertEquals("Which repo?", spec.body)
+        assertEquals("chat/c1", spec.route)
+        assertTrue(spec.actions.isEmpty())
+    }
+
+    @Test fun clarify_off_when_approvals_off() {
+        val e = event(Notif.EVENT_CLARIFY, "c1", "question" to "x")
+        assertNull(toNotificationSpec(e, on.copy(approvals = false), appInForeground = false))
+    }
+
+    @Test fun run_completed_only_when_backgrounded() {
+        val e = event(Notif.EVENT_RUN_COMPLETED, "c1")
+        assertNotNull(toNotificationSpec(e, on, appInForeground = false))
+        assertNull(toNotificationSpec(e, on, appInForeground = true))
+    }
+
+    @Test fun run_completed_off_when_pref_off() {
+        val e = event(Notif.EVENT_RUN_COMPLETED, "c1")
+        assertNull(toNotificationSpec(e, on.copy(runFinished = false), appInForeground = false))
+    }
+
+    @Test fun run_failed_title() {
+        val spec = toNotificationSpec(event(Notif.EVENT_RUN_FAILED, "c1"), on, appInForeground = false)!!
+        assertEquals("Run failed", spec.title)
+        assertEquals(Notif.CHANNEL_ACTIVITY, spec.channelId)
+    }
+
+    @Test fun no_session_is_null() {
+        assertNull(toNotificationSpec(event(Notif.EVENT_RUN_COMPLETED, null), on, appInForeground = false))
+    }
+
+    @Test fun disabled_is_null() {
+        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL, "c1", "prompt" to "x"), on.copy(enabled = false), appInForeground = false))
     }
 
     @Test fun non_approval_and_sessionless_events_are_null() {
-        // Only approval.request is notifiable; run/cron/messaging-style events map to nothing.
-        assertNull(toNotificationSpec(event("run.completed", "c1", "status" to "success"), on))
-        assertNull(toNotificationSpec(event("message.received", "m1", "platform" to "Telegram"), on))
-        assertNull(toNotificationSpec(event("message.delta"), on))
-        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL, sid = null), on))
+        // message.received / message.delta aren't notifiable events on the app's WebSocket.
+        assertNull(toNotificationSpec(event("message.received", "m1", "platform" to "Telegram"), on, appInForeground = false))
+        assertNull(toNotificationSpec(event("message.delta"), on, appInForeground = false))
+        assertNull(toNotificationSpec(event(Notif.EVENT_APPROVAL, sid = null), on, appInForeground = false))
     }
 }

--- a/docs/superpowers/plans/2026-07-08-completion-notifications.md
+++ b/docs/superpowers/plans/2026-07-08-completion-notifications.md
@@ -1,0 +1,314 @@
+# Completion Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Notify on agent run-finished (background-only) and needs-input (`clarify.request`) by mapping existing WS events to notifications.
+
+**Architecture:** A pure `toNotificationSpec(event, prefs, appInForeground)` gains branches for `clarify.request` (always) and `run.completed`/`run.failed` (only when backgrounded). `GatewayConnectionService` supplies the live foreground flag from `ProcessLifecycleOwner`. A new DEFAULT "Activity" channel + a `runFinished` settings toggle.
+
+**Tech Stack:** Kotlin, Hilt, `androidx.lifecycle:lifecycle-process`, NotificationCompat, JUnit.
+
+## Global Constraints
+
+- **No gateway/bridge API changes** — map existing WS events only; reuse the notifications plumbing/channels/`extra_route`. Accepted limit (do NOT fix here): notifications only fire while the foreground service is alive.
+- Deferred: cron-push, FCM durability, run-finished payload enrichment.
+- JDK 21: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Compile: `./gradlew :app:compileDebugKotlin --console=plain`. Tests: `./gradlew :app:testDebugUnitTest --console=plain`. Beta: `./gradlew :app:assembleBeta`.
+- **No AI/assistant attribution** in commits, files, or PRs.
+
+## Grounding
+
+- `NotificationMapper.toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs): NotificationSpec?` — early-returns null on `!prefs.enabled` or `event.sessionId == null`; `id = (event.type + sid).hashCode()` bumped off `1001`; single `Notif.EVENT_APPROVAL` branch builds `route="chat/$sid"`.
+- `NotificationSpec(id, channelId, title, body, route, actions, groupKey)` (no importance). `NotificationPrefs(enabled=false, approvals=true)`. `NotifAction(label, action, sessionId)`.
+- `ServerEvent(type, sessionId, payload)`; `event.str("key")` (safe payload string). `clarify.request` carries `question`; `run.*` has only the generic `session_id`.
+- `HermesNotifier.ensureChannels()` creates `CHANNEL_APPROVALS` (HIGH) + `CHANNEL_SERVICE` (MIN).
+- `GatewayConnectionService`: `@Volatile latestPrefs` fed by `settings.prefs.collect`; collector runs `toNotificationSpec(event, latestPrefs)?.let { notifier.post(it) }`.
+- `NotificationsScreen` has an "approval alerts" toggle bound to a notifications VM/prefs store.
+
+---
+
+### Task 1: Models + pure mapper + tests (TDD)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationModels.kt`
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt`
+- Test: `app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt`
+
+**Interfaces:** Produces `Notif.CHANNEL_ACTIVITY`, `Notif.EVENT_RUN_COMPLETED`, `Notif.EVENT_RUN_FAILED`, `Notif.EVENT_CLARIFY`; `NotificationPrefs.runFinished`; `toNotificationSpec(event, prefs, appInForeground: Boolean)`.
+
+- [ ] **Step 1: Add the constants + pref**
+
+In `NotificationModels.kt`, add to `object Notif` (next to the existing consts):
+```kotlin
+    const val CHANNEL_ACTIVITY = "activity"
+    const val EVENT_RUN_COMPLETED = "run.completed"
+    const val EVENT_RUN_FAILED = "run.failed"
+    const val EVENT_CLARIFY = "clarify.request"
+```
+And add to `NotificationPrefs`:
+```kotlin
+data class NotificationPrefs(
+    val enabled: Boolean = false,
+    val approvals: Boolean = true,
+    val runFinished: Boolean = true,
+)
+```
+
+- [ ] **Step 2: Update the test (signature + new cases)** — `NotificationMapperTest.kt`
+
+Read the file's existing `event(...)` helper + prefs fixtures first. Update every `toNotificationSpec(event, prefs)` call to pass a foreground flag, REPLACE the old `run.completed → null` assertion, and add the branches. The tests should read like (adapt to the existing `event(...)`/prefs helpers):
+```kotlin
+    private val on = NotificationPrefs(enabled = true, approvals = true, runFinished = true)
+
+    @Test fun approval_notifies_regardless_of_foreground() {
+        val e = event("approval.request", "c1", "prompt" to "May I run rm?")
+        assertNotNull(toNotificationSpec(e, on, appInForeground = false))
+        assertNotNull(toNotificationSpec(e, on, appInForeground = true))
+    }
+    @Test fun approval_off_when_pref_off() {
+        val e = event("approval.request", "c1", "prompt" to "x")
+        assertNull(toNotificationSpec(e, on.copy(approvals = false), appInForeground = false))
+    }
+    @Test fun clarify_notifies_with_question_regardless_of_foreground() {
+        val e = event("clarify.request", "c1", "question" to "Which repo?")
+        val spec = toNotificationSpec(e, on, appInForeground = true)!!
+        assertEquals("Needs your input", spec.title)
+        assertEquals("Which repo?", spec.body)
+        assertEquals("chat/c1", spec.route)
+        assertTrue(spec.actions.isEmpty())
+    }
+    @Test fun clarify_off_when_approvals_off() {
+        val e = event("clarify.request", "c1", "question" to "x")
+        assertNull(toNotificationSpec(e, on.copy(approvals = false), appInForeground = false))
+    }
+    @Test fun run_completed_only_when_backgrounded() {
+        val e = event("run.completed", "c1")
+        assertNotNull(toNotificationSpec(e, on, appInForeground = false))
+        assertNull(toNotificationSpec(e, on, appInForeground = true))
+    }
+    @Test fun run_completed_off_when_pref_off() {
+        val e = event("run.completed", "c1")
+        assertNull(toNotificationSpec(e, on.copy(runFinished = false), appInForeground = false))
+    }
+    @Test fun run_failed_title() {
+        val spec = toNotificationSpec(event("run.failed", "c1"), on, appInForeground = false)!!
+        assertEquals("Run failed", spec.title)
+        assertEquals(Notif.CHANNEL_ACTIVITY, spec.channelId)
+    }
+    @Test fun no_session_is_null() {
+        assertNull(toNotificationSpec(event("run.completed", null), on, appInForeground = false))
+    }
+    @Test fun disabled_is_null() {
+        assertNull(toNotificationSpec(event("approval.request", "c1", "prompt" to "x"), on.copy(enabled = false), appInForeground = false))
+    }
+```
+(If the existing `event(...)` helper can't build an event with a null session id, add a small overload or use whatever null-session mechanism the fixtures already have.)
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NotificationMapperTest*' --console=plain 2>&1 | tail -8`
+Expected: FAIL — new signature / branches not present.
+
+- [ ] **Step 4: Implement the mapper** — `NotificationMapper.kt`
+
+```kotlin
+fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForeground: Boolean): NotificationSpec? {
+    if (!prefs.enabled) return null
+    val sid = event.sessionId ?: return null
+    var id = (event.type + sid).hashCode()
+    if (id == 1001) id = 1002
+    return when (event.type) {
+        Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Approval needed",
+            body = event.str("prompt") ?: "The agent is waiting for your approval.",
+            route = "chat/$sid",
+            actions = listOf(NotifAction("Approve", Notif.ACTION_APPROVE, sid), NotifAction("Deny", Notif.ACTION_DENY, sid)),
+            groupKey = "approval",
+        )
+        // Needs-you: always notify (ignores foreground); tap opens the chat to answer.
+        Notif.EVENT_CLARIFY -> if (!prefs.approvals) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Needs your input",
+            body = event.str("question") ?: "The agent has a question.",
+            route = "chat/$sid", actions = emptyList(), groupKey = "approval",
+        )
+        // Run finished: only when backgrounded; generic body (no showable payload fields client-side).
+        Notif.EVENT_RUN_COMPLETED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run finished",
+            body = "Your agent finished — tap to view.", route = "chat/$sid", actions = emptyList(), groupKey = "run",
+        )
+        Notif.EVENT_RUN_FAILED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+            id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run failed",
+            body = "The agent run failed — tap to view.", route = "chat/$sid", actions = emptyList(), groupKey = "run",
+        )
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*NotificationMapperTest*' --console=plain 2>&1 | tail -8`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/NotificationModels.kt app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+git commit -m "feat(notifications): map run-finished (bg) + clarify; foreground-aware mapper"
+```
+
+---
+
+### Task 2: Activity notification channel
+
+**Files:** Modify `app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt`
+
+**Interfaces:** Consumes `Notif.CHANNEL_ACTIVITY` (Task 1).
+
+- [ ] **Step 1: Add the channel in `ensureChannels()`** (after the existing channels)
+
+```kotlin
+    sys.createNotificationChannel(
+        NotificationChannel(Notif.CHANNEL_ACTIVITY, "Activity", NotificationManager.IMPORTANCE_DEFAULT),
+    )
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin --console=plain 2>&1 | grep -E "^e: |BUILD" | head`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+git commit -m "feat(notifications): add DEFAULT-importance Activity channel"
+```
+
+---
+
+### Task 3: Foreground flag in the service + dependency
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`, `app/build.gradle.kts`
+- Modify: `app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt`
+
+**Interfaces:** Consumes `toNotificationSpec(event, prefs, appInForeground)` (Task 1).
+
+- [ ] **Step 1: Add the `lifecycle-process` dependency**
+
+In `gradle/libs.versions.toml`, add under `[libraries]` (reusing the pinned `lifecycle` version ref):
+```toml
+lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
+```
+In `app/build.gradle.kts`, add to `dependencies` (next to the other lifecycle deps):
+```kotlin
+    implementation(libs.lifecycle.process)
+```
+
+- [ ] **Step 2: Observe process lifecycle into a `@Volatile` flag**
+
+Read `GatewayConnectionService.kt` `onCreate` + the event collector first. Add a field near `latestPrefs`:
+```kotlin
+    @Volatile private var appInForeground = false
+```
+In `onCreate` (the observer must be added on the main thread — `ProcessLifecycleOwner` requires it):
+```kotlin
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(
+                androidx.lifecycle.LifecycleEventObserver { _, e ->
+                    when (e) {
+                        androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
+                        androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
+                        else -> {}
+                    }
+                },
+            )
+        }
+```
+
+- [ ] **Step 3: Pass the flag into the mapper**
+
+Change the event-collector call:
+```kotlin
+            runCatching {
+                toNotificationSpec(event, latestPrefs, appInForeground)?.let { notifier.post(it) }
+            }
+```
+
+- [ ] **Step 4: Compile + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head` → `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2` → `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gradle/libs.versions.toml app/build.gradle.kts app/src/main/java/com/hermes/client/notifications/GatewayConnectionService.kt
+git commit -m "feat(notifications): background-scope run-finished via ProcessLifecycleOwner"
+```
+
+---
+
+### Task 4: `runFinished` settings toggle
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt` + its ViewModel + the prefs store (discover on read)
+
+**Interfaces:** Consumes `NotificationPrefs.runFinished` (Task 1).
+
+- [ ] **Step 1: Persist `runFinished`**
+
+Read the prefs store that backs `enabled`/`approvals` (the DataStore/`SettingsRepository` + the notifications VM). Mirror the `approvals` key end-to-end: a DataStore preference key `runFinished` (default `true`), its read into the `NotificationPrefs` flow, and a setter (e.g. `setRunFinished(Boolean)`), following the exact shape of the existing `approvals` key/flow/setter.
+
+- [ ] **Step 2: Add the toggle row to `NotificationsScreen`**
+
+Mirror the existing "approval alerts" toggle row (a `Switch`/`ListItem` bound to the VM), shown when notifications are enabled, labeled **"Run finished"** with a one-line subtitle like "Notify when an agent run completes (while the app is in the background)", bound to `runFinished` + its setter.
+
+- [ ] **Step 3: Compile + suite + assemble**
+
+Run: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --console=plain 2>&1 | grep -E "^e: |FAILED|BUILD" | head` → `BUILD SUCCESSFUL`, no `FAILED`.
+Run: `./gradlew :app:assembleBeta --console=plain 2>&1 | grep -E "^e: |BUILD" | tail -2` → `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
+git add -A  # picks up the VM + prefs-store changes
+git commit -m "feat(notifications): Run finished settings toggle"
+```
+
+---
+
+### Task 5: On-device verification
+
+**Files:** none (verification only). **Harness note:** the mock gateway (`$CLAUDE_JOB_DIR/tmp/mockgw.py`, not committed) likely needs a small test-only addition to emit `run.completed` and `clarify.request` over the WS on demand (e.g. a trigger endpoint or a timed emit after connect). Add it to the mock only — never to the repo.
+
+- [ ] **Step 1: Build + install + enable notifications**
+
+`./gradlew :app:assembleBeta`; install; connect to the mock; in Settings → Notifications, enable notifications (grant POST_NOTIFICATIONS) and confirm "Run finished" is on.
+
+- [ ] **Step 2: Verify**
+
+1. **Backgrounded run-finished:** background the app; have the mock emit `run.completed` (with a `session_id`) → a **"Run finished"** notification appears on the Activity channel; tapping it opens that chat (deep-link).
+2. **Foreground suppression:** with the app foregrounded on a chat, emit `run.completed` → **no** notification.
+3. **Clarify:** emit `clarify.request` (with `question` + `session_id`) → a **"Needs your input"** notification with the question as body; tap opens the chat.
+4. **Toggle off:** turn "Run finished" off in settings; emit `run.completed` backgrounded → **no** notification. (Approvals still fire.)
+5. Approvals behavior unchanged (emit `approval.request` → Approve/Deny inline actions still work).
+
+- [ ] **Step 3: Commit (only if verification-only fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(notifications): completion-notifications verification fixups"   # only if needed
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Element 1 (models + channels consts) → Task 1 Step 1; Element 2 (pure mapper + tests) → Task 1; the Activity channel creation → Task 2; Element 3 (dep + ProcessLifecycleOwner flag + collector wiring) → Task 3; Element 4 (settings toggle + persistence) → Task 4; on-device → Task 5. Accepted FGS limit + deferred items honored (nothing adds FCM/cron/gateway).
+- **Placeholder scan:** mapper + test + model code fully shown. The "discover on read" spots (Task 1 Step 2 `event(...)` helper; Task 4 prefs store + VM) are unavoidable (their exact shape lives in unread files) but the required change is fully specified (mirror `approvals`). Task-5 commit is conditional; the mock addition is explicitly harness-only.
+- **Type consistency:** `toNotificationSpec(event, prefs, appInForeground: Boolean)` defined in Task 1, consumed in Task 3; `Notif.CHANNEL_ACTIVITY`/`EVENT_*`, `NotificationPrefs.runFinished`, `NotificationSpec(...)` fields consistent across tasks and with the codebase.
+
+**Ordering:** Task 1 (pure core) → Task 2 (channel) → Task 3 (service flag, consumes the new signature) → Task 4 (settings) → Task 5 verify.

--- a/docs/superpowers/specs/2026-07-08-completion-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-08-completion-notifications-design.md
@@ -1,0 +1,105 @@
+# Completion Notifications — Design
+
+**Date:** 2026-07-08
+**Status:** Approved (brainstorming) → implementation plan next
+**Branch:** `feature/completion-notifications`
+**Source:** improvement roadmap Phase 2 · Wave 1 (`docs/ideas/improvement-roadmap-2026-07-07.md`); bridge-API spike corroborated by `docs/superpowers/specs/2026-07-03-notifications-approvals-only.md`.
+
+## Goal
+
+Notify the user when an agent **run finishes** and when the agent **needs input** — by mapping two already-existing gateway WS events (`run.completed`/`run.failed`, `clarify.request`) to system notifications. **Client-only**, reusing the existing `GatewayConnectionService` + `NotificationMapper` + `HermesNotifier`.
+
+## The two rules (drive the design)
+
+- **Needs-you (`approval.request` + `clarify.request`) → always notify** (HIGH channel), matching today's approval behavior. Foreground state is ignored.
+- **Run-finished (`run.completed` / `run.failed`) → only when the app is backgrounded** (foreground = the user is watching it live). New DEFAULT-importance "Activity" channel.
+
+## Hard constraints & known limits
+
+- **No gateway/bridge API changes** — map existing events only. Reuse the notifications plumbing + channels + `extra_route` deep-link pattern.
+- **Accepted limit (documented, not fixed here):** notifications only fire while the foreground service is alive + the phone can reach the gateway; they go dark when the FGS is killed (Android 15 ~6h `dataSync` cap, force-stop, reboot). A durable push (FCM/gateway) is a deferred follow-up.
+- **Deferred:** cron-finished/failed push (no WS event exists — gateway follow-up) and payload enrichment for run-finished.
+- No AI/assistant attribution.
+
+## Grounding (from exploration)
+
+- `toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs): NotificationSpec?` is pure + unit-tested (`NotificationMapperTest`); single `approval.request` branch. It early-returns null when `!prefs.enabled` or `event.sessionId == null`; derives `id = (event.type + sid).hashCode()` (bumped off reserved `1001`) so same-type+session **replaces** (per-session de-dup); builds `route = "chat/$sid"`.
+- `ServerEvent(type, sessionId, payload: JsonObject)` — `sessionId` is extracted **generically** (`payload["session_id"]` ?: `params["session_id"]`) for every event. `event.str("key")` safely reads a payload string (never throws). **`clarify.request` carries `question`** (`event.str("question")`, read today in `ChatUiState.reduce`). **`run.completed`/`run.failed` have no showable fields referenced client-side** — only the generic `session_id`.
+- `NotificationSpec(id, channelId, title, body, route, actions, groupKey)` — **no per-spec importance** (channel-level only). `NotificationPrefs(enabled=false, approvals=true)`.
+- `HermesNotifier.ensureChannels()`: `CHANNEL_APPROVALS` (HIGH), `CHANNEL_SERVICE` (MIN). `post(spec)` builds a `BigTextStyle` notification, tap → `MainActivity` `extra_route`, `mgr.notify(spec.id, …)` (same id replaces).
+- `GatewayConnectionService`: collects `client.events`, runs each through `toNotificationSpec(event, latestPrefs)` + posts; keeps `@Volatile latestPrefs` fed by `settings.prefs.collect`. **No foreground awareness today.** `ProcessLifecycleOwner`/`lifecycle-process` is **not** a dependency (must add `androidx.lifecycle:lifecycle-process`, version `2.9.4` already pinned).
+
+## Element 1 — Models + channels (`NotificationModels.kt`, `HermesNotifier.kt`)
+- `Notif`: add `CHANNEL_ACTIVITY = "activity"`; `EVENT_RUN_COMPLETED = "run.completed"`, `EVENT_RUN_FAILED = "run.failed"`, `EVENT_CLARIFY = "clarify.request"`.
+- `NotificationPrefs`: add `val runFinished: Boolean = true`.
+- `HermesNotifier.ensureChannels()`: add `NotificationChannel(Notif.CHANNEL_ACTIVITY, "Activity", NotificationManager.IMPORTANCE_DEFAULT)`.
+
+## Element 2 — Pure mapper (`NotificationMapper.kt`, unit-tested)
+Add an `appInForeground: Boolean` parameter and the new branches:
+```kotlin
+fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForeground: Boolean): NotificationSpec? {
+    if (!prefs.enabled) return null
+    val sid = event.sessionId ?: return null
+    var id = (event.type + sid).hashCode(); if (id == 1001) id = 1002
+    return when (event.type) {
+        Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else NotificationSpec(
+            id, Notif.CHANNEL_APPROVALS, "Approval needed",
+            event.str("prompt") ?: "The agent is waiting for your approval.",
+            "chat/$sid", listOf(NotifAction("Approve", Notif.ACTION_APPROVE, sid), NotifAction("Deny", Notif.ACTION_DENY, sid)), "approval",
+        )
+        // Needs-you: always notify (ignores foreground); tap opens the chat to answer (no inline actions).
+        Notif.EVENT_CLARIFY -> if (!prefs.approvals) null else NotificationSpec(
+            id, Notif.CHANNEL_APPROVALS, "Needs your input",
+            event.str("question") ?: "The agent has a question.", "chat/$sid", emptyList(), "approval",
+        )
+        // Run finished: only when backgrounded; generic body (no showable payload fields client-side).
+        Notif.EVENT_RUN_COMPLETED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+            id, Notif.CHANNEL_ACTIVITY, "Run finished", "Your agent finished — tap to view.", "chat/$sid", emptyList(), "run",
+        )
+        Notif.EVENT_RUN_FAILED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+            id, Notif.CHANNEL_ACTIVITY, "Run failed", "The agent run failed — tap to view.", "chat/$sid", emptyList(), "run",
+        )
+        else -> null
+    }
+}
+```
+(The existing `NotificationMapperTest` case asserting `run.completed → null` must be updated to the new behavior.)
+
+## Element 3 — Foreground flag in the service (`GatewayConnectionService.kt`, `build.gradle.kts`)
+- Add dependency `androidx.lifecycle:lifecycle-process` (2.9.4) to the version catalog + `app/build.gradle.kts`.
+- In `onCreate`, on the main thread, observe process lifecycle into a `@Volatile private var appInForeground = false`:
+```kotlin
+android.os.Handler(android.os.Looper.getMainLooper()).post {
+    androidx.lifecycle.ProcessLifecycleOwner.get().lifecycle.addObserver(
+        androidx.lifecycle.LifecycleEventObserver { _, e ->
+            when (e) {
+                androidx.lifecycle.Lifecycle.Event.ON_START -> appInForeground = true
+                androidx.lifecycle.Lifecycle.Event.ON_STOP -> appInForeground = false
+                else -> {}
+            }
+        },
+    )
+}
+```
+- Pass the flag into the mapper in the event collector: `toNotificationSpec(event, latestPrefs, appInForeground)?.let { notifier.post(it) }`.
+
+## Element 4 — Settings (`NotificationsScreen.kt` + the prefs store)
+- Persist `runFinished` in the same DataStore that backs `enabled`/`approvals` (mirror the `approvals` key). Default `true`.
+- Add a **"Run finished"** toggle row to `NotificationsScreen` (shown when notifications are enabled), bound to `runFinished`. Leave the existing "approval alerts" toggle governing both approvals **and** clarify (both are needs-you); optionally relabel it "Needs-you alerts".
+
+## Testing
+
+- **Unit (pure), TDD — `NotificationMapperTest` (extend):**
+  - `approval.request` → spec regardless of `appInForeground` (both true/false); null when `prefs.approvals=false`.
+  - `clarify.request` → spec with body from `question`, regardless of foreground; null when `prefs.approvals=false`.
+  - `run.completed` → spec when `!appInForeground`; **null when `appInForeground`**; null when `prefs.runFinished=false`.
+  - `run.failed` → spec ("Run failed") when `!appInForeground`.
+  - `event.sessionId == null` → null; `!prefs.enabled` → null.
+- **On-device:** with notifications enabled, background the app, drive a `run.completed` (mock) → a "Run finished" notification appears; tapping it deep-links to that chat. Drive `run.completed` while foregrounded → **no** notification. Drive `clarify.request` (backgrounded or fore) → a "Needs your input" notification → tap opens the chat. Toggle "Run finished" off → no run notification. Approvals unchanged.
+
+## Not doing (YAGNI) / deferred
+
+- Cron-finished/failed push (no WS event — gateway follow-up); FCM/durable push (survives FGS death — gateway follow-up).
+- Run-finished payload enrichment (title/preview) — generic body until the gateway's `run.*` fields are verified.
+- The finer "app foreground but a *different* session open" case for run-finished — v1 gates on app-backgrounded only.
+- Inline actions on clarify (needs a typed/option answer) — tap-to-open instead.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
## Completion notifications — Phase 2 · Wave 1

Notify when an agent **run finishes** and when it **needs input**, by mapping two already-existing gateway WS events to system notifications. **Client-only** — reuses the foreground service + notification plumbing; no gateway changes.

- **`run.completed` / `run.failed` → "Run finished" / "Run failed"** notification on a new DEFAULT-importance **Activity** channel, **only when the app is backgrounded** (foreground = you see it live). Generic body (`run.*` carries no showable fields client-side); tap deep-links to the chat.
- **`clarify.request` → "Needs your input"** notification (HIGH channel, always), body = the question; tap opens the chat to answer.
- Foreground state comes from `ProcessLifecycleOwner` in `GatewayConnectionService` (a `@Volatile` flag, observer removed on destroy — no leak); a **"Run finished"** settings toggle (default on) gates run notifications.

### Honest limits (documented, deferred)
- Notifications only fire **while the foreground service is alive** (Android 15 ~6h `dataSync` cap, force-stop, reboot). A durable push (FCM/gateway) is a gateway follow-up.
- **Cron-finished/failed push** has no WS event → deferred (gateway follow-up). Run-finished body stays generic until the gateway's `run.*` payload is verified.

### Verification
- Unit tests: `NotificationMapperTest` (12 cases — gating across foreground states, pref toggles, no-session, disabled). Full suite + `assembleBeta` green; gitleaks clean.
- Built via subagent-driven development: per-task reviews + an opus whole-branch review (fixed a `ProcessLifecycleOwner` observer leak).
- **On-device end-to-end** (emulator + mock emitting over the WS): enabled notifications → WS connected → backgrounded the app → `run.completed` produced a "Run finished" notification on the Activity channel → tapping it deep-linked to the chat. Settings toggle present.

Spec/plan: `docs/superpowers/specs/2026-07-08-completion-notifications-design.md`, `docs/superpowers/plans/2026-07-08-completion-notifications.md`. Bridge-API spike corroborated by `docs/superpowers/specs/2026-07-03-notifications-approvals-only.md`.
