### PR TITLE
chore(build): migrate to AGP 9 built-in Kotlin (drop the newDsl bridge)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,6 @@ val keystoreProps = Properties().apply {
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
@@ -25,8 +24,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 49
-        versionName = "0.1.48"
+        versionCode = 50
+        versionName = "0.1.49"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ buildscript {
 
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 
-# AGP 9 enables newDsl (and built-in Kotlin) by default, which rejects the kotlin-android
-# plugin. Keep the legacy DSL + kotlin-android plugin for now; migrate to built-in Kotlin
-# before AGP 10. See https://kotl.in/gradle/agp-new-dsl
-android.newDsl=false
-android.builtInKotlin=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,6 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,8 @@
 # AGP 9.1 toolchain (migrated from AGP 8.13.2), needed by the current AndroidX set
 # (lifecycle 2.11 / hilt-navigation 1.4 / compileSdk 37). Key constraints:
 #  - AGP 9.1.0 requires Gradle 9.3.1+ (see gradle-wrapper.properties).
-#  - AGP 9 defaults to `newDsl`/built-in Kotlin, which rejects the kotlin-android plugin.
-#    We keep the plugin via `android.newDsl=false` (gradle.properties) — a temporary bridge;
-#    migrate to built-in Kotlin before AGP 10 removes the opt-out.
+#  - Uses AGP 9's built-in Kotlin (no kotlin-android plugin; newDsl/builtInKotlin at their AGP 9
+#    defaults). The kotlin.plugin.compose / kotlin.plugin.serialization / ksp plugins still apply.
 #  - Kotlin 2.3.10 emits metadata 2.4.0; Hilt 2.59.2 caps at 2.3.0, so we pin the (unshaded,
 #    Dagger 2.57+) kotlin-metadata-jvm on the Hilt processor classpath in app/build.gradle.kts.
 agp = "9.1.0"


### PR DESCRIPTION
Clears the AGP-10 debt from the AGP 9 migration by moving to **built-in Kotlin** and removing the temporary bridge.

## Changes
- `gradle.properties`: drop `android.newDsl=false` / `android.builtInKotlin=false` (use AGP 9 defaults).
- Remove the `org.jetbrains.kotlin.android` plugin from the app + root build files — AGP 9's built-in Kotlin compiles the sources.
- `kotlin.plugin.compose` / `kotlin.plugin.serialization` / `ksp` / `hilt` apply unchanged; the top-level `kotlin { compilerOptions { jvmTarget } }` block and the `kotlin-metadata-jvm` Hilt pin remain required.

## Why
AGP 10 removes the `newDsl`/`builtInKotlin` opt-out, so this is the forward-compatible setup. Per the [AGP built-in Kotlin guide](https://developer.android.com/build/migrate-to-built-in-kotlin).

## Verification
- **209 unit tests pass**, `assembleBeta` green (Hilt/KSP processing intact with the metadata pin), app launches on-device — no crash.

## Notes
- Pre-existing `hiltViewModel` deprecation warnings (from the hilt-navigation 1.4 bump — the fn moved to `androidx.hilt.lifecycle.viewmodel.compose`) are unrelated; a separate cleanup.
- Version coordination: this and #89 (Upcoming-chip fix) both bump to 0.1.49; the second to merge will be rebased to 0.1.50.

versionName 0.1.49.