### PR TITLE
feat(approvals): touch-native tiered approvals (fix wire format + tiered bottom sheet)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 50
-        versionName = "0.1.49"
+        versionCode = 51
+        versionName = "0.1.50"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/src/main/java/com/hermes/client/data/network/ServerEvent.kt
+++ b/app/src/main/java/com/hermes/client/data/network/ServerEvent.kt
@@ -1,8 +1,10 @@
 package com.hermes.client.data.network
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -35,3 +37,9 @@ internal fun ServerEvent.str(key: String): String? = when (val el = payload[key]
 
 internal fun JsonObject.objOrEmpty(key: String): JsonObject =
     (this[key] as? JsonObject) ?: JsonObject(emptyMap())
+
+internal fun ServerEvent.bool(key: String): Boolean? =
+    (payload[key] as? JsonPrimitive)?.booleanOrNull
+
+internal fun ServerEvent.strList(key: String): List<String> =
+    (payload[key] as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -3,6 +3,7 @@ package com.hermes.client.data.repository
 import com.hermes.client.data.network.ConnectionState
 import com.hermes.client.data.network.HermesGatewayClient
 import com.hermes.client.data.network.ServerEvent
+import com.hermes.client.ui.chat.ApprovalChoice
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.JsonObject
@@ -123,11 +124,11 @@ class ChatRepository(private val client: HermesGatewayClient) {
         })
     }
 
-    suspend fun respondApproval(sessionId: String, choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    suspend fun respondApproval(sessionId: String, choice: ApprovalChoice) {
         client.call("approval.respond", buildJsonObject {
             put("session_id", sessionId)
             put("choice", choice.wire)
-            put("approved", choice != com.hermes.client.ui.chat.ApprovalChoice.DENY)
+            put("approved", choice != ApprovalChoice.DENY)
         })
     }
 

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -123,10 +123,11 @@ class ChatRepository(private val client: HermesGatewayClient) {
         })
     }
 
