### PR TITLE
Fix: pass active profile to session.create (new chats were orphaned)

### DIFF
--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -191,7 +191,7 @@ class MainActivity : ComponentActivity() {
             // connect() first — a cold-start share has no open socket yet, and createSession()
             // would otherwise fail after the ready-gate timeout. connect() is idempotent.
             chat.connect()
-            runCatching { chat.createSession() }
+            runCatching { chat.createSession(profileManager.active.value) }
                 .onSuccess { id ->
                     pendingShare.put(
                         id,

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -191,6 +191,10 @@ class MainActivity : ComponentActivity() {
             // connect() first — a cold-start share has no open socket yet, and createSession()
             // would otherwise fail after the ready-gate timeout. connect() is idempotent.
             chat.connect()
+            // Load the active profile before creating: on a cold-start share nothing has called
+            // refresh() yet (that normally happens when SessionsViewModel inits), so active would be
+            // null and the new session would orphan to the gateway's default profile.
+            profileManager.refresh()
             runCatching { chat.createSession(profileManager.active.value) }
                 .onSuccess { id ->
                     pendingShare.put(

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -25,8 +25,17 @@ class ChatRepository(private val client: HermesGatewayClient) {
     /** Force an immediate reconnect, skipping the backoff wait (user tapped "Retry"). */
     fun reconnect() = client.reconnectNow()
 
-    suspend fun createSession(): String {
-        val result = client.call("session.create", buildJsonObject {})
+    /**
+     * Creates a new session. [profile] MUST be the active profile: the gateway binds the session to
+     * a per-profile state.db at creation time, and with no profile it defaults to the gateway's
+     * launch profile. Messages then persist under that default profile, but the session list is
+     * scoped to the active profile — so a chat created (and messaged) under the wrong profile is
+     * invisible in both the app and the desktop. Same per-profile rule as [resume].
+     */
+    suspend fun createSession(profile: String? = null): String {
+        val result = client.call("session.create", buildJsonObject {
+            if (!profile.isNullOrBlank()) put("profile", profile)
+        })
         return result.jsonObject["session_id"]?.jsonPrimitive?.content
             ?: error("session.create returned no id")
     }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -136,7 +136,8 @@ class SessionsViewModel @Inject constructor(
     }
 
     /** Returns the new session id, or null if creation failed (so the UI doesn't crash). */
-    suspend fun createSession(): String? = runCatching { chat.createSession() }.getOrNull()
+    suspend fun createSession(): String? =
+        runCatching { chat.createSession(profileManager.active.value) }.getOrNull()
 
     fun rename(session: Session, title: String) = viewModelScope.launch {
         runCatching { sessions.rename(session.id, title, session.profile) }.onSuccess { refresh() }

--- a/app/src/test/java/com/hermes/client/data/repository/ChatRepositoryTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/ChatRepositoryTest.kt
@@ -5,8 +5,11 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ChatRepositoryTest {
@@ -20,5 +23,29 @@ class ChatRepositoryTest {
         coVerify {
             client.call("prompt.submit", match { it["text"]!!.toString().contains("hello") })
         }
+    }
+
+    // Regression: a new chat created with no profile is bound to the gateway's DEFAULT profile,
+    // so its messages land in a db the (active-profile-scoped) session list never scans → the chat
+    // is invisible in both the Android and Desktop apps. session.create MUST carry the active profile.
+    @Test fun createSession_passes_active_profile() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns buildJsonObject { put("session_id", "abc") }
+        val repo = ChatRepository(client)
+
+        val id = repo.createSession(profile = "acme")
+
+        assertEquals("abc", id)
+        coVerify { client.call("session.create", match { it["profile"]?.jsonPrimitive?.content == "acme" }) }
+    }
+
+    @Test fun createSession_omits_blank_profile() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns buildJsonObject { put("session_id", "abc") }
+        val repo = ChatRepository(client)
+
+        repo.createSession(profile = null)
+
+        coVerify { client.call("session.create", match { !it.containsKey("profile") }) }
     }
 }


### PR DESCRIPTION
## Fix: new chats orphaned to the default profile

**Bug:** Creating a new chat on Android loses it — the chat doesn't appear in the Android sessions list, and it's not in the Desktop app either, **even after sending a message**.

**Root cause (confirmed against the gateway source):** the Android client sent `session.create` with **empty params (no `profile`)**. The gateway binds a session to a per-profile `state.db` **at creation time** — with no profile it defaults to the gateway's launch profile. The first message then persists under that default profile, but both clients list sessions **scoped to the active profile** (`GET /api/profiles/sessions?profile=<active>` opens only that profile's db). So a chat created (and messaged) while a *different* profile is active lands in a db the list never scans → invisible everywhere. Desktop-created chats work because Desktop passes the profile; Android omitted it. The client's own `resume()` doc already documented this per-profile requirement.

**Fix (client-only, no gateway change):** `session.create` now carries the active profile, mirroring `resume`/`history`:
- `ChatRepository.createSession(profile)` → adds `profile` to the RPC params (omitted when blank).
- Callers (`SessionsViewModel.createSession`, `MainActivity` share handler) pass `profileManager.active.value`.

**Verification:**
- Unit tests: `createSession_passes_active_profile` + `createSession_omits_blank_profile`. Full suite + `assembleBeta` green; gitleaks clean.
- On-device (emulator + mock, acme profile active): the `session.create` frame now shows `params={'profile': 'acme'}` — was `{}` before the fix.

Investigated via systematic-debugging (gateway source at `~/.hermes/hermes-agent/tui_gateway/server.py`); this is not a regression from recent work — `session.create` never passed a profile.

Note: this makes a new chat appear once the first message is sent. Showing an *empty* new chat instantly is separate (the gateway filters zero-message sessions server-side) — not in scope here.
