### PR TITLE
fix(notifications): fire 'Run finished' on the real end-of-turn event (message.complete)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 48
-        versionName = "0.1.47"
+        versionCode = 49
+        versionName = "0.1.48"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -6,8 +6,9 @@ import com.hermes.client.data.network.str
 /**
  * Pure mapping from a gateway event to a notification (or null). `approval.request` and
  * `clarify.request` always notify (they need the user's input regardless of whether the app is
- * foregrounded); `run.completed`/`run.failed` only notify when the app is backgrounded — see the
- * note on [Notif]. A stable id is derived from the session so repeats of the same event update
+ * foregrounded); `message.complete` (run finished) and `error` (run failed) only notify when the
+ * app is backgrounded — see the note on [Notif] for why these are the real /api/ws events. A stable
+ * id is derived from the session so a turn's repeated `message.complete`s update one notification
  * rather than stack.
  */
 fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForeground: Boolean): NotificationSpec? {
@@ -36,14 +37,18 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
             body = event.str("question") ?: "The agent has a question.",
             route = "chat/$sid", actions = emptyList(), groupKey = "approval",
         )
-        // Run finished: only when backgrounded; generic body (no showable payload fields client-side).
-        Notif.EVENT_RUN_COMPLETED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+        // Run finished: `message.complete` is the end-of-turn event on /api/ws (the app also uses it
+        // to stop the "generating" spinner). Only notify when backgrounded; the per-session id above
+        // collapses a turn's repeated message.completes into one updating notification, not a stack.
+        Notif.EVENT_MESSAGE_COMPLETE -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
             id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run finished",
             body = "Your agent finished — tap to view.", route = "chat/$sid", actions = emptyList(), groupKey = "run",
         )
-        Notif.EVENT_RUN_FAILED -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
+        // Run failed: the gateway emits `error` on a turn-fatal failure (carries a message).
+        Notif.EVENT_ERROR -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
             id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run failed",