-    suspend fun respondApproval(sessionId: String, approve: Boolean) {
+    suspend fun respondApproval(sessionId: String, choice: com.hermes.client.ui.chat.ApprovalChoice) {
         client.call("approval.respond", buildJsonObject {
             put("session_id", sessionId)
-            put("approved", approve)
+            put("choice", choice.wire)
+            put("approved", choice != com.hermes.client.ui.chat.ApprovalChoice.DENY)
         })
     }
 

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 
-/** Handles the Approve/Deny actions on an approval notification by sending the approval RPC. */
+/** Handles the Allow once/Deny actions on an approval notification by sending the approval RPC. */
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
     @Inject lateinit var chat: ChatRepository

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.hermes.client.data.diagnostics.DebugLog
 import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.ui.chat.ApprovalChoice
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,10 +23,11 @@ class NotificationActionReceiver : BroadcastReceiver() {
         val sid = intent.getStringExtra("session_id") ?: return
         val notifId = intent.getIntExtra("notif_id", -1)
         val approve = intent.action == Notif.ACTION_APPROVE
+        val choice = if (approve) ApprovalChoice.ONCE else ApprovalChoice.DENY
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                runCatching { withTimeout(8_000) { chat.respondApproval(sid, approve) } }
+                runCatching { withTimeout(8_000) { chat.respondApproval(sid, choice) } }
                     .onSuccess {
                         // Only clear the notification once the RPC actually succeeded — on
                         // failure, leave it so the action isn't silently lost.

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -22,8 +22,10 @@ class NotificationActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val sid = intent.getStringExtra("session_id") ?: return
         val notifId = intent.getIntExtra("notif_id", -1)
-        val approve = intent.action == Notif.ACTION_APPROVE
-        val choice = if (approve) ApprovalChoice.ONCE else ApprovalChoice.DENY
+        val choice = when (intent.action) {
+            Notif.ACTION_ALLOW_ONCE -> ApprovalChoice.ONCE
+            else -> ApprovalChoice.DENY
+        }
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
@@ -34,7 +36,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
                         if (notifId != -1) notifier.cancel(notifId)
                     }
                     .onFailure { e ->
-                        DebugLog.log("notif", "approval response failed session=$sid approve=$approve: ${e.message}")
+                        DebugLog.log("notif", "approval response failed session=$sid choice=$choice: ${e.message}")
                     }
             } finally {
                 pending.finish()

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -1,7 +1,10 @@
 package com.hermes.client.notifications
 
 import com.hermes.client.data.network.ServerEvent
+import com.hermes.client.data.network.bool
 import com.hermes.client.data.network.str
+import com.hermes.client.ui.chat.ApprovalTier
+import com.hermes.client.ui.chat.tierFor
 
 /**
  * Pure mapping from a gateway event to a notification (or null). `approval.request` and
@@ -19,18 +22,24 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
     // ongoing foreground-service notification, and notify()-ing over it would clobber it.
     if (id == 1001) id = 1002
     return when (event.type) {
-        Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else NotificationSpec(
-            id = id,
-            channelId = Notif.CHANNEL_APPROVALS,
-            title = "Approval needed",
-            body = event.str("prompt") ?: "The agent is waiting for your approval.",
-            route = "chat/$sid",
-            actions = listOf(
-                NotifAction("Approve", Notif.ACTION_APPROVE, sid),
-                NotifAction("Deny", Notif.ACTION_DENY, sid),
-            ),
-            groupKey = "approval",
-        )
+        Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else {
+            val elevated = tierFor(event.bool("allow_permanent") ?: false) == ApprovalTier.ELEVATED
+            NotificationSpec(
+                id = id,
+                channelId = Notif.CHANNEL_APPROVALS,
+                title = "Approval needed",
+                body = event.str("description")?.ifBlank { null }
+                    ?: event.str("command")?.ifBlank { null }
+                    ?: "The agent is waiting for your approval.",
+                route = "chat/$sid",
+                actions = if (elevated) listOf(NotifAction("Deny", Notif.ACTION_DENY, sid))
+                          else listOf(
+                              NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid),
+                              NotifAction("Deny", Notif.ACTION_DENY, sid),
+                          ),
+                groupKey = "approval",
+            )
+        }
         // Needs-you: always notify (ignores foreground); tap opens the chat to answer.
         Notif.EVENT_CLARIFY -> if (!prefs.approvals) null else NotificationSpec(
             id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Needs your input",

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -7,7 +7,7 @@ data class NotificationPrefs(
     val runFinished: Boolean = true,
 )
 
-/** An inline notification action (Approve/Deny) carrying the target session. */
+/** An inline notification action (Allow once/Deny) carrying the target session. */
 data class NotifAction(val label: String, val action: String, val sessionId: String)
 
 /** A platform-independent description of a notification, so mapping stays unit-testable. */

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -40,6 +40,6 @@ object Notif {
     const val EVENT_MESSAGE_COMPLETE = "message.complete"
     const val EVENT_ERROR = "error"
 
-    const val ACTION_APPROVE = "approve"
+    const val ACTION_ALLOW_ONCE = "allow_once"
     const val ACTION_DENY = "deny"
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
@@ -1,0 +1,102 @@
+package com.hermes.client.ui.chat
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.components.SlideToConfirm
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onDismiss: () -> Unit) {
+    val accent = LocalProfileAccent.current
+    val tier = tierFor(req.allowPermanent)
+    val error = MaterialTheme.colorScheme.error
+    val badge = if (tier == ApprovalTier.ELEVATED) error else accent.accent
+    val label = req.patternKeys.firstOrNull()?.let { " · $it" } ?: ""
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text(
+                (if (tier == ApprovalTier.ELEVATED) "Elevated" else "Approval needed") + label,
+                style = MaterialTheme.typography.titleMedium,
+                color = badge,
+            )
+            if (req.command.isNotBlank()) {
+                Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 12.dp)) {
+                    Text(req.command, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            if (req.description.isNotBlank()) {
+                Text(req.description, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(bottom = 16.dp))
+            }
+
+            if (tier == ApprovalTier.STANDARD) {
+                Button(
+                    onClick = { onRespond(ApprovalChoice.ONCE) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Allow once" },
+                    colors = ButtonDefaults.buttonColors(containerColor = accent.accent, contentColor = accent.onAccent),
+                ) { Text("Allow once") }
+                OutlinedButton(
+                    onClick = { onRespond(ApprovalChoice.SESSION) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Allow this run" },
+                ) { Text("Allow this run") }
+                OutlinedButton(
+                    onClick = { onRespond(ApprovalChoice.ALWAYS) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Always allow" },
+                ) { Text("Always allow") }
+                TextButton(
+                    onClick = { onRespond(ApprovalChoice.DENY) },
+                    modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Deny" },
+                ) { Text("Deny") }
+            } else {
+                // Elevated: Deny is prominent; Allow requires a deliberate slide.
+                var thisRun by remember { mutableStateOf(false) }
+                Button(
+                    onClick = { onRespond(ApprovalChoice.DENY) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Deny" },
+                    colors = ButtonDefaults.buttonColors(containerColor = error),
+                ) { Text("Deny") }
+                TextButton(
+                    onClick = { thisRun = !thisRun },
+                    modifier = Modifier.fillMaxWidth()
+                        .semantics { contentDescription = "Toggle allow scope" },
+                ) {
+                    Text(if (thisRun) "Scope: allow for this run" else "Scope: allow once")
+                }
+                SlideToConfirm(
+                    label = if (thisRun) "  → slide to allow this run" else "  → slide to allow once",
+                    accent = accent.accent,
+                    onConfirm = { onRespond(if (thisRun) ApprovalChoice.SESSION else ApprovalChoice.ONCE) },
+                    modifier = Modifier.padding(vertical = 8.dp)
+                        .semantics { contentDescription = "Slide to allow" },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,7 +38,12 @@ fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onD
     val badge = if (tier == ApprovalTier.ELEVATED) error else accent.accent
     val label = req.patternKeys.firstOrNull()?.let { " · $it" } ?: ""
 
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    // An approval must be an explicit choice: veto the Hidden transition so a swipe / scrim-tap
+    // can't dismiss the sheet while pendingApproval is still set (which would desync — sheet gone
+    // but state still blocked). The sheet leaves composition only when a choice clears the pending.
+    val sheetState = rememberModalBottomSheetState(confirmValueChange = { it != SheetValue.Hidden })
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
             Text(
                 (if (tier == ApprovalTier.ELEVATED) "Elevated" else "Approval needed") + label,

--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt
@@ -1,0 +1,18 @@
+package com.hermes.client.ui.chat
+
+/** The scoped decision the gateway understands: approval.respond {choice}. */
+enum class ApprovalChoice(val wire: String) {
+    ONCE("once"), SESSION("session"), ALWAYS("always"), DENY("deny")
+}
+
+/** Risk tier, derived from the gateway's `allow_permanent` bit (false = Tirith-flagged). */
+enum class ApprovalTier { STANDARD, ELEVATED }
+
+fun tierFor(allowPermanent: Boolean): ApprovalTier =
+    if (allowPermanent) ApprovalTier.STANDARD else ApprovalTier.ELEVATED
+
+/** Allow-scopes offered per tier (DENY is always available separately). */
+fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice> = when (tier) {
+    ApprovalTier.STANDARD -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS)
+    ApprovalTier.ELEVATED -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION)
+}

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -30,7 +30,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -427,13 +426,3 @@ private fun ToolCard(tool: ToolCall) {
     }
 }
 
-@Composable
-fun ApprovalDialog(prompt: String, onApprove: () -> Unit, onDeny: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDeny,
-        title = { Text("Approval requested") },
-        text = { Text(prompt) },
-        confirmButton = { TextButton(onClick = onApprove) { Text("Approve") } },
-        dismissButton = { TextButton(onClick = onDeny) { Text("Deny") } },
-    )
-}

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -488,10 +488,10 @@ fun ChatScreen(
     }
 
     state.pendingApproval?.let { req ->
-        ApprovalDialog(
-            prompt = req.prompt,
-            onApprove = { vm.approve(true) },
-            onDeny = { vm.approve(false) },
+        ApprovalSheet(
+            req = req,
+            onRespond = { vm.respondApproval(it) },
+            onDismiss = { /* keep pending: do nothing until the user chooses */ },
         )
     }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -1,13 +1,20 @@
 package com.hermes.client.ui.chat
 
 import com.hermes.client.data.network.ServerEvent
+import com.hermes.client.data.network.bool
 import com.hermes.client.data.network.str
+import com.hermes.client.data.network.strList
 import com.hermes.client.domain.ChatMessage
 import com.hermes.client.domain.Role
 import com.hermes.client.domain.ToolCall
 import com.hermes.client.domain.ToolStatus
 
-data class ApprovalRequest(val prompt: String)
+data class ApprovalRequest(
+    val command: String,
+    val description: String,
+    val patternKeys: List<String>,
+    val allowPermanent: Boolean,
+)
 data class ClarifyRequest(val question: String, val options: List<String>)
 
 data class ChatUiState(
@@ -28,7 +35,8 @@ fun ChatUiState.withUserMessage(text: String): ChatUiState =
 
 
 /** Pure reducer: folds one server event into the chat state. */
-fun reduce(state: ChatUiState, event: ServerEvent): ChatUiState {
+fun ChatUiState.reduce(event: ServerEvent): ChatUiState {
+    val state = this
     // Targets the last STREAMING assistant message.
     fun mutateLastAssistant(block: (ChatMessage) -> ChatMessage): ChatUiState {
         val idx = state.messages.indexOfLast { it.role == Role.ASSISTANT && it.isStreaming }
@@ -83,7 +91,15 @@ fun reduce(state: ChatUiState, event: ServerEvent): ChatUiState {
                 if (it.id == tid) it.copy(status = ToolStatus.DONE, output = event.str("result") ?: "") else it
             })
         }
-        "approval.request" -> state.copy(pendingApproval = ApprovalRequest(event.str("prompt") ?: ""))
+        "approval.request" -> state.copy(
+            pendingApproval = ApprovalRequest(
+                command = event.str("command") ?: "",
+                description = event.str("description") ?: "",
+                patternKeys = event.strList("pattern_keys")
+                    .ifEmpty { event.str("pattern_key")?.let { listOf(it) } ?: emptyList() },
+                allowPermanent = event.bool("allow_permanent") ?: false,
+            ),
+        )
         "clarify.request" -> state.copy(
             pendingClarify = ClarifyRequest(event.str("question") ?: "", emptyList()),
         )

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -241,9 +241,9 @@ class ChatViewModel @Inject constructor(
 
     fun clearPathItems() { _pathItems.value = emptyList() }
 
-    fun approve(approve: Boolean) {
+    fun respondApproval(choice: com.hermes.client.ui.chat.ApprovalChoice) {
         _state.value = _state.value.copy(pendingApproval = null)
-        viewModelScope.launch { runCatching { chat.respondApproval(sessionId, approve) } }
+        viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
     }
 
     fun clarify(answer: String) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -243,7 +243,14 @@ class ChatViewModel @Inject constructor(
 
     fun respondApproval(choice: ApprovalChoice) {
         _state.value = _state.value.copy(pendingApproval = null)
-        viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
+        viewModelScope.launch {
+            runCatching { chat.respondApproval(sessionId, choice) }
+                .onFailure {
+                    if (it is kotlinx.coroutines.CancellationException) throw it
+                    // The sheet is already gone; surface the failure so a lost approve/deny is visible.
+                    appendError("Couldn't send your approval — check the connection and try again.")
+                }
+        }
     }
 
     fun clarify(answer: String) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -241,7 +241,7 @@ class ChatViewModel @Inject constructor(
 
     fun clearPathItems() { _pathItems.value = emptyList() }
 
-    fun respondApproval(choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    fun respondApproval(choice: ApprovalChoice) {
         _state.value = _state.value.copy(pendingApproval = null)
         viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
     }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -150,7 +150,7 @@ class ChatViewModel @Inject constructor(
             chat.events.filter { it.sessionId == null || it.sessionId == sessionId }
                 // Defense in depth: a single malformed event must never crash the chat.
                 // reduce() is pure, so on a bad event keep the prior state and drop it.
-                .onEach { event -> runCatching { reduce(_state.value, event) }.onSuccess { _state.value = it } }
+                .onEach { event -> runCatching { _state.value.reduce(event) }.onSuccess { _state.value = it } }
                 .collect {}
         }
         // C2 + I3: watch connection transitions

--- a/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +43,9 @@ fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier
     var trackPx by remember { mutableFloatStateOf(0f) }
     var dragPx by remember { mutableFloatStateOf(0f) }
     val density = LocalDensity.current
+    // pointerInput(Unit) captures its lambdas once; wrap onConfirm so a drag-end always calls the
+    // CURRENT lambda (the caller swaps it when the Once/Session toggle flips) rather than a stale one.
+    val currentOnConfirm by rememberUpdatedState(onConfirm)
     Box(
         modifier
             .fillMaxWidth()
@@ -61,7 +65,7 @@ fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier
                 .background(accent, CircleShape)
                 .pointerInput(Unit) {
                     detectHorizontalDragGestures(
-                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) onConfirm() else dragPx = 0f },
+                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) currentOnConfirm() else dragPx = 0f },
                         onHorizontalDrag = { _, delta -> dragPx = (dragPx + delta).coerceIn(0f, trackPx) },
                     )
                 },

--- a/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
@@ -1,0 +1,71 @@
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+private val ThumbSize = 56.dp
+
+// Pure, unit-tested. Progress along the track (0f..1f).
+fun slideProgress(dragPx: Float, trackPx: Float): Float =
+    if (trackPx <= 0f) 0f else dragPx.coerceIn(0f, trackPx) / trackPx
+
+fun isConfirmed(progress: Float): Boolean = progress >= 0.9f
+
+/** Drag the thumb across the track to confirm a deliberate (dangerous) action. */
+@Composable
+fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier: Modifier = Modifier) {
+    var trackPx by remember { mutableFloatStateOf(0f) }
+    var dragPx by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
+    Box(
+        modifier
+            .fillMaxWidth()
+            .height(ThumbSize)
+            .onSizeChanged { size ->
+                val thumbPx = with(density) { ThumbSize.toPx() }
+                trackPx = max(0f, size.width.toFloat() - thumbPx)
+            }
+            .background(accent.copy(alpha = 0.15f), CircleShape),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(label, modifier = Modifier.fillMaxWidth(), color = accent)
+        Box(
+            Modifier
+                .size(ThumbSize)
+                .offset { IntOffset(dragPx.roundToInt(), 0) }
+                .background(accent, CircleShape)
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) onConfirm() else dragPx = 0f },
+                        onHorizontalDrag = { _, delta -> dragPx = (dragPx + delta).coerceIn(0f, trackPx) },
+                    )
+                },
+            contentAlignment = Alignment.Center,
+        ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = Color.White) }
+    }
+}

--- a/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
@@ -1,0 +1,39 @@
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import com.hermes.client.ui.chat.ApprovalChoice
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RespondApprovalTest {
+    private val client = mockk<HermesGatewayClient>(relaxed = true)
+    private val repo = ChatRepository(client) // match the real ctor; add other relaxed deps if needed
+
+    @Test fun once_sends_choice_once_and_approved_true() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.ONCE)
+        assertEquals("s1", params.captured["session_id"]!!.jsonPrimitive.content)
+        assertEquals("once", params.captured["choice"]!!.jsonPrimitive.content)
+        assertTrue(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test fun deny_sends_choice_deny_and_approved_false() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.DENY)
+        assertEquals("deny", params.captured["choice"]!!.jsonPrimitive.content)
+        assertFalse(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+}

--- a/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
@@ -5,7 +5,6 @@ import com.hermes.client.ui.chat.ApprovalChoice
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -16,12 +16,31 @@ class NotificationMapperTest {
         ServerEvent(type, sid, buildJsonObject { pairs.forEach { (k, v) -> put(k, v) } })
 
     @Test fun approval_makes_high_priority_spec_with_actions() {
-        val spec = toNotificationSpec(event(Notif.EVENT_APPROVAL, "s1", "prompt" to "Delete file?"), on, appInForeground = false)!!
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "Delete file?"); put("allow_permanent", true)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
         assertEquals(Notif.CHANNEL_APPROVALS, spec.channelId)
         assertEquals("chat/s1", spec.route)
         assertTrue(spec.body.contains("Delete file?"))
-        assertEquals(listOf(Notif.ACTION_APPROVE, Notif.ACTION_DENY), spec.actions.map { it.action })
+        assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
         assertTrue(spec.actions.all { it.sessionId == "s1" })
+    }
+
+    @Test fun standard_approval_offers_allow_once_and_deny() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "git push -f"); put("allow_permanent", true)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
+    }
+
+    @Test fun elevated_approval_offers_deny_only() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(listOf(Notif.ACTION_DENY), spec.actions.map { it.action })
     }
 
     @Test fun approval_notifies_regardless_of_foreground() {

--- a/app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt
@@ -1,0 +1,47 @@
+package com.hermes.client.ui.chat
+
+import com.hermes.client.data.network.ServerEvent
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApprovalParseTest {
+    private fun approvalEvent(payload: JsonObject) = ServerEvent("approval.request", "s1", payload)
+
+    @Test fun parses_command_description_patterns_and_allow_permanent() {
+        val e = approvalEvent(buildJsonObject {
+            put("session_id", "s1")
+            put("command", "rm -rf /tmp/x")
+            put("description", "recursive delete")
+            putJsonArray("pattern_keys") { add("recursive delete"); add("force") }
+            put("allow_permanent", true)
+        })
+        val state = ChatUiState().reduce(e)
+        val req = state.pendingApproval!!
+        assertEquals("rm -rf /tmp/x", req.command)
+        assertEquals("recursive delete", req.description)
+        assertEquals(listOf("recursive delete", "force"), req.patternKeys)
+        assertTrue(req.allowPermanent)
+    }
+
+    @Test fun missing_fields_degrade_safely() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject { put("session_id", "s1") })).pendingApproval!!
+        assertEquals("", req.command)
+        assertEquals("", req.description)
+        assertEquals(emptyList<String>(), req.patternKeys)
+        assertFalse(req.allowPermanent) // safe default: no "Always"
+    }
+
+    @Test fun single_pattern_key_is_used_when_array_absent() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject {
+            put("session_id", "s1"); put("pattern_key", "force push")
+        })).pendingApproval!!
+        assertEquals(listOf("force push"), req.patternKeys)
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt
@@ -1,0 +1,35 @@
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApprovalTierTest {
+    @Test fun choice_wire_values() {
+        assertEquals("once", ApprovalChoice.ONCE.wire)
+        assertEquals("session", ApprovalChoice.SESSION.wire)
+        assertEquals("always", ApprovalChoice.ALWAYS.wire)
+        assertEquals("deny", ApprovalChoice.DENY.wire)
+    }
+
+    @Test fun allow_permanent_true_is_standard() {
+        assertEquals(ApprovalTier.STANDARD, tierFor(allowPermanent = true))
+    }
+
+    @Test fun allow_permanent_false_is_elevated() {
+        assertEquals(ApprovalTier.ELEVATED, tierFor(allowPermanent = false))
+    }
+
+    @Test fun standard_offers_once_session_always() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS),
+            allowedScopes(ApprovalTier.STANDARD),
+        )
+    }
+
+    @Test fun elevated_offers_only_once_and_session() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION),
+            allowedScopes(ApprovalTier.ELEVATED),
+        )
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
@@ -19,10 +19,10 @@ class ChatReducerTest {
 
     @Test fun start_delta_complete_builds_one_assistant_message() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("message.delta") { put("text","Hel") })
