### PR TITLE
fix(ui): keep Home feed filter tabs on one line

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 49
-        versionName = "0.1.48"
+        versionCode = 50
+        versionName = "0.1.49"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
@@ -2,12 +2,14 @@ package com.hermes.client.ui.activity
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hermes.client.ui.theme.LocalProfileAccent
 
@@ -43,7 +45,18 @@ fun FeedTabs(
                     activeContainerColor = accent.accent,
                     activeContentColor = accent.onAccent,
                 ),
-            ) { Text("$label $count") }
+            ) {
+                // Keep every segment on one line: the four share the row width equally, and the
+                // longest label ("Upcoming N") wraps under Material3's newer SegmentedButton
+                // defaults. A smaller label style + single line + ellipsis keeps them uniform.
+                Text(
+                    "$label $count",
+                    style = MaterialTheme.typography.labelSmall,
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
The `All / Today / Upcoming / Recent` segmented filter wrapped the longest label ("Upcoming N") onto two lines under the Compose Material3 bump (BOM 2025.12) from the AGP 9 migration, leaving that segment boxed and taller than the others.

Fix: render each segment's label with `labelSmall` + `maxLines = 1` + `softWrap = false` + ellipsis, so all four stay uniform single-line pills.

Verified on-device: the row now renders as four even pills (All / Today / Upcoming / Recent), no wrapping. versionName 0.1.49.