### PR TITLE
chore(deps): migrate to AGP 9.1 / compileSdk 37 (unblocks the AndroidX updates)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
     // Hilt 2.59.2 bundles kotlin-metadata-jvm capped at metadata 2.3.0, but Kotlin 2.3.10 emits
     // 2.4.0. Dagger 2.57+ unshades kotlin-metadata-jvm, so pin a matching version on the Hilt
     // processing classpaths (KSP + the plugin's javac aggregation) to read the newer metadata.
-    val kotlinMetadataJvm = "org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.10"
+    val kotlinMetadataJvm = "org.jetbrains.kotlin:kotlin-metadata-jvm:${libs.versions.kotlin.get()}"
     ksp(kotlinMetadataJvm)
     annotationProcessor(kotlinMetadataJvm)
     kspAndroidTest(kotlinMetadataJvm)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,14 +19,14 @@ plugins {
 
 android {
     namespace = "com.hermes.client"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.hermes.client"
         minSdk = 26
-        targetSdk = 36
-        versionCode = 47
-        versionName = "0.1.46"
+        targetSdk = 37
+        versionCode = 48
+        versionName = "0.1.47"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"
@@ -94,6 +94,13 @@ dependencies {
     implementation(libs.navigation.compose)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    // Hilt 2.59.2 bundles kotlin-metadata-jvm capped at metadata 2.3.0, but Kotlin 2.3.10 emits
+    // 2.4.0. Dagger 2.57+ unshades kotlin-metadata-jvm, so pin a matching version on the Hilt
+    // processing classpaths (KSP + the plugin's javac aggregation) to read the newer metadata.
+    val kotlinMetadataJvm = "org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.10"
+    ksp(kotlinMetadataJvm)
+    annotationProcessor(kotlinMetadataJvm)
+    kspAndroidTest(kotlinMetadataJvm)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.okhttp)
     implementation(libs.serialization.json)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Do NOT hardcode org.gradle.java.home here — a machine-specific path breaks CI and clones.
 android.useAndroidX=true
 kotlin.code.style=official
+
+# AGP 9 enables newDsl (and built-in Kotlin) by default, which rejects the kotlin-android
+# plugin. Keep the legacy DSL + kotlin-android plugin for now; migrate to built-in Kotlin
+# before AGP 10. See https://kotl.in/gradle/agp-new-dsl
+android.newDsl=false
+android.builtInKotlin=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,33 +1,35 @@
 [versions]
-# Mature, fully-stable toolchain. AGP 9.x uses built-in Kotlin (rejects the kotlin-android
-# plugin) and the newest AndroidX (core 1.19.0+) demands AGP 9.1 / compileSdk 37 — too
-# bleeding-edge for a maintainable app. We pin AGP 8.13.2 + compileSdk 36 + Gradle 8.14.5
-# with the proven mid-2025 AndroidX set below.
-# Kotlin pinned to 2.2.21 (NOT 2.3.x/2.4.0): Hilt 2.57.1 (the last Hilt that supports AGP 8.x;
-# Hilt 2.59.2 requires AGP 9) caps at Kotlin metadata 2.2.0, which Kotlin 2.2.x emits.
-agp = "8.13.2"
-kotlin = "2.2.21"
-ksp = "2.2.21-2.0.5"
+# AGP 9.1 toolchain (migrated from AGP 8.13.2), needed by the current AndroidX set
+# (lifecycle 2.11 / hilt-navigation 1.4 / compileSdk 37). Key constraints:
+#  - AGP 9.1.0 requires Gradle 9.3.1+ (see gradle-wrapper.properties).
+#  - AGP 9 defaults to `newDsl`/built-in Kotlin, which rejects the kotlin-android plugin.
+#    We keep the plugin via `android.newDsl=false` (gradle.properties) — a temporary bridge;
+#    migrate to built-in Kotlin before AGP 10 removes the opt-out.
+#  - Kotlin 2.3.10 emits metadata 2.4.0; Hilt 2.59.2 caps at 2.3.0, so we pin the (unshaded,
+#    Dagger 2.57+) kotlin-metadata-jvm on the Hilt processor classpath in app/build.gradle.kts.
+agp = "9.1.0"
+kotlin = "2.3.10"
+ksp = "2.3.10"
 coreKtx = "1.16.0"
-lifecycle = "2.9.4"
-activityCompose = "1.10.1"
-composeBom = "2025.06.01"
-navigationCompose = "2.8.9"
-hilt = "2.57.1"
-hiltNavigation = "1.2.0"
+lifecycle = "2.11.0"
+activityCompose = "1.13.0"
+composeBom = "2025.12.01"
+navigationCompose = "2.9.8"
+hilt = "2.59.2"
+hiltNavigation = "1.4.0"
 okhttp = "5.4.0"
 serialization = "1.11.0"
 coroutines = "1.11.0"
-datastore = "1.1.7"
-securityCrypto = "1.0.0"
-markdown = "0.35.0"
-material = "1.12.0"
+datastore = "1.2.1"
+securityCrypto = "1.1.0"
+markdown = "0.43.0"
+material = "1.14.0"
 turbine = "1.2.1"
-mockk = "1.13.13"
+mockk = "1.14.11"
 junit = "4.13.2"
-androidxTestCore = "1.6.1"
-androidxTestJunit = "1.2.1"
-androidxTestRunner = "1.6.2"
+androidxTestCore = "1.7.0"
+androidxTestJunit = "1.3.0"
+androidxTestRunner = "1.7.0"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Migrates the build toolchain to **AGP 9.1** so the pending AndroidX updates that require AGP 9.1 / compileSdk 37 can land (this supersedes the Dependabot gradle group in #80, which couldn't build on AGP 8).

## Toolchain
- AGP `8.13.2 → 9.1.0`, Gradle `8.14.5 → 9.3.1` (AGP 9.1 requires Gradle 9.3.1+)
- Kotlin `2.2.21 → 2.3.10`, KSP `→ 2.3.10`, Hilt `2.57.1 → 2.59.2`
- compileSdk / targetSdk `36 → 37`
- versionName `0.1.47` (code 48)

## Dependency bumps (the #80 group)
lifecycle 2.11.0 · hilt-navigation-compose 1.4.0 · compose BOM 2025.12.01 · navigation 2.9.8 · activity 1.13.0 · datastore 1.2.1 · security-crypto 1.1.0 · mikepenz markdown 0.43.0 · material 1.14.0 · mockk 1.14.11 · androidx test 1.7.0/1.3.0

## AGP 9 bridges (no source changes required)
- `android.newDsl=false` — AGP 9 defaults to the new DSL / built-in Kotlin, which rejects the `kotlin-android` plugin. This keeps the plugin working. **Temporary** — migrate to built-in Kotlin before AGP 10 removes the opt-out.
- `kotlin-metadata-jvm:2.3.10` pinned on the Hilt processor classpath — Kotlin 2.3.10 emits metadata 2.4.0 while Hilt 2.59.2 caps at 2.3.0; Dagger 2.57+ unshades the library so it can be overridden.

## Verification
- `:app:testDebugUnitTest` — **206 passed, 0 failures**
- `:app:assembleBeta` — green (the `checkAarMetadata` gate that blocked #80 now passes); produces a signed beta APK
- On-device: app launches and renders under the new runtime (Compose BOM 2025.12 / lifecycle 2.11), no crash

## Follow-ups
- Built-in-Kotlin migration (drop `newDsl=false`/`kotlin-android`) before AGP 10.
- Minor: the "Upcoming" segmented-button chip renders slightly boxed/wrapped under the new Compose Material — cosmetic, worth a glance.