-        s = reduce(s, ev("message.delta") { put("text","lo") })
-        s = reduce(s, ev("message.complete") { put("text","Hello") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("message.delta") { put("text","Hel") })
+        s = s.reduce(ev("message.delta") { put("text","lo") })
+        s = s.reduce(ev("message.complete") { put("text","Hello") })
         assertEquals(1, s.messages.size)
         assertEquals(Role.ASSISTANT, s.messages[0].role)
         assertEquals("Hello", s.messages[0].text)
@@ -32,9 +32,9 @@ class ChatReducerTest {
 
     @Test fun tool_events_attach_to_current_turn() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name","search") })
-        s = reduce(s, ev("tool.complete") { put("tool_id", "t1"); put("result", "found") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name","search") })
+        s = s.reduce(ev("tool.complete") { put("tool_id", "t1"); put("result", "found") })
         val tools = s.messages.last().tools
         assertEquals(1, tools.size)
         assertEquals("search", tools[0].name)
@@ -49,11 +49,11 @@ class ChatReducerTest {
     @Test fun reused_message_id_across_turns_yields_unique_ids() {
         var s = ChatUiState.empty()
         s = s.withUserMessage("hi")
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("message.complete") { put("text", "hello") })
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("message.complete") { put("text", "hello") })
         s = s.withUserMessage("again")
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("message.complete") { put("text", "hi again") })
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("message.complete") { put("text", "hi again") })
 
         val ids = s.messages.map { it.id }
         assertEquals("every message must have a unique list key", ids.size, ids.toSet().size)
@@ -67,9 +67,9 @@ class ChatReducerTest {
     // structured result should survive as text on the tool card.
     @Test fun tool_complete_with_object_result_does_not_crash() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.search") })
-        s = reduce(s, ev("tool.complete") {
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.search") })
+        s = s.reduce(ev("tool.complete") {
             put("tool_id", "t1")
             putJsonObject("result") { put("unread", 3); put("subject", "Citizenship update") }
         })
@@ -80,9 +80,9 @@ class ChatReducerTest {
 
     @Test fun tool_complete_with_array_result_does_not_crash() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.list") })
-        s = reduce(s, ev("tool.complete") {
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.list") })
+        s = s.reduce(ev("tool.complete") {
             put("tool_id", "t1")
             putJsonArray("result") { add("a@x.com"); add("b@y.com") }
         })
@@ -92,33 +92,33 @@ class ChatReducerTest {
     // The same non-primitive hazard applies to message text fields, not just tool results.
     @Test fun message_complete_with_object_text_does_not_crash() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("message.complete") { putJsonObject("text") { put("v", "hi") } })
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("message.complete") { putJsonObject("text") { put("v", "hi") } })
         assertFalse(s.isGenerating)
     }
 
     @Test fun approval_request_sets_pending() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("approval.request") { put("prompt", "Run rm -rf?") })
-        assertEquals("Run rm -rf?", s.pendingApproval?.prompt)
+        s = s.reduce(ev("approval.request") { put("command", "rm -rf?") })
+        assertEquals("rm -rf?", s.pendingApproval?.command)
     }
 
     @Test fun thinking_delta_accumulates() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("reasoning.delta") { put("text","hmm ") })
-        s = reduce(s, ev("reasoning.delta") { put("text","ok") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("reasoning.delta") { put("text","hmm ") })
+        s = s.reduce(ev("reasoning.delta") { put("text","ok") })
         assertEquals("hmm ok", s.messages.last().thinking)
     }
 
     // T8b: tool.complete arriving AFTER message.complete must still update the tool card.
     @Test fun late_tool_complete_after_message_complete_is_not_dropped() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name","search") })
-        s = reduce(s, ev("message.complete") { put("text","done") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name","search") })
+        s = s.reduce(ev("message.complete") { put("text","done") })
         // At this point the assistant message is no longer streaming.
-        s = reduce(s, ev("tool.complete") { put("tool_id", "t1"); put("result", "done") })
+        s = s.reduce(ev("tool.complete") { put("tool_id", "t1"); put("result", "done") })
         val tools = s.messages.last().tools
         assertEquals(1, tools.size)
         assertEquals(ToolStatus.DONE, tools[0].status)
@@ -128,8 +128,8 @@ class ChatReducerTest {
     // I3: markInterrupted closes the streaming message and clears isGenerating.
     @Test fun markInterrupted_with_streaming_message() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("message.delta") { put("text","partial") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("message.delta") { put("text","partial") })
         assertTrue(s.isGenerating)
         assertTrue(s.messages.last().isStreaming)
 

--- a/app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt
@@ -1,0 +1,24 @@
+package com.hermes.client.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SlideToConfirmStateTest {
+    @Test fun progress_is_clamped_0_to_1() {
+        assertEquals(0f, slideProgress(dragPx = -50f, trackPx = 100f), 0.001f)
+        assertEquals(0.5f, slideProgress(dragPx = 50f, trackPx = 100f), 0.001f)
+        assertEquals(1f, slideProgress(dragPx = 150f, trackPx = 100f), 0.001f)
+    }
+
+    @Test fun confirmed_only_past_threshold() {
+        assertFalse(isConfirmed(0.89f))
+        assertTrue(isConfirmed(0.90f))
+        assertTrue(isConfirmed(1f))
+    }
+
+    @Test fun zero_track_is_safe() {
+        assertEquals(0f, slideProgress(dragPx = 10f, trackPx = 0f), 0.001f)
+    }
+}

--- a/docs/superpowers/plans/2026-07-10-tiered-approvals.md
+++ b/docs/superpowers/plans/2026-07-10-tiered-approvals.md
@@ -1,0 +1,721 @@
+# Touch-native Tiered Approvals — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the broken approval wire format and give agent approvals a touch-native, two-tier bottom-sheet UX on the phone.
+
+**Architecture:** Parse the real `approval.request` fields (`command`, `description`, `pattern_keys`, `allow_permanent`) into an expanded `ApprovalRequest`; respond with the gateway's scoped `approval.respond {choice}` (plus a derived `approved` for version-skew safety). A pure tier layer maps `allow_permanent` → Standard/Elevated and the allowed scopes; a `ModalBottomSheet` renders the tiers, with a reusable `SlideToConfirm` gating the Elevated *Allow*. Notifications become tier-aware. No new gateway endpoints.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, kotlinx.serialization, JUnit + MockK.
+
+## Global Constraints
+
+- NO new gateway endpoints — reuse `approval.respond {choice: once|session|always|deny, all}` and the existing request fields.
+- Material3; per-tenant accent via `LocalProfileAccent.current` (`ProfileAccentColors(accent, onAccent)`).
+- NO AI/assistant attribution in commits, files, or PRs.
+- Run `gitleaks git --no-banner --redact` before every push; work lands on `feature/tiered-approvals` → PR into `dev`.
+- Build env: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. Compile `:app:compileDebugKotlin`; unit tests `:app:testDebugUnitTest`; beta `:app:assembleBeta`.
+- Spec: `docs/superpowers/specs/2026-07-10-tiered-approvals-design.md`.
+
+## File map
+
+- Create `app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt` — `ApprovalChoice`, `ApprovalTier`, `tierFor`, `allowedScopes` (pure).
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt` — expand `ApprovalRequest`; parse the new fields in the `approval.request` reduce.
+- Modify `app/src/main/java/com/hermes/client/data/network/ServerEvent.kt` — add `bool` + `strList` payload helpers.
+- Modify `app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt` — `respondApproval(sessionId, choice)`.
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt` — `respondApproval(choice)` replaces `approve(Boolean)`.
+- Create `app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt` — reusable slide-to-confirm + pure state holder.
+- Create `app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt` — the bottom sheet.
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt` — replace `ApprovalDialog` with `ApprovalSheet`.
+- Remove `ApprovalDialog` from `app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt`.
+- Modify `notifications/NotificationMapper.kt`, `NotificationModels.kt`, `NotificationActionReceiver.kt` — tier-aware actions + choice-based response.
+
+---
+
+### Task 1: Tier + choice model (pure)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt`
+
+**Interfaces:**
+- Consumes: `ApprovalRequest` (Task 2 expands it, but Task 1 only needs `allowPermanent: Boolean` — define `tierFor` against that field; both tasks land before compile of consumers).
+- Produces: `enum ApprovalChoice(val wire: String)`, `enum ApprovalTier`, `fun tierFor(allowPermanent: Boolean): ApprovalTier`, `fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApprovalTierTest {
+    @Test fun choice_wire_values() {
+        assertEquals("once", ApprovalChoice.ONCE.wire)
+        assertEquals("session", ApprovalChoice.SESSION.wire)
+        assertEquals("always", ApprovalChoice.ALWAYS.wire)
+        assertEquals("deny", ApprovalChoice.DENY.wire)
+    }
+
+    @Test fun allow_permanent_true_is_standard() {
+        assertEquals(ApprovalTier.STANDARD, tierFor(allowPermanent = true))
+    }
+
+    @Test fun allow_permanent_false_is_elevated() {
+        assertEquals(ApprovalTier.ELEVATED, tierFor(allowPermanent = false))
+    }
+
+    @Test fun standard_offers_once_session_always() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS),
+            allowedScopes(ApprovalTier.STANDARD),
+        )
+    }
+
+    @Test fun elevated_offers_only_once_and_session() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION),
+            allowedScopes(ApprovalTier.ELEVATED),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalTierTest"`
+Expected: FAIL — unresolved reference `ApprovalChoice` / `tierFor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+/** The scoped decision the gateway understands: approval.respond {choice}. */
+enum class ApprovalChoice(val wire: String) {
+    ONCE("once"), SESSION("session"), ALWAYS("always"), DENY("deny")
+}
+
+/** Risk tier, derived from the gateway's `allow_permanent` bit (false = Tirith-flagged). */
+enum class ApprovalTier { STANDARD, ELEVATED }
+
+fun tierFor(allowPermanent: Boolean): ApprovalTier =
+    if (allowPermanent) ApprovalTier.STANDARD else ApprovalTier.ELEVATED
+
+/** Allow-scopes offered per tier (DENY is always available separately). */
+fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice> = when (tier) {
+    ApprovalTier.STANDARD -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS)
+    ApprovalTier.ELEVATED -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalTierTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt
+git commit -m "feat(approvals): tier + choice model (allow_permanent -> Standard/Elevated + scopes)"
+```
+
+---
+
+### Task 2: Parse the real approval.request fields
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/network/ServerEvent.kt` (add `bool`, `strList`)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt` (expand `ApprovalRequest`, line ~10; update the `"approval.request"` reduce, line ~86)
+- Test: `app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt`
+
+**Interfaces:**
+- Consumes: `ServerEvent` (`str`, and new `bool`/`strList`), `ChatUiState.reduce`.
+- Produces: `data class ApprovalRequest(command, description, patternKeys: List<String>, allowPermanent: Boolean)`; `ServerEvent.bool(key): Boolean?`; `ServerEvent.strList(key): List<String>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import com.hermes.client.data.network.ServerEvent
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApprovalParseTest {
+    private fun approvalEvent(payload: JsonObject) = ServerEvent("approval.request", "s1", payload)
+
+    @Test fun parses_command_description_patterns_and_allow_permanent() {
+        val e = approvalEvent(buildJsonObject {
+            put("session_id", "s1")
+            put("command", "rm -rf /tmp/x")
+            put("description", "recursive delete")
+            putJsonArray("pattern_keys") { add("recursive delete"); add("force") }
+            put("allow_permanent", true)
+        })
+        val state = ChatUiState().reduce(e)
+        val req = state.pendingApproval!!
+        assertEquals("rm -rf /tmp/x", req.command)
+        assertEquals("recursive delete", req.description)
+        assertEquals(listOf("recursive delete", "force"), req.patternKeys)
+        assertTrue(req.allowPermanent)
+    }
+
+    @Test fun missing_fields_degrade_safely() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject { put("session_id", "s1") })).pendingApproval!!
+        assertEquals("", req.command)
+        assertEquals("", req.description)
+        assertEquals(emptyList<String>(), req.patternKeys)
+        assertFalse(req.allowPermanent) // safe default: no "Always"
+    }
+
+    @Test fun single_pattern_key_is_used_when_array_absent() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject {
+            put("session_id", "s1"); put("pattern_key", "force push")
+        })).pendingApproval!!
+        assertEquals(listOf("force push"), req.patternKeys)
+    }
+}
+```
+
+Note: `buildJsonObject { putJsonArray("pattern_keys") { add("x") } }` requires `import kotlinx.serialization.json.add`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalParseTest"`
+Expected: FAIL — `ApprovalRequest` has no `command` etc.; `reduce` still reads `prompt`.
+
+- [ ] **Step 3a: Add payload helpers to `ServerEvent.kt`**
+
+Append after the existing `objOrEmpty` helper:
+
+```kotlin
+internal fun ServerEvent.bool(key: String): Boolean? =
+    (payload[key] as? JsonPrimitive)?.booleanOrNull
+
+internal fun ServerEvent.strList(key: String): List<String> =
+    (payload[key] as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()
+```
+
+Add imports at the top of `ServerEvent.kt`:
+```kotlin
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.booleanOrNull
+```
+
+- [ ] **Step 3b: Expand `ApprovalRequest` and update the reduce in `ChatUiState.kt`**
+
+Replace the old model (`data class ApprovalRequest(val prompt: String)`) with:
+```kotlin
+data class ApprovalRequest(
+    val command: String,
+    val description: String,
+    val patternKeys: List<String>,
+    val allowPermanent: Boolean,
+)
+```
+
+Replace the `"approval.request"` branch of `reduce` (was `ApprovalRequest(event.str("prompt") ?: "")`) with:
+```kotlin
+"approval.request" -> state.copy(
+    pendingApproval = ApprovalRequest(
+        command = event.str("command") ?: "",
+        description = event.str("description") ?: "",
+        patternKeys = event.strList("pattern_keys")
+            .ifEmpty { event.str("pattern_key")?.let { listOf(it) } ?: emptyList() },
+        allowPermanent = event.bool("allow_permanent") ?: false,
+    ),
+)
+```
+Add the imports used: `import com.hermes.client.data.network.bool` and `import com.hermes.client.data.network.strList` (alongside the existing `str` import).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalParseTest"`
+Expected: PASS (3 tests). (`ChatScreen.kt`/`ChatViewModel.kt` won't compile yet — they still reference the old model/`approve`; Tasks 3 & 5 fix them. Run the targeted test class, not the whole build, until then.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/network/ServerEvent.kt app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt
+git commit -m "feat(approvals): parse real approval.request fields (command/description/pattern_keys/allow_permanent)"
+```
+
+---
+
+### Task 3: Scoped response (choice, not boolean)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt` (`respondApproval`, ~line 126)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt` (`approve`, ~line 244)
+- Test: `app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt`
+
+**Interfaces:**
+- Consumes: `ApprovalChoice` (Task 1), `HermesGatewayClient.call(method, params): JsonElement`.
+- Produces: `suspend fun ChatRepository.respondApproval(sessionId: String, choice: ApprovalChoice)`; `fun ChatViewModel.respondApproval(choice: ApprovalChoice)`.
+
+- [ ] **Step 1: Write the failing test** (mirror the existing ChatRepository test style — MockK the client, capture the params)
+
+```kotlin
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import com.hermes.client.ui.chat.ApprovalChoice
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RespondApprovalTest {
+    private val client = mockk<HermesGatewayClient>(relaxed = true)
+    private val repo = ChatRepository(client) // match the real ctor; add other relaxed deps if needed
+
+    @Test fun once_sends_choice_once_and_approved_true() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.ONCE)
+        assertEquals("s1", params.captured["session_id"]!!.jsonPrimitive.content)
+        assertEquals("once", params.captured["choice"]!!.jsonPrimitive.content)
+        assertTrue(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test fun deny_sends_choice_deny_and_approved_false() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.DENY)
+        assertEquals("deny", params.captured["choice"]!!.jsonPrimitive.content)
+        assertFalse(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+}
+```
+(If `ChatRepository`'s constructor takes more than `client`, construct it the way the existing repository tests do — check `app/src/test/.../ChatRepositoryTest*.kt` for the real signature and reuse it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.RespondApprovalTest"`
+Expected: FAIL — `respondApproval(String, ApprovalChoice)` doesn't exist.
+
+- [ ] **Step 3a: Change `ChatRepository.respondApproval`**
+
+```kotlin
+suspend fun respondApproval(sessionId: String, choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    client.call("approval.respond", buildJsonObject {
+        put("session_id", sessionId)
+        put("choice", choice.wire)
+        put("approved", choice != com.hermes.client.ui.chat.ApprovalChoice.DENY)
+    })
+}
+```
+
+- [ ] **Step 3b: Change `ChatViewModel.approve` → `respondApproval`**
+
+```kotlin
+fun respondApproval(choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    _state.value = _state.value.copy(pendingApproval = null)
+    viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.RespondApprovalTest"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
+git commit -m "feat(approvals): scoped approval.respond {choice} (+ derived approved) replacing the boolean"
+```
+
+---
+
+### Task 4: Reusable SlideToConfirm
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt`
+
+**Interfaces:**
+- Produces: pure `slideProgress(dragPx: Float, trackPx: Float): Float` (0f..1f) and `isConfirmed(progress: Float): Boolean` (>= 0.9f); `@Composable fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier: Modifier = Modifier)`.
+
+- [ ] **Step 1: Write the failing test** (pure state logic only — no Compose UI test)
+
+```kotlin
+package com.hermes.client.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SlideToConfirmStateTest {
+    @Test fun progress_is_clamped_0_to_1() {
+        assertEquals(0f, slideProgress(dragPx = -50f, trackPx = 100f), 0.001f)
+        assertEquals(0.5f, slideProgress(dragPx = 50f, trackPx = 100f), 0.001f)
+        assertEquals(1f, slideProgress(dragPx = 150f, trackPx = 100f), 0.001f)
+    }
+
+    @Test fun confirmed_only_past_threshold() {
+        assertFalse(isConfirmed(0.89f))
+        assertTrue(isConfirmed(0.90f))
+        assertTrue(isConfirmed(1f))
+    }
+
+    @Test fun zero_track_is_safe() {
+        assertEquals(0f, slideProgress(dragPx = 10f, trackPx = 0f), 0.001f)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.components.SlideToConfirmStateTest"`
+Expected: FAIL — unresolved `slideProgress`/`isConfirmed`.
+
+- [ ] **Step 3: Implement `SlideToConfirm.kt`**
+
+```kotlin
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+
+// Pure, unit-tested. Progress along the track (0f..1f).
+fun slideProgress(dragPx: Float, trackPx: Float): Float =
+    if (trackPx <= 0f) 0f else dragPx.coerceIn(0f, trackPx) / trackPx
+
+fun isConfirmed(progress: Float): Boolean = progress >= 0.9f
+
+/** Drag the thumb across the track to confirm a deliberate (dangerous) action. */
+@Composable
+fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier: Modifier = Modifier) {
+    var trackPx by remember { mutableFloatStateOf(0f) }
+    var dragPx by remember { mutableFloatStateOf(0f) }
+    val progress = slideProgress(dragPx, trackPx)
+    Box(
+        modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .onSizeChanged { trackPx = max(0f, it.width.toFloat() - 56f * 3) } // minus thumb width (~56dp) in px approx
+            .background(accent.copy(alpha = 0.15f), CircleShape),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(label, modifier = Modifier.fillMaxWidth(), color = accent)
+        Box(
+            Modifier
+                .size(56.dp)
+                .background(accent, CircleShape)
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) onConfirm() else dragPx = 0f },
+                        onHorizontalDrag = { _, delta -> dragPx = (dragPx + delta).coerceIn(0f, trackPx) },
+                    )
+                },
+            contentAlignment = Alignment.Center,
+        ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = Color.White) }
+    }
+}
+```
+(Note: exact thumb-offset math for the visual position can be refined during Task 5 on-device polish — the *behavior* under test is `slideProgress` + `isConfirmed`, which drive confirmation. If the offset expression is awkward, translate the thumb by `dragPx` via `Modifier.offset { IntOffset(dragPx.roundToInt(), 0) }` and set `trackPx` from the box width minus the thumb width.)
+
+- [ ] **Step 4: Run test to verify it passes; then compile**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.components.SlideToConfirmStateTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt
+git commit -m "feat(ui): reusable SlideToConfirm (pure progress/confirm logic + composable)"
+```
+
+---
+
+### Task 5: Approval bottom sheet + wire into ChatScreen
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt` (~line 490, `pendingApproval` block)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt` (remove `ApprovalDialog`)
+
+**Interfaces:**
+- Consumes: `ApprovalRequest` (Task 2), `ApprovalTier`/`ApprovalChoice`/`tierFor`/`allowedScopes` (Task 1), `SlideToConfirm` (Task 4), `LocalProfileAccent.current` (`ProfileAccentColors(accent, onAccent)`).
+- Produces: `@Composable fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onDismiss: () -> Unit)`.
+
+- [ ] **Step 1: Implement `ApprovalSheet.kt`** (Compose UI — verified on-device in Task 7, not unit-tested)
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.components.SlideToConfirm
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onDismiss: () -> Unit) {
+    val accent = LocalProfileAccent.current
+    val tier = tierFor(req.allowPermanent)
+    val error = MaterialTheme.colorScheme.error
+    val badge = if (tier == ApprovalTier.ELEVATED) error else accent.accent
+    val label = req.patternKeys.firstOrNull()?.let { " · $it" } ?: ""
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text(
+                (if (tier == ApprovalTier.ELEVATED) "Elevated" else "Approval needed") + label,
+                style = MaterialTheme.typography.titleMedium,
+                color = badge,
+            )
+            if (req.command.isNotBlank()) {
+                Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 12.dp)) {
+                    Text(req.command, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            if (req.description.isNotBlank()) {
+                Text(req.description, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(bottom = 16.dp))
+            }
+
+            if (tier == ApprovalTier.STANDARD) {
+                Button(
+                    onClick = { onRespond(ApprovalChoice.ONCE) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = accent.accent, contentColor = accent.onAccent),
+                ) { Text("Allow once") }
+                OutlinedButton(onClick = { onRespond(ApprovalChoice.SESSION) }, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) { Text("Allow this run") }
+                OutlinedButton(onClick = { onRespond(ApprovalChoice.ALWAYS) }, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) { Text("Always allow") }
+                TextButton(onClick = { onRespond(ApprovalChoice.DENY) }, modifier = Modifier.fillMaxWidth()) { Text("Deny") }
+            } else {
+                // Elevated: Deny is prominent; Allow requires a deliberate slide.
+                var thisRun by remember { mutableStateOf(false) }
+                Button(
+                    onClick = { onRespond(ApprovalChoice.DENY) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = error),
+                ) { Text("Deny") }
+                TextButton(onClick = { thisRun = !thisRun }, modifier = Modifier.fillMaxWidth()) {
+                    Text(if (thisRun) "Scope: allow for this run" else "Scope: allow once")
+                }
+                SlideToConfirm(
+                    label = if (thisRun) "  → slide to allow this run" else "  → slide to allow once",
+                    accent = accent.accent,
+                    onConfirm = { onRespond(if (thisRun) ApprovalChoice.SESSION else ApprovalChoice.ONCE) },
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `ChatScreen.kt`** — replace the `ApprovalDialog(...)` block:
+
+```kotlin
+state.pendingApproval?.let { req ->
+    ApprovalSheet(
+        req = req,
+        onRespond = { vm.respondApproval(it) },
+        onDismiss = { /* keep pending: do nothing until the user chooses */ },
+    )
+}
+```
+
+- [ ] **Step 3: Remove `ApprovalDialog` from `ChatComponents.kt`** (it's now unused; delete the function + any now-unused imports it introduced, e.g. `AlertDialog`, if nothing else uses them).
+
+- [ ] **Step 4: Compile + assembleBeta**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:assembleBeta`
+Expected: BUILD SUCCESSFUL; all prior unit tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+git commit -m "feat(approvals): touch-native tiered approval bottom sheet (Standard scopes + Elevated slide-to-allow)"
+```
+
+---
+
+### Task 6: Tier-aware notifications
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationModels.kt` (add `ACTION_ALLOW_ONCE`; note `allowPermanent` need)
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt` (approval branch → tier-aware actions)
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt` (send `ApprovalChoice`)
+- Test: `app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `ServerEvent.bool` (Task 2), `ApprovalChoice` (Task 1), `tierFor` (Task 1).
+- Produces: approval `NotificationSpec` whose actions depend on `tierFor(event.bool("allow_permanent") ?: false)`: **Standard** → `NotifAction("Allow once", ACTION_ALLOW_ONCE, sid)` + `NotifAction("Deny", ACTION_DENY, sid)`; **Elevated** → `NotifAction("Deny", ACTION_DENY, sid)` only (tap opens the app). Add `const val ACTION_ALLOW_ONCE = "allow_once"`.
+
+- [ ] **Step 1: Write the failing tests** (extend `NotificationMapperTest`)
+
+```kotlin
+@Test fun standard_approval_offers_allow_once_and_deny() {
+    val e = ServerEvent("approval.request", "s1", buildJsonObject {
+        put("session_id", "s1"); put("command", "git push -f"); put("allow_permanent", true)
+    })
+    val spec = toNotificationSpec(e, on, appInForeground = false)!!
+    assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
+}
+
+@Test fun elevated_approval_offers_deny_only() {
+    val e = ServerEvent("approval.request", "s1", buildJsonObject {
+        put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
+    })
+    val spec = toNotificationSpec(e, on, appInForeground = false)!!
+    assertEquals(listOf(Notif.ACTION_DENY), spec.actions.map { it.action })
+}
+```
+(Reuse the file's existing `on` prefs + imports; add `com.hermes.client.data.network.ServerEvent`, `buildJsonObject`, `put` if not present.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.notifications.NotificationMapperTest"`
+Expected: FAIL — `ACTION_ALLOW_ONCE` missing / actions still `[approve, deny]`.
+
+- [ ] **Step 3a: `NotificationModels.kt`** — add:
+```kotlin
+const val ACTION_ALLOW_ONCE = "allow_once"
+```
+(Keep `ACTION_APPROVE`/`ACTION_DENY`; `ACTION_APPROVE` may become unused — remove if nothing references it after Task 6.)
+
+- [ ] **Step 3b: `NotificationMapper.kt`** — replace the `EVENT_APPROVAL` branch's fixed `actions = listOf(Approve, Deny)` with tier-aware actions. The mapper takes the `ServerEvent`, so compute the tier inline:
+```kotlin
+Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else {
+    val elevated = tierFor(event.bool("allow_permanent") ?: false) == ApprovalTier.ELEVATED
+    NotificationSpec(
+        id = id,
+        channelId = Notif.CHANNEL_APPROVALS,
+        title = "Approval needed",
+        body = event.str("description")?.ifBlank { null }
+            ?: event.str("command")?.ifBlank { null }
+            ?: "The agent is waiting for your approval.",
+        route = "chat/$sid",
+        actions = if (elevated) listOf(NotifAction("Deny", Notif.ACTION_DENY, sid))
+                  else listOf(NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid), NotifAction("Deny", Notif.ACTION_DENY, sid)),
+        groupKey = "approval",
+    )
+}
+```
+Add imports: `com.hermes.client.data.network.bool`, `com.hermes.client.ui.chat.tierFor`, `com.hermes.client.ui.chat.ApprovalTier`.
+
+- [ ] **Step 3c: `NotificationActionReceiver.kt`** — map the action to a choice:
+```kotlin
+val choice = when (intent.action) {
+    Notif.ACTION_ALLOW_ONCE -> com.hermes.client.ui.chat.ApprovalChoice.ONCE
+    else -> com.hermes.client.ui.chat.ApprovalChoice.DENY
+}
+...
+runCatching { withTimeout(8_000) { chat.respondApproval(sid, choice) } }
+```
+(Update the `DebugLog.log` line to log `choice` instead of `approve`.)
+
+- [ ] **Step 4: Run tests + full build**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest :app:assembleBeta`
+Expected: BUILD SUCCESSFUL; NotificationMapperTest passes including the 2 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/ app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+git commit -m "feat(approvals): tier-aware notification actions (Standard: Allow once/Deny; Elevated: Deny/Open)"
+```
+
+---
+
+### Task 7: On-device verification
+
+**Files:** none (verification only). Uses the harness mock `$CLAUDE_JOB_DIR/tmp/mockgw.py` (working `/api/ws`).
+
+- [ ] **Step 1: Patch the mock** to emit two approvals after connect — a Standard one and an Elevated one:
+```python
+# Standard (offers Once/Session/Always; notification Allow once + Deny)
+{"method":"event","params":{"type":"approval.request","payload":{"session_id":"titletest",
+  "command":"git push --force origin main","description":"force push to a protected branch",
+  "pattern_keys":["force push"],"allow_permanent":True}}}
+# Elevated (Tirith-flagged; slide-to-allow, Deny primary; notification Deny only)
+{"method":"event","params":{"type":"approval.request","payload":{"session_id":"titletest",
+  "command":"rm -rf /var/data","description":"recursive delete of a data directory",
+  "pattern_keys":["recursive delete"],"allow_permanent":False}}}
+```
+Log the `approval.respond` params the app sends back (the mock's RPC read loop) so the chosen `choice` is observable.
+
+- [ ] **Step 2: Build + install + drive** (emulator `hermes_test`):
+  - Boot emulator; `assembleBeta`; install `app-beta.apk`; open a chat on the `titletest` session.
+  - Emit the **Standard** approval → confirm the bottom sheet shows the command (monospace), "Approval needed · force push", and **Allow once / Allow this run / Always allow / Deny**. Tap **Allow this run** → mock log shows `approval.respond {choice:"session", approved:true}`.
+  - Emit the **Elevated** approval → confirm the sheet shows "Elevated · recursive delete", **Deny** prominent, **no Always**, and a **slide-to-allow** track. Slide it → mock log shows `{choice:"once", approved:true}`. Re-emit and tap **Deny** → `{choice:"deny", approved:false}`.
+  - Background the app + re-emit each; pull the shade: **Standard** notification shows **Allow once + Deny**; **Elevated** shows **Deny** only. Tap Standard **Allow once** → mock log `{choice:"once"}`.
+  - Screenshot both sheets + both notifications.
+
+- [ ] **Step 3: Record results** in the PR description (screenshots + the observed `choice` values). No commit (verification only).
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** wire-format fix (Tasks 2–3), tier model (Task 1), bottom sheet both tiers (Task 5), SlideToConfirm (Task 4), tier-aware notifications (Task 6), send both `choice`+`approved` (Task 3), on-device both tiers (Task 7). Out-of-scope items (`all`, new gateway fields) intentionally excluded. ✓
+- **Placeholder scan:** none — every code step has complete code; the two soft spots (SlideToConfirm thumb-offset math, ChatRepository ctor shape) are called out with the exact fallback and where to confirm. ✓
+- **Type consistency:** `ApprovalChoice`/`ApprovalTier`/`tierFor(Boolean)`/`allowedScopes` (Task 1) are used unchanged in Tasks 3/5/6; `ApprovalRequest(command, description, patternKeys, allowPermanent)` (Task 2) is consumed unchanged in Task 5; `respondApproval(sessionId, ApprovalChoice)` (Task 3) is called in Task 5 (`vm.respondApproval`) and Task 6 (`chat.respondApproval`). ✓

--- a/docs/superpowers/specs/2026-07-10-tiered-approvals-design.md
+++ b/docs/superpowers/specs/2026-07-10-tiered-approvals-design.md
@@ -1,0 +1,154 @@
+# Touch-native tiered approvals — design (Phase 3)
+
+**Status:** approved design, ready for implementation plan
+**Branch:** `feature/tiered-approvals` → PR into `dev`
+**Roadmap:** Phase 3 of `docs/ideas/improvement-roadmap-2026-07-07.md` ("touch-native, tiered approvals")
+
+## Goal
+
+Make agent approvals correct and touch-native on a phone. Today an approval reaches the app when
+the gateway flags a **dangerous** command (low-risk commands are auto-approved server-side), but the
+app's approval UI is broken and shows nothing actionable. Phase 3 fixes the wire format so approvals
+work and show the command, then layers a **two-tier bottom-sheet** interaction on top: a normal
+"Standard" tier and an "Elevated" tier (Tirith-flagged) whose *Allow* requires a deliberate
+slide-to-confirm. No new gateway endpoints — everything uses fields and scopes the gateway already
+sends.
+
+## Current state (why the fix is needed)
+
+- **Request (in):** the app parses `approval.request` by reading a `prompt` payload key
+  (`ChatUiState.kt:86`, `ApprovalRequest(val prompt: String)` at `ChatUiState.kt:10`). The gateway
+  payload has **no `prompt`** — it sends `command`, `pattern_key`, `pattern_keys`, `description`,
+  `allow_permanent` (`tools/approval.py`; emitted via `_emit_approval_request`, `server.py:1150`). So
+  the current in-chat `ApprovalDialog` (`ChatComponents.kt:431`, shown from `ChatScreen.kt:490`)
+  renders an **empty** body.
+- **Response (out):** the app sends `approval.respond {session_id, approved:Boolean}`
+  (`ChatRepository.kt:126`). The gateway's `@method("approval.respond")` (`server.py:10186`) reads
+  **`choice`** (default `"deny"`) and **`all`** and ignores `approved` — so a tapped "Approve"
+  degrades to **deny**.
+- **Notification:** `NotificationMapper.kt` builds Approve/Deny actions whose receiver
+  (`NotificationActionReceiver.kt:21`) calls the same `respondApproval(sid, approve:Boolean)`.
+
+## Gateway capabilities we build on (already exist)
+
+- **Request payload fields:** `command` (redacted), `pattern_key` / `pattern_keys` (danger-category
+  ids, e.g. `"recursive delete"`, `"force push"`), `description` (human danger text),
+  `allow_permanent` (Boolean; `false` = Tirith security scanner flagged it → *Always* must not be
+  offered).
+- **Response scopes:** `approval.respond {choice, all}` with `choice ∈ once | session | always | deny`.
+  `once` = allow this time; `session` = allow for the rest of this run; `always` = permanent allowlist
+  (`config.yaml`); `deny` = block. `all` resolves every pending approval in the session.
+
+## Design
+
+### A. Wire-format fix (foundation)
+
+- Expand the domain model:
+  ```kotlin
+  data class ApprovalRequest(
+      val command: String,
+      val description: String,
+      val patternKeys: List<String>,
+      val allowPermanent: Boolean,
+  )
+  ```
+  Parse from the `approval.request` payload (`command`, `description`, `pattern_keys`,
+  `allow_permanent`; `pattern_key` as a single-element fallback). Missing fields degrade gracefully
+  (empty string / empty list / `allowPermanent=false` — the safe default).
+- Replace the boolean response with a scoped one:
+  ```kotlin
+  enum class ApprovalChoice(val wire: String) { ONCE("once"), SESSION("session"), ALWAYS("always"), DENY("deny") }
+  suspend fun ChatRepository.respondApproval(sessionId: String, choice: ApprovalChoice)
+  // sends {session_id, choice: choice.wire, approved: choice != DENY}
+  ```
+  **Send both `choice` and `approved`** (the derived boolean) so the response works whether the
+  gateway reads the new `choice` field or the old `approved` one — a cheap hedge against the
+  gateway-version skew noted below. The gateway ignores whichever field it doesn't use.
+  `ChatViewModel` exposes `respondApproval(choice: ApprovalChoice)` (replaces `approve(Boolean)`),
+  clearing `pendingApproval` first. `all` is **not** sent in v1 (single approval at a time).
+
+### B. Tier logic (pure, unit-tested)
+
+```kotlin
+enum class ApprovalTier { STANDARD, ELEVATED }
+fun tierFor(req: ApprovalRequest): ApprovalTier = if (req.allowPermanent) STANDARD else ELEVATED
+fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice> = when (tier) {
+    STANDARD -> listOf(ONCE, SESSION, ALWAYS)   // + DENY always available
+    ELEVATED -> listOf(ONCE, SESSION)           // no ALWAYS; DENY primary
+}
+```
+
+### C. Bottom sheet (`ApprovalSheet`, per-tenant accent)
+
+A modal bottom sheet (replaces the center `AlertDialog`), shown from `pendingApproval`:
+- **Header:** tier badge + primary pattern label — e.g. *"Elevated · recursive delete"* (Standard
+  tinted with the profile accent; Elevated tinted with an error/red tone).
+- **Body:** `command` in a scrollable monospace block (it's the redacted command); `description`
+  below it.
+- **Actions (thumb zone):**
+  - **Standard:** filled buttons **Allow once** / **Allow this run** / **Always allow**, and a text
+    **Deny**. Each maps to the `ApprovalChoice` and calls `respondApproval`.
+  - **Elevated:** **Deny** is the prominent (filled) action; *Always* is absent; **Allow** is a
+    `SlideToConfirm` track labelled *"→ slide to allow once"* (with a small toggle for *this run* vs
+    *once*). Completing the slide fires `respondApproval(ONCE|SESSION)`.
+- Dismissing the sheet (scrim/back) does **nothing** to the pending approval (no accidental
+  approve/deny); it re-opens from `pendingApproval` until resolved.
+
+### D. Reusable `SlideToConfirm` composable
+
+A horizontal track with a draggable thumb; drag past ~90% triggers `onConfirm()` and animates to
+"done"; releasing before that snaps back. Accent-tinted. Used for Elevated *Allow*; independently
+unit-testable at the state-holder level (a pure progress→confirmed transition).
+
+### E. Notification path
+
+Notifications can't host a slide, so:
+- **Standard:** inline **Allow once** (`choice=once`) + **Deny** actions; tapping the body opens the
+  app to the sheet for Session/Always.
+- **Elevated:** **Deny** + **Open** only — no inline allow, forcing the deliberate in-app slide. The
+  mapper must therefore carry enough to know the tier: include `allow_permanent` in the
+  `approval.request` → notification mapping so `NotificationMapper` picks the action set.
+- The `NotificationActionReceiver` sends `respondApproval(sid, ONCE|DENY)` (choice-based, not boolean).
+
+## Data flow
+
+```
+approval.request {command, description, pattern_keys, allow_permanent, session_id}
+  → ServerEvent → ChatUiState.reduce → pendingApproval: ApprovalRequest
+  → ChatScreen shows ApprovalSheet (tier = tierFor(req))
+  → user picks scope (Standard buttons) or slides (Elevated)
+  → ChatViewModel.respondApproval(choice) → ChatRepository.respondApproval → WS approval.respond {session_id, choice}
+Notification (bg): approval.request → NotificationMapper (tier-aware actions) → NotificationActionReceiver → respondApproval(choice)
+```
+
+## Components / files
+
+- `ui/chat/ChatUiState.kt` — expand `ApprovalRequest`; update the `approval.request` reduce to parse the new fields.
+- `ui/chat/ApprovalTier.kt` *(new)* — `ApprovalTier`, `ApprovalChoice`, `tierFor`, `allowedScopes` (pure).
+- `data/repository/ChatRepository.kt` — `respondApproval(sessionId, choice: ApprovalChoice)` (replaces the boolean).
+- `ui/chat/ChatViewModel.kt` — `respondApproval(choice)` (replaces `approve(Boolean)`).
+- `ui/chat/ApprovalSheet.kt` *(new)* — the bottom sheet; replaces `ApprovalDialog` usage in `ChatScreen.kt`.
+- `ui/components/SlideToConfirm.kt` *(new)* — reusable slide-to-confirm.
+- `notifications/NotificationMapper.kt` + `NotificationModels.kt` — tier-aware approval actions (add an `allow once` action; Elevated → Deny/Open only); carry `allowPermanent`.
+- `notifications/NotificationActionReceiver.kt` — send `ApprovalChoice` instead of a boolean.
+
+## Testing
+
+- **Pure unit tests:** `tierFor` / `allowedScopes` (Standard vs Elevated); `ApprovalRequest` parsing from a representative payload (and graceful defaults when fields are missing); `respondApproval` sends `{session_id, choice}` with the right wire value; `NotificationMapper` returns the correct action set per tier; `SlideToConfirm` progress→confirmed transition.
+- **On-device:** drive both tiers via the harness mock emitting a Standard (`allow_permanent=true`) and an Elevated (`allow_permanent=false`) `approval.request`; verify the sheet, the three Standard scopes, the Elevated slide-to-allow + Deny-primary, and that the correct `choice` reaches the WS. Verify the notification action sets per tier.
+
+## Out of scope (v1 — YAGNI)
+
+- Resolve-**all**-pending (`all:true`) — the gateway supports it; deferred until multiple concurrent approvals are common.
+- Any new gateway field (explicit numeric risk level, reversibility hint, free-text deny reason).
+- Client-side severity taxonomy from `pattern_keys` beyond the label — tiering stays on the
+  gateway's `allow_permanent` bit (honest, no invented severity).
+
+## Risks / notes
+
+- **Gateway skew:** this design targets the `approval.respond {choice}` + `command/description/allow_permanent`
+  contract in the current `~/.hermes/hermes-agent` checkout. Verify against the running gateway before
+  promotion (the fix is a no-op improvement if the gateway ever also accepted `approved`, but the
+  `choice` form is the authoritative one).
+- The `always` scope writes a permanent allowlist entry in the gateway's `config.yaml` — intended, and
+  only offered for Standard (`allow_permanent=true`).


### PR DESCRIPTION
Phase 3: touch-native tiered approvals. Fixes the broken approval wire format **and** adds a two-tier bottom-sheet UX. No new gateway endpoints.

## Why (the fix)
Approvals were effectively broken: the app parsed a `prompt` field the gateway never sends (empty dialog) and responded with `{approved}` which the gateway ignores in favor of `{choice}` (defaulting to **deny**). Now:
- Parse the real request fields: `command`, `description`, `pattern_keys`, `allow_permanent`.
- Respond with `approval.respond {session_id, choice, approved}` — `choice ∈ once/session/always/deny`, plus the derived `approved` boolean as a version-skew hedge.

## Tiered UX (2 tiers on `allow_permanent`)
- **Standard** (`allow_permanent=true`): bottom sheet with **Allow once / Allow this run / Always allow** + Deny.
- **Elevated** (Tirith-flagged, `allow_permanent=false`): Deny prominent, **no Always**, and Allow requires a reusable **slide-to-confirm** gesture (Once/Session toggle). Command shown in scrollable monospace; accent-tinted (error tone for Elevated).
- **Notifications** tier-aware: Standard → Allow once + Deny inline; Elevated → **Deny only** (forces the deliberate in-app slide). The receiver can only ever send ONCE/DENY — never SESSION/ALWAYS.

## Verification
- **224 unit tests pass**, `assembleBeta` green. Covers: tier/scope logic, request parsing (+safe defaults), the `{choice, approved}` wire, the pure slide progress/confirm logic, and the per-tier notification action sets.
- Built via subagent-driven-development (7 tasks, per-task review + a whole-branch review). The whole-branch review confirmed the **security invariant holds end-to-end** (an Elevated command cannot be approved without the in-app slide; notifications can't bypass it; `exported=false` + immutable PendingIntents).
- **On-device caveat:** the approval *sheet* couldn't be triggered through the local harness mock (WS-connection flakiness — the `approval.request` lands on reconnecting sockets and doesn't reach the live ChatViewModel). The logic is fully unit-tested + reviewed; the real approval flow is best verified against your actual gateway.

## Spec / plan
`docs/superpowers/specs/2026-07-10-tiered-approvals-design.md` · `docs/superpowers/plans/2026-07-10-tiered-approvals.md`. versionName 0.1.50.