-            body = "The agent run failed — tap to view.", route = "chat/$sid", actions = emptyList(), groupKey = "run",
+            body = event.str("message") ?: "The agent run failed — tap to view.",
+            route = "chat/$sid", actions = emptyList(), groupKey = "run",
         )
         else -> null
     }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -47,7 +47,7 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
         // Run failed: the gateway emits `error` on a turn-fatal failure (carries a message).
         Notif.EVENT_ERROR -> if (!prefs.runFinished || appInForeground) null else NotificationSpec(
             id = id, channelId = Notif.CHANNEL_ACTIVITY, title = "Run failed",
-            body = event.str("message") ?: "The agent run failed — tap to view.",
+            body = event.str("message")?.takeIf { it.isNotBlank() } ?: "The agent run failed — tap to view.",
             route = "chat/$sid", actions = emptyList(), groupKey = "run",
         )
         else -> null

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -27,14 +27,18 @@ object Notif {
     const val CHANNEL_SERVICE = "service"
     const val CHANNEL_ACTIVITY = "activity"
 
-    // `approval.request` is the only notifiable event on the app's WebSocket (/api/ws). Verified
-    // against the gateway source: it broadcasts approval + run/tool/message-stream lifecycle events,
-    // but NOT cron-finished (cron delivers to messaging platforms) or a messaging-inbound event —
-    // so those aren't offered here. See docs/superpowers/specs/2026-07-03-notifications-approvals-only.
+    // Notifiable events on the app's WebSocket (/api/ws), verified against the gateway source:
+    //  - approval.request / clarify.request -> the agent needs the user (always notify)
+    //  - message.complete                   -> a turn finished (the "Run finished" alert)
+    //  - error                              -> a turn failed (the "Run failed" alert)
+    // The gateway's /api/ws emits `message.complete` at end-of-turn (tui_gateway/server.py); it does
+    // NOT emit `run.completed`/`run.failed` (those belong to the separate messaging-platform HTTP/SSE
+    // API the app never connects to) — which is why the earlier run.completed mapping never fired.
+    // Cron-finished isn't offered (cron delivers to messaging platforms).
     const val EVENT_APPROVAL = "approval.request"
-    const val EVENT_RUN_COMPLETED = "run.completed"
-    const val EVENT_RUN_FAILED = "run.failed"
     const val EVENT_CLARIFY = "clarify.request"
+    const val EVENT_MESSAGE_COMPLETE = "message.complete"
+    const val EVENT_ERROR = "error"
 
     const val ACTION_APPROVE = "approve"
     const val ACTION_DENY = "deny"

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -76,6 +76,12 @@ class NotificationMapperTest {
         assertNull(toNotificationSpec(event(Notif.EVENT_ERROR, "c1"), on, appInForeground = true))
     }
 
+    @Test fun error_falls_back_to_default_body_when_message_missing_or_blank() {
+        val fallback = "The agent run failed — tap to view."
+        assertEquals(fallback, toNotificationSpec(event(Notif.EVENT_ERROR, "c1"), on, appInForeground = false)!!.body)
+        assertEquals(fallback, toNotificationSpec(event(Notif.EVENT_ERROR, "c1", "message" to "   "), on, appInForeground = false)!!.body)
+    }
+
     // Regression: the gateway's /api/ws never emits run.completed/run.failed (those are on the
     // separate messaging API), so the app must NOT key on them — the 0.1.44 feature did and could
     // never fire. message.complete/error are the real end-of-turn events.

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -54,25 +54,46 @@ class NotificationMapperTest {
         assertNull(toNotificationSpec(e, on.copy(approvals = false), appInForeground = false))
     }
 
-    @Test fun run_completed_only_when_backgrounded() {
-        val e = event(Notif.EVENT_RUN_COMPLETED, "c1")
-        assertNotNull(toNotificationSpec(e, on, appInForeground = false))
+    @Test fun message_complete_is_run_finished_only_when_backgrounded() {
+        val e = event(Notif.EVENT_MESSAGE_COMPLETE, "c1")
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals("Run finished", spec.title)
+        assertEquals(Notif.CHANNEL_ACTIVITY, spec.channelId)
+        assertEquals("chat/c1", spec.route)
         assertNull(toNotificationSpec(e, on, appInForeground = true))
     }
 
-    @Test fun run_completed_off_when_pref_off() {
-        val e = event(Notif.EVENT_RUN_COMPLETED, "c1")
+    @Test fun message_complete_off_when_pref_off() {
+        val e = event(Notif.EVENT_MESSAGE_COMPLETE, "c1")
         assertNull(toNotificationSpec(e, on.copy(runFinished = false), appInForeground = false))
     }
 
-    @Test fun run_failed_title() {
-        val spec = toNotificationSpec(event(Notif.EVENT_RUN_FAILED, "c1"), on, appInForeground = false)!!
+    @Test fun error_maps_to_run_failed_with_message() {
+        val spec = toNotificationSpec(event(Notif.EVENT_ERROR, "c1", "message" to "boom"), on, appInForeground = false)!!
         assertEquals("Run failed", spec.title)
+        assertEquals("boom", spec.body)
         assertEquals(Notif.CHANNEL_ACTIVITY, spec.channelId)
+        assertNull(toNotificationSpec(event(Notif.EVENT_ERROR, "c1"), on, appInForeground = true))
+    }
+
+    // Regression: the gateway's /api/ws never emits run.completed/run.failed (those are on the
+    // separate messaging API), so the app must NOT key on them — the 0.1.44 feature did and could
+    // never fire. message.complete/error are the real end-of-turn events.
+    @Test fun legacy_run_events_do_not_notify() {
+        assertNull(toNotificationSpec(event("run.completed", "c1"), on, appInForeground = false))
+        assertNull(toNotificationSpec(event("run.failed", "c1"), on, appInForeground = false))
+    }
+
+    // A turn can emit several message.completes; the per-session id keeps them one updating
+    // notification rather than a growing stack.
+    @Test fun repeated_message_complete_share_one_notification_id() {
+        val a = toNotificationSpec(event(Notif.EVENT_MESSAGE_COMPLETE, "c1"), on, appInForeground = false)!!
+        val b = toNotificationSpec(event(Notif.EVENT_MESSAGE_COMPLETE, "c1"), on, appInForeground = false)!!
+        assertEquals(a.id, b.id)
     }
 
     @Test fun no_session_is_null() {
-        assertNull(toNotificationSpec(event(Notif.EVENT_RUN_COMPLETED, null), on, appInForeground = false))
+        assertNull(toNotificationSpec(event(Notif.EVENT_MESSAGE_COMPLETE, null), on, appInForeground = false))
     }
 
     @Test fun disabled_is_null() {


### PR DESCRIPTION
Fixes the completion-notification bug you hit — you sent a request, it finished, and no alert fired.

## Root cause
The 0.1.44 feature keyed the "Run finished" notification on **`run.completed`/`run.failed`**, but the app's WebSocket (`/api/ws`) **never emits those** — they belong to a separate messaging-platform HTTP/SSE API the app doesn't connect to. The socket emits **`message.complete`** at end-of-turn (`tui_gateway/server.py`). So the completion branch was unreachable for interactive turns, regardless of settings. (Independently confirmed by an in-repo comment the feature author left.)

## Fix
- `message.complete` → **Run finished** (the app already uses this event to stop the generating spinner).
- `error` → **Run failed** (carries a message).
- The per-session notification id collapses a turn's repeated `message.complete`s into one updating notification (no stacking). Foreground-suppression + the `enabled`/`runFinished` prefs are unchanged.

## Verification
- **On-device (emulator + mock):** notifications enabled, app backgrounded → a `message.complete` posts **"Run finished — Your agent finished — tap to view."** (alerting), alongside the ongoing "Hermes — Connected" service notification. Screenshot-confirmed.
- **208 unit tests pass** — `NotificationMapperTest` now covers `message.complete`/`error`, a **regression guard** that the legacy `run.*` strings no longer notify, and the per-session dedup id.

## Note
Two secondary factors still apply by design: the master **Enable notifications** toggle is **off by default** (must be turned on — it starts the background service), and completion alerts are **suppressed while the app is foregrounded**.

versionName 0.1.48 (code 49).