### PR TITLE
chore: rename develop branch to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: develop
+    target-branch: dev
     labels: ["dependencies"]
     open-pull-requests-limit: 5
     groups:
@@ -28,7 +28,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    target-branch: develop
+    target-branch: dev
     labels: ["dependencies", "ci"]
     groups:
       actions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ name: CI
 # Uses an unsigned debug build, so it needs no secrets.
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: CodeQL
 # Static code-scanning for security vulnerabilities in the Kotlin/Java sources.
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,9 +4,9 @@ name: Security
 # (release runtime) dependencies.
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
 
 jobs:
   secret-scan:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,11 @@ agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Branches & pull requests
 
-New work lands on `develop` first; `main` is the protected, always-releasable branch (see
+New work lands on `dev` first; `main` is the protected, always-releasable branch (see
 [Development & release workflow](README.md#development--release-workflow)).
 
-1. Branch from `develop`: `git switch develop && git switch -c feature/my-change`.
-2. Open a PR **into `develop`**. Keep it focused and incremental; describe what changed and
+1. Branch from `dev`: `git switch dev && git switch -c feature/my-change`.
+2. Open a PR **into `dev`**. Keep it focused and incremental; describe what changed and
    how you verified it.
 3. CI (build + unit tests + CodeQL + secret scan) must pass, and review conversations must be
    resolved, before merge.

--- a/README.md
+++ b/README.md
@@ -261,22 +261,22 @@ the same Wi-Fi.
 | Branch | Role | Distribution |
 |--------|------|--------------|
 | `main` | Production / stable. Always releasable. | Stable releases (`v1.2.3`) |
-| `develop` | Beta / integration. New features land here first. | Beta pre-releases (`v1.2.3-beta.1`) |
-| `feature/*` | Short-lived work branches. | — (open a PR into `develop`) |
+| `dev` | Beta / integration. New features land here first. | Beta pre-releases (`v1.2.3-beta.1`) |
+| `feature/*` | Short-lived work branches. | — (open a PR into `dev`) |
 
 Day-to-day flow:
 
 ```
-feature/x ──PR──▶ develop ──(stabilize)──▶ main
+feature/x ──PR──▶ dev ──(stabilize)──▶ main
                     │                         │
               beta pre-release          stable release
               v0.2.0-beta.1               v0.2.0
 ```
 
-1. Branch from `develop`: `git switch develop && git switch -c feature/my-change`.
-2. Open a PR into `develop`. CI (`.github/workflows/ci.yml`) builds and unit-tests every push/PR.
-3. Cut a **beta** for testers: tag a commit on `develop`, e.g. `git tag v0.2.0-beta.1 && git push --tags`.
-4. When stable, merge `develop` → `main` and tag the release: `git tag v0.2.0 && git push --tags`.
+1. Branch from `dev`: `git switch dev && git switch -c feature/my-change`.
+2. Open a PR into `dev`. CI (`.github/workflows/ci.yml`) builds and unit-tests every push/PR.
+3. Cut a **beta** for testers: tag a commit on `dev`, e.g. `git tag v0.2.0-beta.1 && git push --tags`.
+4. When stable, merge `dev` → `main` and tag the release: `git tag v0.2.0 && git push --tags`.
 
 **Automated releases** (`.github/workflows/release.yml`) — pushing a `v*` tag builds a
 signed APK and publishes a GitHub Release:
@@ -310,7 +310,7 @@ gitignored `keystore.properties`.
 ## Contributing
 
 Contributions are welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)** for setup, the
-architecture/test conventions, and the branch workflow (new work lands on `develop` via PR).
+architecture/test conventions, and the branch workflow (new work lands on `dev` via PR).
 All participation is governed by the **[Code of Conduct](CODE_OF_CONDUCT.md)**.
 
 ## Security

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ android {
             signingConfig = signingConfigs.findByName("release")
         }
         // Beta channel: a separate applicationId + "Hermes Beta" label so testers can run
-        // the beta alongside the production app. Cut from the `develop` branch as a GitHub
+        // the beta alongside the production app. Cut from the `dev` branch as a GitHub
         // pre-release. Inherits the release signing config.
         create("beta") {
             initWith(getByName("release"))

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,7 +1,7 @@
 # Plan — Direction A: Mobile↔Desktop Session Parity
 
 Spec: `docs/ideas/mobile-desktop-parity.md`
-Branch: `feature/session-parity` off `develop` (PRs into `develop`; never push `main`)
+Branch: `feature/session-parity` off `dev` (PRs into `dev`; never push `main`)
 
 ## Goal
 Make the mobile session list a faithful desktop mirror: all profiles in one
@@ -176,16 +176,16 @@ Full behavioral review before building the beta.
 
 ## Phase 4 — Ship
 
-### T6 — Build, test, beta APK, ship to develop
+### T6 — Build, test, beta APK, ship to dev
 - Bump `versionCode`/`versionName` in `app/build.gradle.kts`.
 - `gitleaks git --no-banner --redact` (must be clean).
 - Full unit suite green.
 - Build the **beta** variant APK, deliver to the user, commit to
-  `feature/session-parity`, open PR into `develop`.
+  `feature/session-parity`, open PR into `dev`.
 - Update `README.md`/`docs/ideas/mobile-desktop-parity.md` status as needed.
 
 Acceptance: signed beta APK installs alongside release; all parity behaviors work
-on-device; PR open into `develop` with green CI.
+on-device; PR open into `dev` with green CI.
 
 ---
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # TODO — Session Parity (Direction A)
 
-Branch: `feature/session-parity` off `develop`. Full plan: `tasks/plan.md`.
+Branch: `feature/session-parity` off `dev`. Full plan: `tasks/plan.md`.
 
 ## Phase 1 — Foundation
 - [x] **T1** All-profiles list; each session under its true profile
@@ -38,8 +38,8 @@ Branch: `feature/session-parity` off `develop`. Full plan: `tasks/plan.md`.
 - [x] **CHECKPOINT C** — human review (full behavioral review)
 
 ## Phase 4 — Ship
-- [x] **T6** Build, test, beta APK, ship to develop
+- [x] **T6** Build, test, beta APK, ship to dev
   - [x] Bump versionCode/versionName
   - [x] gitleaks clean; full unit suite green
-  - [x] Build beta APK, deliver, commit, PR into `develop`
+  - [x] Build beta APK, deliver, commit, PR into `dev`
   - [x] Update README / idea doc status


### PR DESCRIPTION
Renames the beta/integration branch **develop → dev** and updates all references so CI + Dependabot keep working.

The branch itself was renamed via GitHub (open Dependabot PRs #80/#19 retargeted to `dev`, `develop` now redirects). This syncs the config/docs onto `main`:
- `.github/dependabot.yml` — `target-branch: dev` (read from the default branch, so it must be updated on main or Dependabot targets a dead branch).
- `.github/workflows/{ci,security,codeql}.yml` — `branches: [main, dev]`.
- `README.md` — branch-workflow section.

No version bump / no release tag — config + docs only.