### PR TITLE
Fix: pick up AI title via session.title event (new chats were 'Untitled')

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -72,6 +72,12 @@ class SessionsViewModel @Inject constructor(
         // The list is scoped to the active profile (like the desktop, one tenant at a time), so it
         // reloads whenever the selected profile changes — including the first value once it loads.
         viewModelScope.launch { profileManager.active.collect { refresh() } }
+        // The gateway auto-titles a new chat after its first message and pushes a `session.title`
+        // event; re-fetch so the AI title replaces "Untitled" (and the now-non-empty chat appears).
+        // This VM stays in the back stack while a chat is open, so it catches the event live.
+        viewModelScope.launch {
+            chat.events.collect { if (it.type == "session.title") refresh() }
+        }
     }
 
     fun refresh() = viewModelScope.launch {

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -80,24 +81,34 @@ class SessionsViewModel @Inject constructor(
         }
     }
 
-    fun refresh() = viewModelScope.launch {
-        _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
-        try {
-            // Fetch the cross-profile list (true per-session profile + cron/empty already filtered),
-            // then scope to the active profile so only that tenant's sessions show. Until the active
-            // profile is known, fall back to showing everything rather than a blank list.
-            val active = profileManager.active.value
-            val all = sessions.listAllProfiles()
-            val list = if (active.isNullOrBlank()) all else all.filter { it.profile == active }
-            _state.value = SessionsUiState(sessions = list)
-        } catch (e: HermesApiException) {
-            if (e.code == 401) {
-                _state.value = SessionsUiState(unauthorized = true)
-            } else {
+    // Several triggers call refresh() (profile change, session.title event, manual). Cancel any
+    // in-flight refresh before starting a new one so a slow older request can't complete last and
+    // overwrite the list with stale data (latest-wins).
+    private var refreshJob: Job? = null
+
+    fun refresh() {
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
+            _state.value = _state.value.copy(loading = true, error = null, unauthorized = false)
+            try {
+                // Fetch the cross-profile list (true per-session profile + cron/empty already filtered),
+                // then scope to the active profile so only that tenant's sessions show. Until the active
+                // profile is known, fall back to showing everything rather than a blank list.
+                val active = profileManager.active.value
+                val all = sessions.listAllProfiles()
+                val list = if (active.isNullOrBlank()) all else all.filter { it.profile == active }
+                _state.value = SessionsUiState(sessions = list)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e // a superseded refresh is cancelled, not an error — don't clobber state
+            } catch (e: HermesApiException) {
+                if (e.code == 401) {
+                    _state.value = SessionsUiState(unauthorized = true)
+                } else {
+                    _state.value = SessionsUiState(error = e.message ?: "Failed to load")
+                }
+            } catch (e: Exception) {
                 _state.value = SessionsUiState(error = e.message ?: "Failed to load")
             }
-        } catch (e: Exception) {
-            _state.value = SessionsUiState(error = e.message ?: "Failed to load")
         }
     }
 

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -11,6 +11,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -31,6 +33,7 @@ class SessionsViewModelTest {
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
+        every { chatRepo.events } returns kotlinx.coroutines.flow.MutableSharedFlow()
         every { profileManager.active } returns MutableStateFlow<String?>("personal")
         every { pinStore.pinned } returns MutableStateFlow<Set<String>>(emptySet())
         every { groupExpansion.collapsed } returns MutableStateFlow<Set<String>>(emptySet())
@@ -83,6 +86,30 @@ class SessionsViewModelTest {
         val ids = vm.state.value.sessions.map { it.id }
         assertTrue("refresh must surface the newly-added session", ids.contains("s2"))
         assertEquals(2, ids.size)
+    }
+
+    // Regression: after a new chat's first message, the gateway auto-generates a title and pushes a
+    // `session.title` WS event. The list must re-fetch on that event so the AI title replaces
+    // "Untitled" — mirroring the desktop. Without this the new chat stays "Untitled" forever.
+    @Test fun session_title_event_refreshes_the_list() = runTest {
+        val events = kotlinx.coroutines.flow.MutableSharedFlow<com.hermes.client.data.network.ServerEvent>(extraBufferCapacity = 8)
+        every { chatRepo.events } returns events
+        var fetches = 0
+        coEvery { sessionRepo.listAllProfiles() } coAnswers { fetches++; emptyList() }
+        buildVm()
+        advanceUntilIdle()
+        val before = fetches
+
+        events.emit(
+            com.hermes.client.data.network.ServerEvent(
+                type = "session.title",
+                sessionId = "sk1",
+                payload = buildJsonObject { put("title", "Fix the login bug") },
+            ),
+        )
+        advanceUntilIdle()
+
+        assertTrue("a session.title event must trigger a list refresh", fetches > before)
     }
 
     // The list is scoped to the active profile (one tenant at a time, like the desktop): a session


### PR DESCRIPTION
## Fix: new chats stayed "Untitled" instead of getting the AI title

**Bug:** After the previous fix (new chats now persist + appear), a new chat showed as **"Untitled"** in the Android list instead of the AI-generated title that the Desktop app displays.

**Root cause (from the gateway source):** the gateway auto-titles a session after its first message via a background LLM call, writes the `title` DB column, and **pushes a `session.title` WS event** (`payload: {session_id, title}`) to the connection that ran the turn. Android's `SessionsViewModel` only refreshed on profile-change — it never subscribed to WS events — so it never picked up the title, and the list kept the client-side `"Untitled"` fallback. Desktop works because it listens for that same `session.title` event and patches its list.

**Fix (client-only, no gateway change):** `SessionsViewModel` now collects `chat.events` and calls `refresh()` on a `session.title` event — the same mechanism the desktop uses. A full refresh (not in-place) because the freshly-titled chat isn't in the stale list yet; the re-fetch both surfaces it and carries the AI title. The VM stays in the back stack while a chat is open, so it catches the event live.

**Verification:**
- Unit test: `session_title_event_refreshes_the_list` (a `session.title` event triggers a list re-fetch). Full suite + `assembleBeta` green; gitleaks clean.
- On-device (emulator + mock emitting `session.title`): the Chats list updated live from **"Untitled" → the AI title**.

Investigated via systematic-debugging against `~/.hermes/hermes-agent` (`agent/title_generator.py`, `tui_gateway/server.py` emits `session.title`).
