### PR TITLE
Release v0.1.49 to production (built-in Kotlin + feed-tab fix)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,6 @@ val keystoreProps = Properties().apply {
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
@@ -25,8 +24,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 49
-        versionName = "0.1.48"
+        versionCode = 50
+        versionName = "0.1.49"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 49
-        versionName = "0.1.48"
+        versionCode = 50
+        versionName = "0.1.49"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
@@ -53,7 +53,6 @@ fun FeedTabs(
                     "$label $count",
                     style = MaterialTheme.typography.labelSmall,
                     maxLines = 1,
-                    softWrap = false,
                     overflow = TextOverflow.Ellipsis,
                 )
             }

--- a/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/FeedTabs.kt
@@ -2,12 +2,14 @@ package com.hermes.client.ui.activity
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.hermes.client.ui.theme.LocalProfileAccent
 
@@ -43,7 +45,18 @@ fun FeedTabs(
                     activeContainerColor = accent.accent,
                     activeContentColor = accent.onAccent,
                 ),
-            ) { Text("$label $count") }
+            ) {
+                // Keep every segment on one line: the four share the row width equally, and the
+                // longest label ("Upcoming N") wraps under Material3's newer SegmentedButton
+                // defaults. A smaller label style + single line + ellipsis keeps them uniform.
+                Text(
+                    "$label $count",
+                    style = MaterialTheme.typography.labelSmall,
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ buildscript {
 
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 
-# AGP 9 enables newDsl (and built-in Kotlin) by default, which rejects the kotlin-android
-# plugin. Keep the legacy DSL + kotlin-android plugin for now; migrate to built-in Kotlin
-# before AGP 10. See https://kotl.in/gradle/agp-new-dsl
-android.newDsl=false
-android.builtInKotlin=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,6 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,8 @@
 # AGP 9.1 toolchain (migrated from AGP 8.13.2), needed by the current AndroidX set
 # (lifecycle 2.11 / hilt-navigation 1.4 / compileSdk 37). Key constraints:
 #  - AGP 9.1.0 requires Gradle 9.3.1+ (see gradle-wrapper.properties).
-#  - AGP 9 defaults to `newDsl`/built-in Kotlin, which rejects the kotlin-android plugin.
-#    We keep the plugin via `android.newDsl=false` (gradle.properties) — a temporary bridge;
-#    migrate to built-in Kotlin before AGP 10 removes the opt-out.
+#  - Uses AGP 9's built-in Kotlin (no kotlin-android plugin; newDsl/builtInKotlin at their AGP 9
+#    defaults). The kotlin.plugin.compose / kotlin.plugin.serialization / ksp plugins still apply.
 #  - Kotlin 2.3.10 emits metadata 2.4.0; Hilt 2.59.2 caps at 2.3.0, so we pin the (unshaded,
 #    Dagger 2.57+) kotlin-metadata-jvm on the Hilt processor classpath in app/build.gradle.kts.
 agp = "9.1.0"


### PR DESCRIPTION
Promotes `dev` → `main` for **v0.1.49** (0.1.48 → 0.1.49).

## What ships
- **AGP 9 built-in Kotlin migration** — removes the temporary `newDsl=false`/`kotlin-android` bridge; forward-compatible for AGP 10. Compose/serialization/KSP/Hilt + the kotlin-metadata-jvm pin unchanged.
- **UI:** Home feed filter tabs stay on one line (Upcoming-chip wrap fixed).

## Verified
- 209 unit tests pass; assembleBeta green; app launches on-device. Soaked as v0.1.49-beta.1.

## Gates
- Dependabot: 0 open HIGH/CRITICAL. dev CI green. Tag `v0.1.49` after merge.