### PR TITLE
Release v0.1.50 — Sessions/Projects view, cross-profile projects, tiered approvals

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 50
-        versionName = "0.1.49"
+        versionCode = 51
+        versionName = "0.1.50"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.
         manifestPlaceholders["appLabel"] = "Hermes"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 53
+        versionCode = 54
         versionName = "0.1.50"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 52
+        versionCode = 53
         versionName = "0.1.50"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.hermes.client"
         minSdk = 26
         targetSdk = 37
-        versionCode = 51
+        versionCode = 52
         versionName = "0.1.50"
         testInstrumentationRunner = "com.hermes.client.HiltTestRunner"
         // App name; the beta build type overrides this so both can be installed at once.

--- a/app/src/main/java/com/hermes/client/data/network/Dtos.kt
+++ b/app/src/main/java/com/hermes/client/data/network/Dtos.kt
@@ -24,6 +24,8 @@ import kotlinx.serialization.Serializable
     val archived: Boolean = false,
     val cwd: String? = null,
     val source: String? = null,
+    @SerialName("git_branch") val gitBranch: String? = null,
+    @SerialName("git_repo_root") val gitRepoRoot: String? = null,
 )
 @Serializable data class SessionListDto(val sessions: List<SessionDto> = emptyList())
 
@@ -187,4 +189,50 @@ data class ModelOptionDto(
     val enabled: Boolean = false,
     val available: Boolean = true,
     val tools: List<String> = emptyList(),
+)
+
+/**
+ * Gateway `projects.tree` result. Single-profile (the connected gateway's bound profile).
+ * `scoped_session_ids` is parsed but unused in v1 (Sessions mode shows the flat REST list
+ * independently). `icon` is an unknown key here and intentionally ignored (YAGNI).
+ */
+@Serializable data class ProjectTreeDto(
+    val projects: List<ProjectNodeDto> = emptyList(),
+    @SerialName("active_id") val activeId: String? = null,
+)
+
+@Serializable data class ProjectNodeDto(
+    val id: String,
+    val label: String = "",
+    val path: String? = null,
+    val color: String? = null,
+    val isAuto: Boolean = false,
+    val sessionCount: Int = 0,
+    val lastActive: Double? = null,
+    val repos: List<RepoDto> = emptyList(),
+    // On projects.tree these are up to preview_limit newest rows; on project_sessions it's empty.
+    val previewSessions: List<SessionDto> = emptyList(),
+)
+
+@Serializable data class RepoDto(
+    val id: String,
+    val label: String = "",
+    val path: String? = null,
+    val sessionCount: Int = 0,
+    // Gateway calls the branch lanes "groups".
+    val groups: List<LaneDto> = emptyList(),
+)
+
+@Serializable data class LaneDto(
+    val id: String,
+    val label: String = "",
+    val path: String? = null,
+    val isMain: Boolean = false,
+    // Lane sessions are empty on projects.tree (counts only) and hydrated on project_sessions.
+    val sessions: List<SessionDto> = emptyList(),
+)
+
+/** Gateway `projects.project_sessions` result — a single hydrated node (or null). */
+@Serializable data class ProjectSessionsResultDto(
+    val project: ProjectNodeDto? = null,
 )

--- a/app/src/main/java/com/hermes/client/data/network/ServerEvent.kt
+++ b/app/src/main/java/com/hermes/client/data/network/ServerEvent.kt
@@ -1,8 +1,10 @@
 package com.hermes.client.data.network
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -35,3 +37,9 @@ internal fun ServerEvent.str(key: String): String? = when (val el = payload[key]
 
 internal fun JsonObject.objOrEmpty(key: String): JsonObject =
     (this[key] as? JsonObject) ?: JsonObject(emptyMap())
+
+internal fun ServerEvent.bool(key: String): Boolean? =
+    (payload[key] as? JsonPrimitive)?.booleanOrNull
+
+internal fun ServerEvent.strList(key: String): List<String> =
+    (payload[key] as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -3,6 +3,7 @@ package com.hermes.client.data.repository
 import com.hermes.client.data.network.ConnectionState
 import com.hermes.client.data.network.HermesGatewayClient
 import com.hermes.client.data.network.ServerEvent
+import com.hermes.client.ui.chat.ApprovalChoice
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.JsonObject
@@ -123,11 +124,11 @@ class ChatRepository(private val client: HermesGatewayClient) {
         })
     }
 
-    suspend fun respondApproval(sessionId: String, choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    suspend fun respondApproval(sessionId: String, choice: ApprovalChoice) {
         client.call("approval.respond", buildJsonObject {
             put("session_id", sessionId)
             put("choice", choice.wire)
-            put("approved", choice != com.hermes.client.ui.chat.ApprovalChoice.DENY)
+            put("approved", choice != ApprovalChoice.DENY)
         })
     }
 

--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -123,10 +123,11 @@ class ChatRepository(private val client: HermesGatewayClient) {
         })
     }
 
-    suspend fun respondApproval(sessionId: String, approve: Boolean) {
+    suspend fun respondApproval(sessionId: String, choice: com.hermes.client.ui.chat.ApprovalChoice) {
         client.call("approval.respond", buildJsonObject {
             put("session_id", sessionId)
-            put("approved", approve)
+            put("choice", choice.wire)
+            put("approved", choice != com.hermes.client.ui.chat.ApprovalChoice.DENY)
         })
     }
 

--- a/app/src/main/java/com/hermes/client/data/repository/ProjectsRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ProjectsRepository.kt
@@ -1,0 +1,34 @@
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import com.hermes.client.data.network.ProjectSessionsResultDto
+import com.hermes.client.data.network.ProjectTreeDto
+import com.hermes.client.domain.Project
+import com.hermes.client.domain.ProjectTree
+import com.hermes.client.domain.toDomain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Browse-only access to the gateway's server-authoritative project tree over WS JSON-RPC.
+ * Single-profile: `projects.tree` reflects the connected gateway's bound profile and takes no
+ * profile param (see the design's profile-scoping note). Piggybacks on the socket the sessions
+ * screen already opens via [ChatRepository.connect].
+ */
+class ProjectsRepository(
+    private val client: HermesGatewayClient,
+    private val json: Json,
+) {
+    /** Fetch the project overview (nodes with counts + up to [previewLimit] preview sessions). */
+    suspend fun tree(previewLimit: Int = 3): ProjectTree {
+        val result = client.call("projects.tree", buildJsonObject { put("preview_limit", previewLimit) })
+        return json.decodeFromJsonElement(ProjectTreeDto.serializer(), result).toDomain()
+    }
+
+    /** Hydrate one project's sessions for drill-in. [projectId] must equal a tree node id. */
+    suspend fun projectSessions(projectId: String): Project? {
+        val result = client.call("projects.project_sessions", buildJsonObject { put("project_id", projectId) })
+        return json.decodeFromJsonElement(ProjectSessionsResultDto.serializer(), result).project?.toDomain()
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/SessionRepository.kt
@@ -8,13 +8,30 @@ import com.hermes.client.domain.Session
 import com.hermes.client.domain.toDomain
 
 /**
- * Mirror the desktop session list: show interactive, used sessions only. Cron-created sessions
- * live in the Cron view, and empty (0-message) sessions are scratch — both are hidden from the
- * session list so the mobile counts match the desktop dashboard.
+ * Mirror the desktop sidebar session list: show interactive, used sessions only. Sessions whose
+ * source is in [SessionRepository.EXCLUDED_SOURCES] — cron (shown in the Cron view), the internal
+ * subagent/tool sources, and every messaging platform (telegram/slack/email/… live in their own
+ * surfaces) — plus empty (0-message) scratch sessions are hidden, matching the desktop's
+ * SIDEBAR_EXCLUDED_SOURCES so the two lists agree. A null/unknown source is kept.
  */
-private fun Session.isInteractive(): Boolean = source != "cron" && messageCount > 0
+private fun Session.isInteractive(): Boolean =
+    messageCount > 0 && (source == null || source !in SessionRepository.EXCLUDED_SOURCES)
 
 class SessionRepository(private val rest: HermesRestApi) {
+    companion object {
+        /**
+         * Sources hidden from the sessions list, matching the desktop's SIDEBAR_EXCLUDED_SOURCES:
+         * cron + subagent + tool + every messaging platform. Local sources (cli/tui/desktop/…) and
+         * the app's own `hermes-dispatch` sessions are NOT excluded — they show in the list.
+         */
+        val EXCLUDED_SOURCES: Set<String> = setOf(
+            "cron", "subagent", "tool",
+            "telegram", "discord", "slack", "mattermost", "matrix", "signal", "whatsapp",
+            "bluebubbles", "homeassistant", "email", "sms", "webhook", "api_server",
+            "weixin", "wecom", "qqbot", "yuanbao", "dingtalk", "feishu",
+        )
+    }
+
     suspend fun list(profile: String? = null): List<Session> =
         rest.sessions(limit = 50, offset = 0, profile = profile).map { it.toDomain() }
 

--- a/app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.emptyPreferences
 import com.hermes.client.ui.sessions.ViewMode
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 
 private val Context.viewModeDataStore by preferencesDataStore(name = "sessions_view_mode")
 
@@ -14,12 +17,16 @@ private val Context.viewModeDataStore by preferencesDataStore(name = "sessions_v
 class ViewModeStore(private val context: Context) {
     private val key = stringPreferencesKey("view_mode")
 
-    val mode: Flow<ViewMode> = context.viewModeDataStore.data.map { prefs ->
-        when (prefs[key]) {
-            ViewMode.PROJECTS.name -> ViewMode.PROJECTS
-            else -> ViewMode.SESSIONS
+    val mode: Flow<ViewMode> = context.viewModeDataStore.data
+        // A corrupt/unreadable DataStore throws IOException on read — fall back to defaults
+        // instead of crashing the Chats screen.
+        .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+        .map { prefs ->
+            when (prefs[key]) {
+                ViewMode.PROJECTS.name -> ViewMode.PROJECTS
+                else -> ViewMode.SESSIONS
+            }
         }
-    }
 
     suspend fun set(mode: ViewMode) {
         context.viewModeDataStore.edit { it[key] = mode.name }

--- a/app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt
@@ -1,0 +1,27 @@
+package com.hermes.client.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.hermes.client.ui.sessions.ViewMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.viewModeDataStore by preferencesDataStore(name = "sessions_view_mode")
+
+/** Device-local persisted Chats view mode. Defaults to [ViewMode.SESSIONS]. */
+class ViewModeStore(private val context: Context) {
+    private val key = stringPreferencesKey("view_mode")
+
+    val mode: Flow<ViewMode> = context.viewModeDataStore.data.map { prefs ->
+        when (prefs[key]) {
+            ViewMode.PROJECTS.name -> ViewMode.PROJECTS
+            else -> ViewMode.SESSIONS
+        }
+    }
+
+    suspend fun set(mode: ViewMode) {
+        context.viewModeDataStore.edit { it[key] = mode.name }
+    }
+}

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -150,6 +150,13 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideViewModeStore(
+        @ApplicationContext context: Context,
+    ): com.hermes.client.data.repository.ViewModeStore =
+        com.hermes.client.data.repository.ViewModeStore(context)
+
+    @Provides
+    @Singleton
     fun provideProfileAccentStore(
         @ApplicationContext context: Context,
     ): com.hermes.client.data.repository.ProfileAccentStore =

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -10,6 +10,7 @@ import com.hermes.client.data.network.HermesRestApi
 import com.hermes.client.data.repository.ChatRepository
 import com.hermes.client.data.repository.ModelRepository
 import com.hermes.client.data.repository.ProfileRepository
+import com.hermes.client.data.repository.ProjectsRepository
 import com.hermes.client.data.repository.SessionRepository
 import com.hermes.client.data.repository.ToolsRepository
 import dagger.Module
@@ -106,6 +107,14 @@ object AppModule {
     @Singleton
     fun provideChatRepository(client: HermesGatewayClient): ChatRepository =
         ChatRepository(client)
+
+    @Provides
+    @Singleton
+    fun provideProjectsRepository(
+        client: HermesGatewayClient,
+        json: Json,
+    ): ProjectsRepository =
+        ProjectsRepository(client, json)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/hermes/client/domain/Mappers.kt
+++ b/app/src/main/java/com/hermes/client/domain/Mappers.kt
@@ -1,6 +1,10 @@
 package com.hermes.client.domain
 
+import com.hermes.client.data.network.LaneDto
 import com.hermes.client.data.network.MessageDto
+import com.hermes.client.data.network.ProjectNodeDto
+import com.hermes.client.data.network.ProjectTreeDto
+import com.hermes.client.data.network.RepoDto
 import com.hermes.client.data.network.SessionDto
 
 fun SessionDto.toDomain() = Session(
@@ -16,6 +20,9 @@ fun SessionDto.toDomain() = Session(
     archived = archived,
     source = source,
     lastActive = com.hermes.client.ui.util.secondsToEpochMs(lastActive),
+    cwd = cwd?.ifBlank { null },
+    gitBranch = gitBranch?.ifBlank { null },
+    gitRepoRoot = gitRepoRoot?.ifBlank { null },
 )
 
 fun MessageDto.toDomain() = ChatMessage(
@@ -26,4 +33,37 @@ fun MessageDto.toDomain() = ChatMessage(
         else -> Role.SYSTEM
     },
     text = content.orEmpty(),
+)
+
+fun ProjectTreeDto.toDomain() = ProjectTree(
+    projects = projects.map { it.toDomain() },
+    activeId = activeId,
+)
+
+fun ProjectNodeDto.toDomain() = Project(
+    id = id,
+    label = label,
+    path = path,
+    color = color?.ifBlank { null },
+    isAuto = isAuto,
+    sessionCount = sessionCount,
+    lastActive = com.hermes.client.ui.util.secondsToEpochMs(lastActive),
+    repos = repos.map { it.toDomain() },
+    previewSessions = previewSessions.map { it.toDomain() },
+)
+
+fun RepoDto.toDomain() = ProjectRepo(
+    id = id,
+    label = label,
+    path = path,
+    sessionCount = sessionCount,
+    lanes = groups.map { it.toDomain() },
+)
+
+fun LaneDto.toDomain() = ProjectLane(
+    id = id,
+    label = label,
+    path = path,
+    isMain = isMain,
+    sessions = sessions.map { it.toDomain() },
 )

--- a/app/src/main/java/com/hermes/client/domain/Models.kt
+++ b/app/src/main/java/com/hermes/client/domain/Models.kt
@@ -20,6 +20,11 @@ data class Session(
     // Epoch millis of last activity (from the gateway's last_active seconds), for recency sorting
     // and the Mission Control feed. Null when the gateway omits it.
     val lastActive: Long? = null,
+    // Full working directory (not just the basename in [workspace]); null when the session has none.
+    val cwd: String? = null,
+    // Git context resolved server-side, present on project-tree session rows; null otherwise.
+    val gitBranch: String? = null,
+    val gitRepoRoot: String? = null,
 )
 
 data class ToolCall(
@@ -38,4 +43,40 @@ data class ChatMessage(
     val isStreaming: Boolean = false,
     val isError: Boolean = false,
     val interrupted: Boolean = false,
+)
+
+/** A server-authoritative project (explicit user project or an auto git-repo/discovered project). */
+data class Project(
+    val id: String,
+    val label: String,
+    val path: String?,
+    // Hex string like "#RRGGBB" for explicit projects; null for auto/discovered (render with accent).
+    val color: String?,
+    val isAuto: Boolean,
+    val sessionCount: Int,
+    val lastActive: Long?,
+    val repos: List<ProjectRepo>,
+    // Newest sessions for the overview card; empty after drill-in (lanes carry the full set then).
+    val previewSessions: List<Session>,
+)
+
+data class ProjectRepo(
+    val id: String,
+    val label: String,
+    val path: String?,
+    val sessionCount: Int,
+    val lanes: List<ProjectLane>,
+)
+
+data class ProjectLane(
+    val id: String,
+    val label: String,
+    val path: String?,
+    val isMain: Boolean,
+    val sessions: List<Session>,
+)
+
+data class ProjectTree(
+    val projects: List<Project>,
+    val activeId: String?,
 )

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 
-/** Handles the Approve/Deny actions on an approval notification by sending the approval RPC. */
+/** Handles the Allow once/Deny actions on an approval notification by sending the approval RPC. */
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
     @Inject lateinit var chat: ChatRepository

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.hermes.client.data.diagnostics.DebugLog
 import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.ui.chat.ApprovalChoice
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,10 +23,11 @@ class NotificationActionReceiver : BroadcastReceiver() {
         val sid = intent.getStringExtra("session_id") ?: return
         val notifId = intent.getIntExtra("notif_id", -1)
         val approve = intent.action == Notif.ACTION_APPROVE
+        val choice = if (approve) ApprovalChoice.ONCE else ApprovalChoice.DENY
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                runCatching { withTimeout(8_000) { chat.respondApproval(sid, approve) } }
+                runCatching { withTimeout(8_000) { chat.respondApproval(sid, choice) } }
                     .onSuccess {
                         // Only clear the notification once the RPC actually succeeded — on
                         // failure, leave it so the action isn't silently lost.

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -22,8 +22,10 @@ class NotificationActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val sid = intent.getStringExtra("session_id") ?: return
         val notifId = intent.getIntExtra("notif_id", -1)
-        val approve = intent.action == Notif.ACTION_APPROVE
-        val choice = if (approve) ApprovalChoice.ONCE else ApprovalChoice.DENY
+        val choice = when (intent.action) {
+            Notif.ACTION_ALLOW_ONCE -> ApprovalChoice.ONCE
+            else -> ApprovalChoice.DENY
+        }
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
@@ -34,7 +36,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
                         if (notifId != -1) notifier.cancel(notifId)
                     }
                     .onFailure { e ->
-                        DebugLog.log("notif", "approval response failed session=$sid approve=$approve: ${e.message}")
+                        DebugLog.log("notif", "approval response failed session=$sid choice=$choice: ${e.message}")
                     }
             } finally {
                 pending.finish()

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -1,7 +1,10 @@
 package com.hermes.client.notifications
 
 import com.hermes.client.data.network.ServerEvent
+import com.hermes.client.data.network.bool
 import com.hermes.client.data.network.str
+import com.hermes.client.ui.chat.ApprovalTier
+import com.hermes.client.ui.chat.tierFor
 
 /**
  * Pure mapping from a gateway event to a notification (or null). `approval.request` and
@@ -19,18 +22,24 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
     // ongoing foreground-service notification, and notify()-ing over it would clobber it.
     if (id == 1001) id = 1002
     return when (event.type) {
-        Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else NotificationSpec(
-            id = id,
-            channelId = Notif.CHANNEL_APPROVALS,
-            title = "Approval needed",
-            body = event.str("prompt") ?: "The agent is waiting for your approval.",
-            route = "chat/$sid",
-            actions = listOf(
-                NotifAction("Approve", Notif.ACTION_APPROVE, sid),
-                NotifAction("Deny", Notif.ACTION_DENY, sid),
-            ),
-            groupKey = "approval",
-        )
+        Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else {
+            val elevated = tierFor(event.bool("allow_permanent") ?: false) == ApprovalTier.ELEVATED
+            NotificationSpec(
+                id = id,
+                channelId = Notif.CHANNEL_APPROVALS,
+                title = "Approval needed",
+                body = event.str("description")?.ifBlank { null }
+                    ?: event.str("command")?.ifBlank { null }
+                    ?: "The agent is waiting for your approval.",
+                route = "chat/$sid",
+                actions = if (elevated) listOf(NotifAction("Deny", Notif.ACTION_DENY, sid))
+                          else listOf(
+                              NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid),
+                              NotifAction("Deny", Notif.ACTION_DENY, sid),
+                          ),
+                groupKey = "approval",
+            )
+        }
         // Needs-you: always notify (ignores foreground); tap opens the chat to answer.
         Notif.EVENT_CLARIFY -> if (!prefs.approvals) null else NotificationSpec(
             id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Needs your input",

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -7,7 +7,7 @@ data class NotificationPrefs(
     val runFinished: Boolean = true,
 )
 
-/** An inline notification action (Approve/Deny) carrying the target session. */
+/** An inline notification action (Allow once/Deny) carrying the target session. */
 data class NotifAction(val label: String, val action: String, val sessionId: String)
 
 /** A platform-independent description of a notification, so mapping stays unit-testable. */

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -40,6 +40,6 @@ object Notif {
     const val EVENT_MESSAGE_COMPLETE = "message.complete"
     const val EVENT_ERROR = "error"
 
-    const val ACTION_APPROVE = "approve"
+    const val ACTION_ALLOW_ONCE = "allow_once"
     const val ACTION_DENY = "deny"
 }

--- a/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/activity/MissionControlScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle

--- a/app/src/main/java/com/hermes/client/ui/admin/SessionAdminScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/admin/SessionAdminScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
@@ -1,0 +1,102 @@
+package com.hermes.client.ui.chat
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.components.SlideToConfirm
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onDismiss: () -> Unit) {
+    val accent = LocalProfileAccent.current
+    val tier = tierFor(req.allowPermanent)
+    val error = MaterialTheme.colorScheme.error
+    val badge = if (tier == ApprovalTier.ELEVATED) error else accent.accent
+    val label = req.patternKeys.firstOrNull()?.let { " · $it" } ?: ""
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text(
+                (if (tier == ApprovalTier.ELEVATED) "Elevated" else "Approval needed") + label,
+                style = MaterialTheme.typography.titleMedium,
+                color = badge,
+            )
+            if (req.command.isNotBlank()) {
+                Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 12.dp)) {
+                    Text(req.command, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            if (req.description.isNotBlank()) {
+                Text(req.description, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(bottom = 16.dp))
+            }
+
+            if (tier == ApprovalTier.STANDARD) {
+                Button(
+                    onClick = { onRespond(ApprovalChoice.ONCE) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Allow once" },
+                    colors = ButtonDefaults.buttonColors(containerColor = accent.accent, contentColor = accent.onAccent),
+                ) { Text("Allow once") }
+                OutlinedButton(
+                    onClick = { onRespond(ApprovalChoice.SESSION) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Allow this run" },
+                ) { Text("Allow this run") }
+                OutlinedButton(
+                    onClick = { onRespond(ApprovalChoice.ALWAYS) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Always allow" },
+                ) { Text("Always allow") }
+                TextButton(
+                    onClick = { onRespond(ApprovalChoice.DENY) },
+                    modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Deny" },
+                ) { Text("Deny") }
+            } else {
+                // Elevated: Deny is prominent; Allow requires a deliberate slide.
+                var thisRun by remember { mutableStateOf(false) }
+                Button(
+                    onClick = { onRespond(ApprovalChoice.DENY) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Deny" },
+                    colors = ButtonDefaults.buttonColors(containerColor = error),
+                ) { Text("Deny") }
+                TextButton(
+                    onClick = { thisRun = !thisRun },
+                    modifier = Modifier.fillMaxWidth()
+                        .semantics { contentDescription = "Toggle allow scope" },
+                ) {
+                    Text(if (thisRun) "Scope: allow for this run" else "Scope: allow once")
+                }
+                SlideToConfirm(
+                    label = if (thisRun) "  → slide to allow this run" else "  → slide to allow once",
+                    accent = accent.accent,
+                    onConfirm = { onRespond(if (thisRun) ApprovalChoice.SESSION else ApprovalChoice.ONCE) },
+                    modifier = Modifier.padding(vertical = 8.dp)
+                        .semantics { contentDescription = "Slide to allow" },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,7 +38,12 @@ fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onD
     val badge = if (tier == ApprovalTier.ELEVATED) error else accent.accent
     val label = req.patternKeys.firstOrNull()?.let { " · $it" } ?: ""
 
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    // An approval must be an explicit choice: veto the Hidden transition so a swipe / scrim-tap
+    // can't dismiss the sheet while pendingApproval is still set (which would desync — sheet gone
+    // but state still blocked). The sheet leaves composition only when a choice clears the pending.
+    val sheetState = rememberModalBottomSheetState(confirmValueChange = { it != SheetValue.Hidden })
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
             Text(
                 (if (tier == ApprovalTier.ELEVATED) "Elevated" else "Approval needed") + label,

--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt
@@ -1,0 +1,18 @@
+package com.hermes.client.ui.chat
+
+/** The scoped decision the gateway understands: approval.respond {choice}. */
+enum class ApprovalChoice(val wire: String) {
+    ONCE("once"), SESSION("session"), ALWAYS("always"), DENY("deny")
+}
+
+/** Risk tier, derived from the gateway's `allow_permanent` bit (false = Tirith-flagged). */
+enum class ApprovalTier { STANDARD, ELEVATED }
+
+fun tierFor(allowPermanent: Boolean): ApprovalTier =
+    if (allowPermanent) ApprovalTier.STANDARD else ApprovalTier.ELEVATED
+
+/** Allow-scopes offered per tier (DENY is always available separately). */
+fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice> = when (tier) {
+    ApprovalTier.STANDARD -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS)
+    ApprovalTier.ELEVATED -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION)
+}

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -30,7 +30,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -427,13 +426,3 @@ private fun ToolCard(tool: ToolCall) {
     }
 }
 
-@Composable
-fun ApprovalDialog(prompt: String, onApprove: () -> Unit, onDeny: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDeny,
-        title = { Text("Approval requested") },
-        text = { Text(prompt) },
-        confirmButton = { TextButton(onClick = onApprove) { Text("Approve") } },
-        dismissButton = { TextButton(onClick = onDeny) { Text("Deny") } },
-    )
-}

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -74,7 +74,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.data.network.ConnectionState
 import com.hermes.client.ui.components.StatusDot

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -488,10 +488,10 @@ fun ChatScreen(
     }
 
     state.pendingApproval?.let { req ->
-        ApprovalDialog(
-            prompt = req.prompt,
-            onApprove = { vm.approve(true) },
-            onDeny = { vm.approve(false) },
+        ApprovalSheet(
+            req = req,
+            onRespond = { vm.respondApproval(it) },
+            onDismiss = { /* keep pending: do nothing until the user chooses */ },
         )
     }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -1,13 +1,20 @@
 package com.hermes.client.ui.chat
 
 import com.hermes.client.data.network.ServerEvent
+import com.hermes.client.data.network.bool
 import com.hermes.client.data.network.str
+import com.hermes.client.data.network.strList
 import com.hermes.client.domain.ChatMessage
 import com.hermes.client.domain.Role
 import com.hermes.client.domain.ToolCall
 import com.hermes.client.domain.ToolStatus
 
-data class ApprovalRequest(val prompt: String)
+data class ApprovalRequest(
+    val command: String,
+    val description: String,
+    val patternKeys: List<String>,
+    val allowPermanent: Boolean,
+)
 data class ClarifyRequest(val question: String, val options: List<String>)
 
 data class ChatUiState(
@@ -28,7 +35,8 @@ fun ChatUiState.withUserMessage(text: String): ChatUiState =
 
 
 /** Pure reducer: folds one server event into the chat state. */
-fun reduce(state: ChatUiState, event: ServerEvent): ChatUiState {
+fun ChatUiState.reduce(event: ServerEvent): ChatUiState {
+    val state = this
     // Targets the last STREAMING assistant message.
     fun mutateLastAssistant(block: (ChatMessage) -> ChatMessage): ChatUiState {
         val idx = state.messages.indexOfLast { it.role == Role.ASSISTANT && it.isStreaming }
@@ -83,7 +91,15 @@ fun reduce(state: ChatUiState, event: ServerEvent): ChatUiState {
                 if (it.id == tid) it.copy(status = ToolStatus.DONE, output = event.str("result") ?: "") else it
             })
         }
-        "approval.request" -> state.copy(pendingApproval = ApprovalRequest(event.str("prompt") ?: ""))
+        "approval.request" -> state.copy(
+            pendingApproval = ApprovalRequest(
+                command = event.str("command") ?: "",
+                description = event.str("description") ?: "",
+                patternKeys = event.strList("pattern_keys")
+                    .ifEmpty { event.str("pattern_key")?.let { listOf(it) } ?: emptyList() },
+                allowPermanent = event.bool("allow_permanent") ?: false,
+            ),
+        )
         "clarify.request" -> state.copy(
             pendingClarify = ClarifyRequest(event.str("question") ?: "", emptyList()),
         )

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -241,9 +241,9 @@ class ChatViewModel @Inject constructor(
 
     fun clearPathItems() { _pathItems.value = emptyList() }
 
-    fun approve(approve: Boolean) {
+    fun respondApproval(choice: com.hermes.client.ui.chat.ApprovalChoice) {
         _state.value = _state.value.copy(pendingApproval = null)
-        viewModelScope.launch { runCatching { chat.respondApproval(sessionId, approve) } }
+        viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
     }
 
     fun clarify(answer: String) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -243,7 +243,14 @@ class ChatViewModel @Inject constructor(
 
     fun respondApproval(choice: ApprovalChoice) {
         _state.value = _state.value.copy(pendingApproval = null)
-        viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
+        viewModelScope.launch {
+            runCatching { chat.respondApproval(sessionId, choice) }
+                .onFailure {
+                    if (it is kotlinx.coroutines.CancellationException) throw it
+                    // The sheet is already gone; surface the failure so a lost approve/deny is visible.
+                    appendError("Couldn't send your approval — check the connection and try again.")
+                }
+        }
     }
 
     fun clarify(answer: String) {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -241,7 +241,7 @@ class ChatViewModel @Inject constructor(
 
     fun clearPathItems() { _pathItems.value = emptyList() }
 
-    fun respondApproval(choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    fun respondApproval(choice: ApprovalChoice) {
         _state.value = _state.value.copy(pendingApproval = null)
         viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
     }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -150,7 +150,7 @@ class ChatViewModel @Inject constructor(
             chat.events.filter { it.sessionId == null || it.sessionId == sessionId }
                 // Defense in depth: a single malformed event must never crash the chat.
                 // reduce() is pure, so on a bad event keep the prior state and drop it.
-                .onEach { event -> runCatching { reduce(_state.value, event) }.onSuccess { _state.value = it } }
+                .onEach { event -> runCatching { _state.value.reduce(event) }.onSuccess { _state.value = it } }
                 .collect {}
         }
         // C2 + I3: watch connection transitions

--- a/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +43,9 @@ fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier
     var trackPx by remember { mutableFloatStateOf(0f) }
     var dragPx by remember { mutableFloatStateOf(0f) }
     val density = LocalDensity.current
+    // pointerInput(Unit) captures its lambdas once; wrap onConfirm so a drag-end always calls the
+    // CURRENT lambda (the caller swaps it when the Once/Session toggle flips) rather than a stale one.
+    val currentOnConfirm by rememberUpdatedState(onConfirm)
     Box(
         modifier
             .fillMaxWidth()
@@ -61,7 +65,7 @@ fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier
                 .background(accent, CircleShape)
                 .pointerInput(Unit) {
                     detectHorizontalDragGestures(
-                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) onConfirm() else dragPx = 0f },
+                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) currentOnConfirm() else dragPx = 0f },
                         onHorizontalDrag = { _, delta -> dragPx = (dragPx + delta).coerceIn(0f, trackPx) },
                     )
                 },

--- a/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
+++ b/app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt
@@ -1,0 +1,71 @@
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+private val ThumbSize = 56.dp
+
+// Pure, unit-tested. Progress along the track (0f..1f).
+fun slideProgress(dragPx: Float, trackPx: Float): Float =
+    if (trackPx <= 0f) 0f else dragPx.coerceIn(0f, trackPx) / trackPx
+
+fun isConfirmed(progress: Float): Boolean = progress >= 0.9f
+
+/** Drag the thumb across the track to confirm a deliberate (dangerous) action. */
+@Composable
+fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier: Modifier = Modifier) {
+    var trackPx by remember { mutableFloatStateOf(0f) }
+    var dragPx by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
+    Box(
+        modifier
+            .fillMaxWidth()
+            .height(ThumbSize)
+            .onSizeChanged { size ->
+                val thumbPx = with(density) { ThumbSize.toPx() }
+                trackPx = max(0f, size.width.toFloat() - thumbPx)
+            }
+            .background(accent.copy(alpha = 0.15f), CircleShape),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(label, modifier = Modifier.fillMaxWidth(), color = accent)
+        Box(
+            Modifier
+                .size(ThumbSize)
+                .offset { IntOffset(dragPx.roundToInt(), 0) }
+                .background(accent, CircleShape)
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) onConfirm() else dragPx = 0f },
+                        onHorizontalDrag = { _, delta -> dragPx = (dragPx + delta).coerceIn(0f, trackPx) },
+                    )
+                },
+            contentAlignment = Alignment.Center,
+        ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = Color.White) }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronDetailScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.util.formatEpoch
 import com.hermes.client.ui.util.formatIso

--- a/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronEditScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/cron/CronScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import android.widget.Toast
 

--- a/app/src/main/java/com/hermes/client/ui/messaging/MessagingScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/messaging/MessagingScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/messaging/MessagingSetupScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/messaging/MessagingSetupScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/models/ModelsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/models/ModelsScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/YouHubScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.components.HermesTopBar
 import com.hermes.client.ui.components.HubRow

--- a/app/src/main/java/com/hermes/client/ui/profiles/ProfilesScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/profiles/ProfilesScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.nav.ShellViewModel
 

--- a/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ArchivedSessionsScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.domain.Session
 

--- a/app/src/main/java/com/hermes/client/ui/sessions/ProjectDerivation.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ProjectDerivation.kt
@@ -68,4 +68,4 @@ private fun buildProject(id: String, label: String, rows: List<Session>): Projec
 }
 
 private fun basename(path: String): String =
-    path.trimEnd('/').substringAfterLast('/').ifBlank { path }
+    path.trimEnd('/', '\\').substringAfterLast('/').substringAfterLast('\\').ifBlank { path }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ProjectDerivation.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ProjectDerivation.kt
@@ -1,0 +1,71 @@
+package com.hermes.client.ui.sessions
+
+import com.hermes.client.domain.Project
+import com.hermes.client.domain.ProjectLane
+import com.hermes.client.domain.ProjectRepo
+import com.hermes.client.domain.Session
+
+/** Group id for sessions that have no git repo (loose chats). */
+const val NO_PROJECT_ID = "__no_project__"
+
+/**
+ * Cross-profile Projects derived client-side from the session list, grouped by git repo root.
+ *
+ * Stopgap: the gateway's `projects.tree` is pinned to the launch (default) profile and takes no
+ * profile param, so it can't serve a selected tenant's projects to the phone. Until the gateway
+ * gains a `profile` param, this lists every repo that has chats **across all profiles**, so the
+ * phone shows real projects instead of just the default profile's one.
+ *
+ * Each [Project] carries all its sessions in a single lane; [Project.previewSessions] is the three
+ * most-recent. Sessions keep their own [Session.profile], so opening one still resolves against the
+ * right per-profile DB, and the UI can badge each project/session with its tenant. Loose sessions
+ * (no git repo) collapse into one "No project" group, sorted last.
+ */
+fun deriveProjectsFromSessions(sessions: List<Session>): List<Project> {
+    // Prefer the resolved git repo root, but fall back to the working directory — many sessions
+    // never get a git_repo_root, and grouping on it alone would collapse most projects into the
+    // "No project" bucket. Sessions with neither are the loose group.
+    val byRepo = sessions.groupBy { it.gitRepoRoot?.ifBlank { null } ?: it.cwd?.ifBlank { null } }
+
+    val projects = byRepo
+        .filterKeys { it != null }
+        .map { (repo, rows) -> buildProject(repo!!, basename(repo), rows) }
+        .sortedWith(
+            compareByDescending<Project> { it.lastActive ?: Long.MIN_VALUE }
+                .thenBy { it.label.lowercase() },
+        )
+
+    val loose = byRepo[null].orEmpty()
+    val looseProject = if (loose.isNotEmpty()) buildProject(NO_PROJECT_ID, "No project", loose) else null
+
+    return projects + listOfNotNull(looseProject)
+}
+
+private fun buildProject(id: String, label: String, rows: List<Session>): Project {
+    val byRecency = rows.sortedByDescending { it.lastActive ?: Long.MIN_VALUE }
+    val path = id.takeIf { it != NO_PROJECT_ID }
+    return Project(
+        id = id,
+        label = label,
+        path = path,
+        color = null,
+        isAuto = true,
+        sessionCount = rows.size,
+        lastActive = rows.mapNotNull { it.lastActive }.maxOrNull(),
+        repos = listOf(
+            ProjectRepo(
+                id = id,
+                label = label,
+                path = path,
+                sessionCount = rows.size,
+                lanes = listOf(
+                    ProjectLane(id = "all", label = "", path = null, isMain = true, sessions = byRecency),
+                ),
+            ),
+        ),
+        previewSessions = byRecency.take(3),
+    )
+}
+
+private fun basename(path: String): String =
+    path.trimEnd('/').substringAfterLast('/').ifBlank { path }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt
@@ -39,13 +39,23 @@ fun ProjectOverview(projects: List<Project>, onOpenProject: (Project) -> Unit) {
     }
 }
 
+/** Distinct profiles (tenants) a project's chats belong to — projects span profiles in this view. */
+private fun Project.tenantProfiles(): List<String> =
+    repos.asSequence()
+        .flatMap { it.lanes.asSequence() }
+        .flatMap { it.sessions.asSequence() }
+        .mapNotNull { it.profile?.takeIf { p -> p.isNotBlank() } }
+        .distinct()
+        .toList()
+
 @Composable
 fun ProjectCard(project: Project, onClick: () -> Unit) {
     ListItem(
         headlineContent = { Text(project.label) },
         supportingContent = {
-            val repos = if (project.isAuto) "auto" else "${project.repos.size} repo${if (project.repos.size == 1) "" else "s"}"
-            Text("${project.sessionCount} session${if (project.sessionCount == 1) "" else "s"} · $repos")
+            val tenants = project.tenantProfiles()
+            val tenantText = if (tenants.isEmpty()) "" else " · ${tenants.joinToString(", ")}"
+            Text("${project.sessionCount} session${if (project.sessionCount == 1) "" else "s"}$tenantText")
         },
         leadingContent = {
             Icon(Icons.Rounded.Folder, contentDescription = null, tint = projectTint(project.color), modifier = Modifier.size(24.dp))
@@ -87,7 +97,10 @@ fun ProjectScopeView(project: Project, onBack: () -> Unit, onOpenSession: (Sessi
             items(lane.sessions, key = { "sess-${it.id}" }) { s ->
                 ListItem(
                     headlineContent = { Text(s.title) },
-                    supportingContent = { Text(s.model ?: "") },
+                    // Badge the tenant since a project can span profiles.
+                    supportingContent = {
+                        Text(listOfNotNull(s.profile?.takeIf { it.isNotBlank() }, s.model).joinToString(" · "))
+                    },
                     modifier = Modifier.clickable { onOpenSession(s) },
                 )
             }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -69,7 +69,7 @@ fun ProjectScopeView(project: Project, onBack: () -> Unit, onOpenSession: (Sessi
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Start,
             ) {
-                Icon(Icons.Rounded.ArrowBack, contentDescription = "Back", tint = LocalProfileAccent.current.accent, modifier = Modifier.padding(end = 8.dp))
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back", tint = LocalProfileAccent.current.accent, modifier = Modifier.padding(end = 8.dp))
                 Text(project.label, style = MaterialTheme.typography.titleSmall, color = LocalProfileAccent.current.accent)
             }
         }

--- a/app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt
@@ -1,0 +1,106 @@
+package com.hermes.client.ui.sessions
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.hermes.client.domain.Project
+import com.hermes.client.domain.Session
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+/** Parse the gateway's "#RRGGBB" project color; fall back to the tenant accent when null/invalid. */
+@Composable
+private fun projectTint(color: String?): Color {
+    val accent = LocalProfileAccent.current.accent
+    return color?.let { runCatching { Color(android.graphics.Color.parseColor(it)) }.getOrNull() } ?: accent
+}
+
+/** Projects overview: one tappable card per project. */
+@Composable
+fun ProjectOverview(projects: List<Project>, onOpenProject: (Project) -> Unit) {
+    LazyColumn(Modifier.fillMaxWidth()) {
+        items(projects, key = { it.id }) { p -> ProjectCard(p, onClick = { onOpenProject(p) }) }
+    }
+}
+
+@Composable
+fun ProjectCard(project: Project, onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(project.label) },
+        supportingContent = {
+            val repos = if (project.isAuto) "auto" else "${project.repos.size} repo${if (project.repos.size == 1) "" else "s"}"
+            Text("${project.sessionCount} session${if (project.sessionCount == 1) "" else "s"} · $repos")
+        },
+        leadingContent = {
+            Icon(Icons.Rounded.Folder, contentDescription = null, tint = projectTint(project.color), modifier = Modifier.size(24.dp))
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
+
+/**
+ * Drill-in for one hydrated project: a back row, then its sessions. A single-lane project renders a
+ * flat list; multi-lane projects show repo/branch sub-headers.
+ */
+@Composable
+fun ProjectScopeView(project: Project, onBack: () -> Unit, onOpenSession: (Session) -> Unit) {
+    val lanes = project.repos.flatMap { repo -> repo.lanes.map { repo to it } }
+    val multi = lanes.size > 1
+    LazyColumn(Modifier.fillMaxWidth()) {
+        item(key = "back") {
+            Row(
+                Modifier.fillMaxWidth().clickable(onClick = onBack).padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+            ) {
+                Icon(Icons.Rounded.ArrowBack, contentDescription = "Back", tint = LocalProfileAccent.current.accent, modifier = Modifier.padding(end = 8.dp))
+                Text(project.label, style = MaterialTheme.typography.titleSmall, color = LocalProfileAccent.current.accent)
+            }
+        }
+        lanes.forEach { (repo, lane) ->
+            if (multi) {
+                item(key = "lane-${repo.id}-${lane.id}") {
+                    Text(
+                        "${repo.label} · ${lane.label}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp),
+                    )
+                }
+            }
+            items(lane.sessions, key = { "sess-${it.id}" }) { s ->
+                ListItem(
+                    headlineContent = { Text(s.title) },
+                    supportingContent = { Text(s.model ?: "") },
+                    modifier = Modifier.clickable { onOpenSession(s) },
+                )
+            }
+        }
+        if (lanes.isEmpty()) {
+            item(key = "empty-scope") {
+                Text(
+                    "No sessions in this project.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt
@@ -3,6 +3,9 @@ package com.hermes.client.ui.sessions
 import com.hermes.client.data.repository.GroupExpansionStore
 import com.hermes.client.domain.Session
 
+/** Which list the Chats screen shows: a flat recency list, or the gateway's project tree. */
+enum class ViewMode { SESSIONS, PROJECTS }
+
 /**
  * A workspace sub-group within a profile. [sessions] is empty when the group is collapsed;
  * [count] always reflects the true number of rows so the header reads correctly either way.
@@ -61,3 +64,7 @@ fun groupSessions(
                 .thenByDescending { it.count }
                 .thenBy { it.profile },
         )
+
+/** Flat, most-recent-first order for Sessions mode. Sessions with no [Session.lastActive] sort last. */
+fun sessionsByRecency(sessions: List<Session>): List<Session> =
+    sessions.sortedByDescending { it.lastActive ?: Long.MIN_VALUE }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -121,7 +121,7 @@ fun SessionsScreen(
                     Text(
                         "Projects · ${activeProfile ?: "default"}",
                         style = MaterialTheme.typography.labelMedium,
-                        color = com.hermes.client.ui.components.AccentChrome.onBar,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                     )
                 }

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -118,10 +118,11 @@ fun SessionsScreen(
                         )
                     }
                 } else {
-                    // Projects come from the gateway's own profile (projects.tree takes no profile
-                    // param), NOT the selected tenant — so don't label them with the active profile.
+                    // Projects are derived from chats across ALL profiles (stopgap until the gateway
+                    // supports per-profile projects.tree), so they span tenants — each row is badged
+                    // with its profile. The per-profile switcher doesn't apply here.
                     Text(
-                        "Projects on this gateway · not filtered by profile",
+                        "Projects · all profiles",
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
@@ -165,18 +166,18 @@ fun SessionsScreen(
                                 message = projectsState.error!!,
                                 onRetry = { vm.loadProjectTree() },
                             )
-                        projectsState.scope != null && projectsState.scopeLoading ->
-                            com.hermes.client.ui.components.LoadingState()
                         projectsState.scope != null ->
                             ProjectScopeView(
                                 project = projectsState.scope!!,
                                 onBack = { vm.exitProject() },
-                                onOpenSession = { s -> onOpen(s.id) },
+                                // Projects span profiles, so switch to the session's own profile
+                                // (awaited) before opening, or the chat resumes against the wrong DB.
+                                onOpenSession = { s -> scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
                             )
                         projectsState.tree.isEmpty() ->
                             com.hermes.client.ui.components.EmptyState(
                                 title = "No projects",
-                                subtitle = "Projects are created on the desktop app.",
+                                subtitle = "Chats run in a project folder show up here.",
                                 actionLabel = "Reload",
                                 onAction = { vm.loadProjectTree() },
                             )

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -118,8 +118,10 @@ fun SessionsScreen(
                         )
                     }
                 } else {
+                    // Projects come from the gateway's own profile (projects.tree takes no profile
+                    // param), NOT the selected tenant — so don't label them with the active profile.
                     Text(
-                        "Projects · ${activeProfile ?: "default"}",
+                        "Projects on this gateway · not filtered by profile",
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -163,6 +163,8 @@ fun SessionsScreen(
                                 message = projectsState.error!!,
                                 onRetry = { vm.loadProjectTree() },
                             )
+                        projectsState.scope != null && projectsState.scopeLoading ->
+                            com.hermes.client.ui.components.LoadingState()
                         projectsState.scope != null ->
                             ProjectScopeView(
                                 project = projectsState.scope!!,

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.domain.Session
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -20,9 +20,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Archive
-import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -37,6 +35,9 @@ import androidx.compose.material3.MaterialTheme
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.rememberSwipeToDismissBoxState
@@ -70,9 +71,10 @@ fun SessionsScreen(
     val activeProfile by vm.activeProfile.collectAsStateWithLifecycle()
     val profiles by vm.profiles.collectAsStateWithLifecycle()
     val pinnedTokens by vm.pinnedTokens.collectAsStateWithLifecycle()
-    val collapsedGroups by vm.collapsedGroups.collectAsStateWithLifecycle()
     val query by vm.query.collectAsStateWithLifecycle()
     val messageResults by vm.messageResults.collectAsStateWithLifecycle()
+    val viewMode by vm.viewMode.collectAsStateWithLifecycle()
+    val projectsState by vm.projectsState.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
 
     // I1: route to Setup when a 401 is received
@@ -104,12 +106,39 @@ fun SessionsScreen(
                 )
                 // Same tenant switcher as Agent Activity: a chip row, active one selected. Tapping
                 // switches the active profile and the list re-fetches.
-                if (profiles.size > 1) {
-                    com.hermes.client.ui.components.ProfileSwitcher(
-                        names = profiles.map { it.name },
-                        active = activeProfile,
-                        onSelect = vm::switchProfile,
+                // Sessions mode spans all profiles (REST); Projects mode is single-profile (the
+                // gateway's bound profile — projects.tree takes no profile param), so the switcher
+                // would be misleading there. Show a caption instead.
+                if (viewMode == ViewMode.SESSIONS) {
+                    if (profiles.size > 1) {
+                        com.hermes.client.ui.components.ProfileSwitcher(
+                            names = profiles.map { it.name },
+                            active = activeProfile,
+                            onSelect = vm::switchProfile,
+                        )
+                    }
+                } else {
+                    Text(
+                        "Projects · ${activeProfile ?: "default"}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = com.hermes.client.ui.components.AccentChrome.onBar,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
                     )
+                }
+                val accent = LocalProfileAccent.current
+                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+                    val tabs = listOf(ViewMode.SESSIONS to "Sessions", ViewMode.PROJECTS to "Projects")
+                    tabs.forEachIndexed { i, (mode, label) ->
+                        SegmentedButton(
+                            selected = viewMode == mode,
+                            onClick = { vm.setViewMode(mode) },
+                            shape = SegmentedButtonDefaults.itemShape(i, tabs.size),
+                            colors = SegmentedButtonDefaults.colors(
+                                activeContainerColor = accent.accent,
+                                activeContentColor = accent.onAccent,
+                            ),
+                        ) { Text(label) }
+                    }
                 }
             }
         },
@@ -124,205 +153,135 @@ fun SessionsScreen(
         },
     ) { padding ->
         Column(Modifier.padding(padding).fillMaxSize()) {
-            // Search: typing filters the loaded list by title/workspace instantly; the keyboard
-            // Search action runs a full message-content search via the gateway.
-            OutlinedTextField(
-                value = query,
-                onValueChange = vm::onQueryChange,
-                placeholder = { Text("Search sessions…") },
-                singleLine = true,
-                trailingIcon = {
-                    if (query.isNotBlank()) {
-                        IconButton(onClick = { vm.onQueryChange("") }) {
-                            Icon(Icons.Rounded.Close, contentDescription = "Clear search")
-                        }
+            if (viewMode == ViewMode.PROJECTS) {
+                Box(Modifier.fillMaxSize()) {
+                    when {
+                        projectsState.loading && projectsState.tree.isEmpty() ->
+                            com.hermes.client.ui.components.LoadingState()
+                        projectsState.error != null ->
+                            com.hermes.client.ui.components.ErrorState(
+                                message = projectsState.error!!,
+                                onRetry = { vm.loadProjectTree() },
+                            )
+                        projectsState.scope != null ->
+                            ProjectScopeView(
+                                project = projectsState.scope!!,
+                                onBack = { vm.exitProject() },
+                                onOpenSession = { s -> onOpen(s.id) },
+                            )
+                        projectsState.tree.isEmpty() ->
+                            com.hermes.client.ui.components.EmptyState(
+                                title = "No projects",
+                                subtitle = "Projects are created on the desktop app.",
+                                actionLabel = "Reload",
+                                onAction = { vm.loadProjectTree() },
+                            )
+                        else -> ProjectOverview(projectsState.tree, onOpenProject = { vm.enterProject(it) })
                     }
-                },
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(onSearch = { vm.searchMessages() }),
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
-            )
-            Box(Modifier.fillMaxSize()) {
-            when {
-                state.loading -> com.hermes.client.ui.components.LoadingState()
-                state.error != null -> com.hermes.client.ui.components.ErrorState(
-                    message = state.error!!,
-                    onRetry = { vm.refresh() },
+                }
+            } else {
+                // ── Sessions mode (flat recency) ─────────────────────────────────────────────
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = vm::onQueryChange,
+                    placeholder = { Text("Search sessions…") },
+                    singleLine = true,
+                    trailingIcon = {
+                        if (query.isNotBlank()) {
+                            IconButton(onClick = { vm.onQueryChange("") }) {
+                                Icon(Icons.Rounded.Close, contentDescription = "Clear search")
+                            }
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { vm.searchMessages() }),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
                 )
-                state.sessions.isEmpty() && query.isBlank() && messageResults.isEmpty() ->
-                    com.hermes.client.ui.components.EmptyState(
-                        title = "No sessions yet",
-                        subtitle = "Start a conversation with the New button.",
-                        actionLabel = "New session",
-                        onAction = { scope.launch { vm.createSession()?.let { onOpen(it) } } },
-                    )
-                else -> {
-                    val q = query.trim()
-                    // Instant client-side title/workspace filter over the loaded sessions.
-                    val matches = if (q.isEmpty()) state.sessions
-                    else state.sessions.filter {
-                        it.title.contains(q, ignoreCase = true) ||
-                            it.workspace.contains(q, ignoreCase = true)
-                    }
-                    // Pins are keyed by each session's OWN profile (the list spans all profiles),
-                    // so a pin made in another tenant still shows here.
-                    val isPinned = { s: Session ->
-                        com.hermes.client.data.repository.PinStore.token(s.profile, s.id) in pinnedTokens
-                    }
-                    val pinned = matches.filter(isPinned)
-                    // Two-tier tree: Profile → Workspace → rows, with collapsed groups already
-                    // pruned. The active profile sorts first.
-                    val tree = groupSessions(
-                        matches.filterNot(isPinned),
-                        collapsedGroups,
-                        activeProfile,
-                    )
+                Box(Modifier.fillMaxSize()) {
+                    when {
+                        state.loading -> com.hermes.client.ui.components.LoadingState()
+                        state.error != null -> com.hermes.client.ui.components.ErrorState(
+                            message = state.error!!,
+                            onRetry = { vm.refresh() },
+                        )
+                        state.sessions.isEmpty() && query.isBlank() && messageResults.isEmpty() ->
+                            com.hermes.client.ui.components.EmptyState(
+                                title = "No sessions yet",
+                                subtitle = "Start a conversation with the New button.",
+                                actionLabel = "New session",
+                                onAction = { scope.launch { vm.createSession()?.let { onOpen(it) } } },
+                            )
+                        else -> {
+                            val q = query.trim()
+                            val matches = if (q.isEmpty()) state.sessions
+                            else state.sessions.filter {
+                                it.title.contains(q, ignoreCase = true) ||
+                                    it.workspace.contains(q, ignoreCase = true)
+                            }
+                            val isPinned = { s: Session ->
+                                com.hermes.client.data.repository.PinStore.token(s.profile, s.id) in pinnedTokens
+                            }
+                            val pinned = matches.filter(isPinned)
+                            val recent = sessionsByRecency(matches.filterNot(isPinned))
 
-                    LazyColumn {
-                        // Gateway message-content search results (populated on the Search action).
-                        if (messageResults.isNotEmpty()) {
-                            item(key = "h-msg") { SectionHeader("Message matches", messageResults.size) }
-                            // No custom key: results are transient and snippets can collide
-                            // (duplicate/empty), which would crash the list. Index keys are safe.
-                            items(messageResults) { r ->
-                                ListItem(
-                                    headlineContent = {
-                                        Text(r.snippet?.take(140)?.replace("\n", " ") ?: r.sessionId)
-                                    },
-                                    supportingContent = { Text(r.model ?: r.role ?: "") },
-                                    modifier = Modifier.clickable { onOpen(r.sessionId) },
-                                )
-                                HorizontalDivider()
-                            }
-                        }
-                        // Hint when nothing matches by title — message search is one tap away.
-                        if (q.isNotEmpty() && matches.isEmpty() && messageResults.isEmpty()) {
-                            item(key = "no-title-match") {
-                                Text(
-                                    "No titles match \"$q\". Press search on the keyboard to search message text.",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(16.dp),
-                                )
-                            }
-                        }
-                        if (pinned.isNotEmpty()) {
-                            // "Device only" makes clear pins live on this phone and don't sync to
-                            // the desktop app (the gateway has no pin concept).
-                            item(key = "h-pinned") { SectionHeader("Pinned", pinned.size, note = "Device only") }
-                            items(pinned, key = { "p-${it.id}" }) { s ->
-                                SessionRow(
-                                    session = s,
-                                    isPinned = true,
-                                    showProfile = true,
-                                    // Switch to the session's profile (awaited) before navigating,
-                                    // so the chat resumes against the right per-profile DB.
-                                    onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
-                                    onTogglePin = { vm.togglePin(s) },
-                                    onRename = { vm.rename(s, it) },
-                                    onArchive = { vm.archive(s) },
-                                    onDelete = { vm.delete(s) },
-                                    modifier = Modifier.animateItem(),
-                                )
-                            }
-                        }
-                        tree.forEach { pg ->
-                            item(key = "ph-${pg.profile}") {
-                                CollapsibleHeader(
-                                    label = pg.profile,
-                                    count = pg.count,
-                                    collapsed = pg.collapsed,
-                                    indent = false,
-                                    onToggle = {
-                                        vm.toggleGroup(
-                                            com.hermes.client.data.repository.GroupExpansionStore
-                                                .profileKey(pg.profile),
+                            LazyColumn {
+                                if (messageResults.isNotEmpty()) {
+                                    item(key = "h-msg") { SectionHeader("Message matches", messageResults.size) }
+                                    items(messageResults) { r ->
+                                        ListItem(
+                                            headlineContent = {
+                                                Text(r.snippet?.take(140)?.replace("\n", " ") ?: r.sessionId)
+                                            },
+                                            supportingContent = { Text(r.model ?: r.role ?: "") },
+                                            modifier = Modifier.clickable { onOpen(r.sessionId) },
                                         )
-                                    },
-                                )
-                            }
-                            pg.workspaces.forEach { wg ->
-                                item(key = "wh-${pg.profile}-${wg.workspace}") {
-                                    CollapsibleHeader(
-                                        label = wg.workspace,
-                                        count = wg.count,
-                                        collapsed = wg.collapsed,
-                                        indent = true,
-                                        onToggle = {
-                                            vm.toggleGroup(
-                                                com.hermes.client.data.repository.GroupExpansionStore
-                                                    .workspaceKey(pg.profile, wg.workspace),
-                                            )
-                                        },
-                                    )
+                                        HorizontalDivider()
+                                    }
                                 }
-                                items(wg.sessions, key = { it.id }) { s ->
-                                    SessionRow(
-                                        session = s,
-                                        isPinned = false,
-                                        showProfile = false,
-                                        onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
-                                        onTogglePin = { vm.togglePin(s) },
-                                        onRename = { vm.rename(s, it) },
-                                        onArchive = { vm.archive(s) },
-                                        onDelete = { vm.delete(s) },
-                                        modifier = Modifier.animateItem(),
-                                    )
+                                if (q.isNotEmpty() && matches.isEmpty() && messageResults.isEmpty()) {
+                                    item(key = "no-title-match") {
+                                        Text(
+                                            "No titles match \"$q\". Press search on the keyboard to search message text.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.padding(16.dp),
+                                        )
+                                    }
+                                }
+                                if (pinned.isNotEmpty()) {
+                                    item(key = "h-pinned") { SectionHeader("Pinned", pinned.size, note = "Device only") }
+                                    items(pinned, key = { "p-${it.id}" }) { s ->
+                                        SessionRow(
+                                            session = s, isPinned = true, showProfile = true,
+                                            onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
+                                            onTogglePin = { vm.togglePin(s) },
+                                            onRename = { vm.rename(s, it) },
+                                            onArchive = { vm.archive(s) },
+                                            onDelete = { vm.delete(s) },
+                                            modifier = Modifier.animateItem(),
+                                        )
+                                    }
+                                }
+                                if (recent.isNotEmpty()) {
+                                    item(key = "h-recent") { SectionHeader("Recent", recent.size) }
+                                    items(recent, key = { it.id }) { s ->
+                                        SessionRow(
+                                            session = s, isPinned = false, showProfile = true,
+                                            onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
+                                            onTogglePin = { vm.togglePin(s) },
+                                            onRename = { vm.rename(s, it) },
+                                            onArchive = { vm.archive(s) },
+                                            onDelete = { vm.delete(s) },
+                                            modifier = Modifier.animateItem(),
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-            }
         }
-    }
-}
-
-/**
- * A tap-to-collapse group header (profile = top tier, workspace = indented sub-tier). A leading
- * chevron shows the state; the whole row toggles. Profile labels read in caps; workspace labels
- * are indented and lighter so the two tiers are visually distinct.
- */
-@Composable
-private fun CollapsibleHeader(
-    label: String,
-    count: Int,
-    collapsed: Boolean,
-    indent: Boolean,
-    onToggle: () -> Unit,
-) {
-    androidx.compose.foundation.layout.Row(
-        Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onToggle)
-            .padding(
-                start = if (indent) 28.dp else 16.dp,
-                end = 16.dp,
-                top = if (indent) 6.dp else 16.dp,
-                bottom = 4.dp,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            if (collapsed) Icons.Rounded.ChevronRight else Icons.Rounded.ExpandMore,
-            contentDescription = if (collapsed) "Expand" else "Collapse",
-            tint = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
-            else LocalProfileAccent.current.accent,
-            modifier = Modifier.padding(end = 8.dp).size(18.dp),
-        )
-        Text(
-            if (indent) label else label.uppercase(),
-            style = MaterialTheme.typography.labelMedium,
-            color = if (indent) MaterialTheme.colorScheme.onSurfaceVariant
-            else LocalProfileAccent.current.accent,
-            modifier = Modifier.weight(1f),
-        )
-        Text(
-            count.toString(),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -8,7 +8,10 @@ import com.hermes.client.data.repository.ChatRepository
 import com.hermes.client.data.repository.GroupExpansionStore
 import com.hermes.client.data.repository.PinStore
 import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.data.repository.ProjectsRepository
 import com.hermes.client.data.repository.SessionRepository
+import com.hermes.client.data.repository.ViewModeStore
+import com.hermes.client.domain.Project
 import com.hermes.client.domain.Session
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,6 +31,15 @@ data class SessionsUiState(
     val unauthorized: Boolean = false,
 )
 
+/** Projects-mode state: [tree] is the overview; [scope] is the drilled-in hydrated project (null = overview). */
+data class ProjectsUiState(
+    val tree: List<Project> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val scope: Project? = null,
+    val scopeLoading: Boolean = false,
+)
+
 @HiltViewModel
 class SessionsViewModel @Inject constructor(
     private val sessions: SessionRepository,
@@ -35,6 +47,8 @@ class SessionsViewModel @Inject constructor(
     private val profileManager: ProfileManager,
     private val pinStore: PinStore,
     private val groupExpansion: GroupExpansionStore,
+    private val projects: ProjectsRepository,
+    private val viewModeStore: ViewModeStore,
 ) : ViewModel() {
     private val _state = MutableStateFlow(SessionsUiState())
     val state: StateFlow<SessionsUiState> = _state.asStateFlow()
@@ -66,6 +80,55 @@ class SessionsViewModel @Inject constructor(
 
     /** Collapse or expand a group (profile or workspace) by its [GroupExpansionStore] key. */
     fun toggleGroup(groupKey: String) = viewModelScope.launch { groupExpansion.toggle(groupKey) }
+
+    /** Persisted view mode (Sessions flat list vs the gateway project tree). */
+    val viewMode: StateFlow<ViewMode> =
+        viewModeStore.mode.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ViewMode.SESSIONS)
+
+    private val _projects = MutableStateFlow(ProjectsUiState())
+    val projectsState: StateFlow<ProjectsUiState> = _projects.asStateFlow()
+
+    /** Switch view mode; on the first entry into Projects (empty tree) fetch it. */
+    fun setViewMode(mode: ViewMode) {
+        viewModelScope.launch { viewModeStore.set(mode) }
+        if (mode == ViewMode.PROJECTS && _projects.value.tree.isEmpty() && !_projects.value.loading) {
+            loadProjectTree()
+        }
+    }
+
+    private var projectTreeJob: Job? = null
+
+    /** Fetch the project overview (also the retry entry point). Latest-wins like [refresh]. */
+    fun loadProjectTree() {
+        projectTreeJob?.cancel()
+        projectTreeJob = viewModelScope.launch {
+            _projects.value = _projects.value.copy(loading = true, error = null)
+            try {
+                val tree = projects.tree()
+                _projects.value = _projects.value.copy(loading = false, tree = tree.projects)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _projects.value = _projects.value.copy(loading = false, error = e.message ?: "Failed to load projects")
+            }
+        }
+    }
+
+    /** Drill into a project: hydrate its sessions. Falls back to the overview node on failure. */
+    fun enterProject(project: Project) {
+        viewModelScope.launch {
+            _projects.value = _projects.value.copy(scope = project, scopeLoading = true)
+            val hydrated = runCatching { projects.projectSessions(project.id) }
+                .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
+                .getOrNull() ?: project
+            _projects.value = _projects.value.copy(scope = hydrated, scopeLoading = false)
+        }
+    }
+
+    /** Return to the project overview. */
+    fun exitProject() {
+        _projects.value = _projects.value.copy(scope = null)
+    }
 
     init {
         chat.connect()

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -88,12 +88,9 @@ class SessionsViewModel @Inject constructor(
     private val _projects = MutableStateFlow(ProjectsUiState())
     val projectsState: StateFlow<ProjectsUiState> = _projects.asStateFlow()
 
-    /** Switch view mode; on the first entry into Projects (empty tree) fetch it. */
+    /** Persist the chosen view mode; the [viewMode] observer in init fetches the tree when needed. */
     fun setViewMode(mode: ViewMode) {
         viewModelScope.launch { viewModeStore.set(mode) }
-        if (mode == ViewMode.PROJECTS && _projects.value.tree.isEmpty() && !_projects.value.loading) {
-            loadProjectTree()
-        }
     }
 
     private var projectTreeJob: Job? = null
@@ -144,6 +141,17 @@ class SessionsViewModel @Inject constructor(
         // This VM stays in the back stack while a chat is open, so it catches the event live.
         viewModelScope.launch {
             chat.events.collect { if (it.type == "session.title") refresh() }
+        }
+        // Fetch the project tree whenever Projects becomes the active view without a loaded tree.
+        // Covers both the toggle tap AND a cold launch restored into Projects mode (persisted) —
+        // the launch case previously never called loadProjectTree, so Projects showed a spurious
+        // "No projects" until the user toggled.
+        viewModelScope.launch {
+            viewModeStore.mode.collect { mode ->
+                if (mode == ViewMode.PROJECTS && _projects.value.tree.isEmpty() && !_projects.value.loading) {
+                    loadProjectTree()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -97,6 +97,7 @@ class SessionsViewModel @Inject constructor(
     }
 
     private var projectTreeJob: Job? = null
+    private var projectScopeJob: Job? = null
 
     /** Fetch the project overview (also the retry entry point). Latest-wins like [refresh]. */
     fun loadProjectTree() {
@@ -116,7 +117,8 @@ class SessionsViewModel @Inject constructor(
 
     /** Drill into a project: hydrate its sessions. Falls back to the overview node on failure. */
     fun enterProject(project: Project) {
-        viewModelScope.launch {
+        projectScopeJob?.cancel()
+        projectScopeJob = viewModelScope.launch {
             _projects.value = _projects.value.copy(scope = project, scopeLoading = true)
             val hydrated = runCatching { projects.projectSessions(project.id) }
                 .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
@@ -127,7 +129,8 @@ class SessionsViewModel @Inject constructor(
 
     /** Return to the project overview. */
     fun exitProject() {
-        _projects.value = _projects.value.copy(scope = null)
+        projectScopeJob?.cancel()
+        _projects.value = _projects.value.copy(scope = null, scopeLoading = false)
     }
 
     init {

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt
@@ -8,7 +8,6 @@ import com.hermes.client.data.repository.ChatRepository
 import com.hermes.client.data.repository.GroupExpansionStore
 import com.hermes.client.data.repository.PinStore
 import com.hermes.client.data.repository.ProfileManager
-import com.hermes.client.data.repository.ProjectsRepository
 import com.hermes.client.data.repository.SessionRepository
 import com.hermes.client.data.repository.ViewModeStore
 import com.hermes.client.domain.Project
@@ -37,7 +36,6 @@ data class ProjectsUiState(
     val loading: Boolean = false,
     val error: String? = null,
     val scope: Project? = null,
-    val scopeLoading: Boolean = false,
 )
 
 @HiltViewModel
@@ -47,7 +45,6 @@ class SessionsViewModel @Inject constructor(
     private val profileManager: ProfileManager,
     private val pinStore: PinStore,
     private val groupExpansion: GroupExpansionStore,
-    private val projects: ProjectsRepository,
     private val viewModeStore: ViewModeStore,
 ) : ViewModel() {
     private val _state = MutableStateFlow(SessionsUiState())
@@ -94,16 +91,19 @@ class SessionsViewModel @Inject constructor(
     }
 
     private var projectTreeJob: Job? = null
-    private var projectScopeJob: Job? = null
 
-    /** Fetch the project overview (also the retry entry point). Latest-wins like [refresh]. */
+    /** Build the project overview (also the retry entry point). Latest-wins like [refresh]. */
     fun loadProjectTree() {
         projectTreeJob?.cancel()
         projectTreeJob = viewModelScope.launch {
             _projects.value = _projects.value.copy(loading = true, error = null)
             try {
-                val tree = projects.tree()
-                _projects.value = _projects.value.copy(loading = false, tree = tree.projects)
+                // Stopgap: derive Projects from the cross-profile session list (all profiles),
+                // because the gateway's projects.tree is pinned to the launch profile and can't
+                // serve a selected tenant's projects. Re-wire to a per-profile gateway RPC (see
+                // ProjectsRepository) once the gateway accepts a `profile` param.
+                val derived = deriveProjectsFromSessions(sessions.listAllProfiles())
+                _projects.value = _projects.value.copy(loading = false, tree = derived)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -112,22 +112,14 @@ class SessionsViewModel @Inject constructor(
         }
     }
 
-    /** Drill into a project: hydrate its sessions. Falls back to the overview node on failure. */
+    /** Drill into a project. Derived projects already carry all their sessions — no fetch needed. */
     fun enterProject(project: Project) {
-        projectScopeJob?.cancel()
-        projectScopeJob = viewModelScope.launch {
-            _projects.value = _projects.value.copy(scope = project, scopeLoading = true)
-            val hydrated = runCatching { projects.projectSessions(project.id) }
-                .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
-                .getOrNull() ?: project
-            _projects.value = _projects.value.copy(scope = hydrated, scopeLoading = false)
-        }
+        _projects.value = _projects.value.copy(scope = project)
     }
 
     /** Return to the project overview. */
     fun exitProject() {
-        projectScopeJob?.cancel()
-        _projects.value = _projects.value.copy(scope = null, scopeLoading = false)
+        _projects.value = _projects.value.copy(scope = null)
     }
 
     init {

--- a/app/src/main/java/com/hermes/client/ui/settings/AboutScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/AboutScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/hermes/client/ui/settings/AppearanceScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/AppearanceScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.data.repository.ThemeMode
 

--- a/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/ConnectionSettingsScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/DiagnosticsScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.data.diagnostics.DebugLog
 import java.time.Instant

--- a/app/src/main/java/com/hermes/client/ui/settings/EnvScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/EnvScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/settings/McpSettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/McpSettingsScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/settings/MemorySettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/MemorySettingsScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/NotificationsScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @Composable

--- a/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/tools/AgentsToolsScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.ui.theme.LocalProfileAccent
 

--- a/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/usage/UsageScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope

--- a/app/src/test/java/com/hermes/client/data/repository/ProjectsRepositoryTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/ProjectsRepositoryTest.kt
@@ -1,0 +1,63 @@
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProjectsRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test fun tree_calls_projects_tree_and_parses_nodes() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement(
+            """{ "projects": [ { "id": "p1", "label": "Alpha", "isAuto": false, "sessionCount": 2 } ],
+                 "active_id": "p1" }""",
+        )
+        val repo = ProjectsRepository(client, json)
+
+        val tree = repo.tree()
+
+        assertEquals("p1", tree.activeId)
+        assertEquals("Alpha", tree.projects.single().label)
+        coVerify { client.call("projects.tree", any()) }
+    }
+
+    @Test fun tree_passes_preview_limit_param() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement("""{"projects":[]}""")
+        val repo = ProjectsRepository(client, json)
+
+        repo.tree(previewLimit = 5)
+
+        coVerify { client.call("projects.tree", match { it["preview_limit"]!!.jsonPrimitive.content == "5" }) }
+    }
+
+    @Test fun projectSessions_calls_rpc_with_id_and_parses_project() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement(
+            """{ "project": { "id": "p1", "label": "Alpha", "isAuto": false, "sessionCount": 1,
+                 "repos": [], "previewSessions": [] } }""",
+        )
+        val repo = ProjectsRepository(client, json)
+
+        val project = repo.projectSessions("p1")
+
+        assertEquals("Alpha", project?.label)
+        coVerify { client.call("projects.project_sessions", match { it["project_id"]!!.jsonPrimitive.content == "p1" }) }
+    }
+
+    @Test fun projectSessions_returns_null_when_project_absent() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement("""{"project":null}""")
+        val repo = ProjectsRepository(client, json)
+
+        assertNull(repo.projectSessions("nope"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
@@ -1,0 +1,39 @@
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import com.hermes.client.ui.chat.ApprovalChoice
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RespondApprovalTest {
+    private val client = mockk<HermesGatewayClient>(relaxed = true)
+    private val repo = ChatRepository(client) // match the real ctor; add other relaxed deps if needed
+
+    @Test fun once_sends_choice_once_and_approved_true() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.ONCE)
+        assertEquals("s1", params.captured["session_id"]!!.jsonPrimitive.content)
+        assertEquals("once", params.captured["choice"]!!.jsonPrimitive.content)
+        assertTrue(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test fun deny_sends_choice_deny_and_approved_false() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.DENY)
+        assertEquals("deny", params.captured["choice"]!!.jsonPrimitive.content)
+        assertFalse(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+}

--- a/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
@@ -5,7 +5,6 @@ import com.hermes.client.ui.chat.ApprovalChoice
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive

--- a/app/src/test/java/com/hermes/client/data/repository/SessionRepositoryTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/SessionRepositoryTest.kt
@@ -16,19 +16,26 @@ class SessionRepositoryTest {
     private fun dto(id: String, source: String?, msgs: Int, archived: Boolean = false) =
         SessionDto(sessionId = id, source = source, messageCount = msgs, archived = archived, profile = "personal")
 
-    // Parity with desktop: the list hides cron-created and empty (0-message) sessions, so a
-    // profile shows the same count the desktop dashboard shows.
-    @Test fun listAllProfiles_hides_cron_and_empty_sessions() = runTest {
+    // Parity with desktop SIDEBAR_EXCLUDED_SOURCES: the list hides cron, subagent, tool, and every
+    // messaging-platform source, plus empty (0-message) sessions. Local sources (tui/cli/…), the
+    // app's own hermes-dispatch sessions, and unknown/null sources are kept.
+    @Test fun listAllProfiles_hides_excluded_sources_and_empty_sessions() = runTest {
         coEvery { rest.profileSessions(any(), false) } returns ProfileSessionsDto(
             sessions = listOf(
                 dto("keep-tui", "tui", 5),
-                dto("hide-cron", "cron", 12),     // cron → hidden
-                dto("hide-empty", "tui", 0),       // 0 messages → hidden
+                dto("hide-cron", "cron", 12),           // cron → hidden
+                dto("hide-subagent", "subagent", 8),    // subagent → hidden
+                dto("hide-tool", "tool", 4),            // tool → hidden
+                dto("hide-telegram", "telegram", 6),    // messaging → hidden
+                dto("hide-empty", "tui", 0),            // 0 messages → hidden
                 dto("keep-dispatch", "hermes-dispatch", 2),
-                dto("hide-empty-cron", "cron", 0),
+                dto("keep-null-source", null, 3),       // unknown/null source → kept
             ),
         )
-        assertEquals(listOf("keep-tui", "keep-dispatch"), repo.listAllProfiles().map { it.id })
+        assertEquals(
+            listOf("keep-tui", "keep-dispatch", "keep-null-source"),
+            repo.listAllProfiles().map { it.id },
+        )
     }
 
     @Test fun archivedAllProfiles_also_hides_cron_and_empty() = runTest {

--- a/app/src/test/java/com/hermes/client/domain/ProjectMappersTest.kt
+++ b/app/src/test/java/com/hermes/client/domain/ProjectMappersTest.kt
@@ -1,0 +1,98 @@
+package com.hermes.client.domain
+
+import com.hermes.client.data.network.ProjectSessionsResultDto
+import com.hermes.client.data.network.ProjectTreeDto
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectMappersTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val treeJson = """
+    {
+      "projects": [
+        {
+          "id": "p_ab12", "label": "Roam and Trail", "path": "/u/andrew/roam-and-trail",
+          "color": "#4F8A10", "icon": "root-folder", "isAuto": false,
+          "sessionCount": 3, "lastActive": 1752000000.0,
+          "repos": [
+            { "id": "/u/andrew/roam-and-trail", "label": "roam-and-trail", "path": "/u/andrew/roam-and-trail",
+              "sessionCount": 3,
+              "groups": [
+                { "id": "main", "label": "main", "path": "/u/andrew/roam-and-trail",
+                  "isMain": true, "isKanban": false, "sessions": [] }
+              ] }
+          ],
+          "previewSessions": [
+            { "id": "s1", "title": "Affiliate setup", "model": "gpt", "last_active": 1752000000.0,
+              "message_count": 4, "cwd": "/u/andrew/roam-and-trail",
+              "git_branch": "main", "git_repo_root": "/u/andrew/roam-and-trail", "source": "hermes-dispatch" }
+          ]
+        },
+        {
+          "id": "/u/andrew/inbound", "label": "inbound", "path": "/u/andrew/inbound",
+          "isAuto": true, "sessionCount": 1, "lastActive": 1751990000.0,
+          "repos": [],
+          "previewSessions": [ { "id": "s2", "title": "Flight tracker", "message_count": 2 } ]
+        }
+      ],
+      "active_id": "p_ab12",
+      "scoped_session_ids": ["s1", "s2"]
+    }
+    """.trimIndent()
+
+    @Test fun maps_full_tree_including_repos_lanes_and_previews() {
+        val tree = json.decodeFromString(ProjectTreeDto.serializer(), treeJson).toDomain()
+
+        assertEquals("p_ab12", tree.activeId)
+        assertEquals(2, tree.projects.size)
+
+        val explicit = tree.projects[0]
+        assertEquals("Roam and Trail", explicit.label)
+        assertEquals("#4F8A10", explicit.color)
+        assertEquals(false, explicit.isAuto)
+        assertEquals(3, explicit.sessionCount)
+        assertEquals(1, explicit.repos.size)
+        assertEquals("roam-and-trail", explicit.repos[0].label)
+        assertEquals(1, explicit.repos[0].lanes.size)
+        assertTrue(explicit.repos[0].lanes[0].isMain)
+        // preview session mapped through Session.toDomain
+        assertEquals("Affiliate setup", explicit.previewSessions.single().title)
+        assertEquals("main", explicit.previewSessions.single().gitBranch)
+        assertEquals("/u/andrew/roam-and-trail", explicit.previewSessions.single().cwd)
+    }
+
+    @Test fun auto_project_has_null_color_and_no_repos() {
+        val tree = json.decodeFromString(ProjectTreeDto.serializer(), treeJson).toDomain()
+        val auto = tree.projects[1]
+        assertEquals("inbound", auto.label)
+        assertNull(auto.color)
+        assertTrue(auto.isAuto)
+        assertTrue(auto.repos.isEmpty())
+        assertEquals("Flight tracker", auto.previewSessions.single().title)
+    }
+
+    @Test fun project_sessions_result_hydrates_lane_sessions() {
+        val projJson = """
+        { "project": { "id": "p_ab12", "label": "Roam and Trail", "path": "/u/andrew/roam-and-trail",
+          "isAuto": false, "sessionCount": 1, "lastActive": 1752000000.0,
+          "repos": [ { "id": "r", "label": "roam-and-trail", "path": "/u/andrew/roam-and-trail",
+            "sessionCount": 1, "groups": [ { "id": "main", "label": "main", "path": "/u",
+              "isMain": true, "isKanban": false,
+              "sessions": [ { "id": "s1", "title": "Affiliate setup", "model": "gpt",
+                "last_active": 1752000000.0, "message_count": 4 } ] } ] } ],
+          "previewSessions": [] } }
+        """.trimIndent()
+
+        val project = json.decodeFromString(ProjectSessionsResultDto.serializer(), projJson).project!!.toDomain()
+        assertEquals("Affiliate setup", project.repos.single().lanes.single().sessions.single().title)
+    }
+
+    @Test fun missing_project_maps_to_null() {
+        val project = json.decodeFromString(ProjectSessionsResultDto.serializer(), """{"project":null}""").project
+        assertNull(project)
+    }
+}

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -16,12 +16,31 @@ class NotificationMapperTest {
         ServerEvent(type, sid, buildJsonObject { pairs.forEach { (k, v) -> put(k, v) } })
 
     @Test fun approval_makes_high_priority_spec_with_actions() {
-        val spec = toNotificationSpec(event(Notif.EVENT_APPROVAL, "s1", "prompt" to "Delete file?"), on, appInForeground = false)!!
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "Delete file?"); put("allow_permanent", true)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
         assertEquals(Notif.CHANNEL_APPROVALS, spec.channelId)
         assertEquals("chat/s1", spec.route)
         assertTrue(spec.body.contains("Delete file?"))
-        assertEquals(listOf(Notif.ACTION_APPROVE, Notif.ACTION_DENY), spec.actions.map { it.action })
+        assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
         assertTrue(spec.actions.all { it.sessionId == "s1" })
+    }
+
+    @Test fun standard_approval_offers_allow_once_and_deny() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "git push -f"); put("allow_permanent", true)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
+    }
+
+    @Test fun elevated_approval_offers_deny_only() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(listOf(Notif.ACTION_DENY), spec.actions.map { it.action })
     }
 
     @Test fun approval_notifies_regardless_of_foreground() {

--- a/app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt
@@ -1,0 +1,47 @@
+package com.hermes.client.ui.chat
+
+import com.hermes.client.data.network.ServerEvent
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApprovalParseTest {
+    private fun approvalEvent(payload: JsonObject) = ServerEvent("approval.request", "s1", payload)
+
+    @Test fun parses_command_description_patterns_and_allow_permanent() {
+        val e = approvalEvent(buildJsonObject {
+            put("session_id", "s1")
+            put("command", "rm -rf /tmp/x")
+            put("description", "recursive delete")
+            putJsonArray("pattern_keys") { add("recursive delete"); add("force") }
+            put("allow_permanent", true)
+        })
+        val state = ChatUiState().reduce(e)
+        val req = state.pendingApproval!!
+        assertEquals("rm -rf /tmp/x", req.command)
+        assertEquals("recursive delete", req.description)
+        assertEquals(listOf("recursive delete", "force"), req.patternKeys)
+        assertTrue(req.allowPermanent)
+    }
+
+    @Test fun missing_fields_degrade_safely() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject { put("session_id", "s1") })).pendingApproval!!
+        assertEquals("", req.command)
+        assertEquals("", req.description)
+        assertEquals(emptyList<String>(), req.patternKeys)
+        assertFalse(req.allowPermanent) // safe default: no "Always"
+    }
+
+    @Test fun single_pattern_key_is_used_when_array_absent() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject {
+            put("session_id", "s1"); put("pattern_key", "force push")
+        })).pendingApproval!!
+        assertEquals(listOf("force push"), req.patternKeys)
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt
@@ -1,0 +1,35 @@
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApprovalTierTest {
+    @Test fun choice_wire_values() {
+        assertEquals("once", ApprovalChoice.ONCE.wire)
+        assertEquals("session", ApprovalChoice.SESSION.wire)
+        assertEquals("always", ApprovalChoice.ALWAYS.wire)
+        assertEquals("deny", ApprovalChoice.DENY.wire)
+    }
+
+    @Test fun allow_permanent_true_is_standard() {
+        assertEquals(ApprovalTier.STANDARD, tierFor(allowPermanent = true))
+    }
+
+    @Test fun allow_permanent_false_is_elevated() {
+        assertEquals(ApprovalTier.ELEVATED, tierFor(allowPermanent = false))
+    }
+
+    @Test fun standard_offers_once_session_always() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS),
+            allowedScopes(ApprovalTier.STANDARD),
+        )
+    }
+
+    @Test fun elevated_offers_only_once_and_session() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION),
+            allowedScopes(ApprovalTier.ELEVATED),
+        )
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
@@ -19,10 +19,10 @@ class ChatReducerTest {
 
     @Test fun start_delta_complete_builds_one_assistant_message() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("message.delta") { put("text","Hel") })
-        s = reduce(s, ev("message.delta") { put("text","lo") })
-        s = reduce(s, ev("message.complete") { put("text","Hello") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("message.delta") { put("text","Hel") })
+        s = s.reduce(ev("message.delta") { put("text","lo") })
+        s = s.reduce(ev("message.complete") { put("text","Hello") })
         assertEquals(1, s.messages.size)
         assertEquals(Role.ASSISTANT, s.messages[0].role)
         assertEquals("Hello", s.messages[0].text)
@@ -32,9 +32,9 @@ class ChatReducerTest {
 
     @Test fun tool_events_attach_to_current_turn() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name","search") })
-        s = reduce(s, ev("tool.complete") { put("tool_id", "t1"); put("result", "found") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name","search") })
+        s = s.reduce(ev("tool.complete") { put("tool_id", "t1"); put("result", "found") })
         val tools = s.messages.last().tools
         assertEquals(1, tools.size)
         assertEquals("search", tools[0].name)
@@ -49,11 +49,11 @@ class ChatReducerTest {
     @Test fun reused_message_id_across_turns_yields_unique_ids() {
         var s = ChatUiState.empty()
         s = s.withUserMessage("hi")
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("message.complete") { put("text", "hello") })
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("message.complete") { put("text", "hello") })
         s = s.withUserMessage("again")
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("message.complete") { put("text", "hi again") })
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("message.complete") { put("text", "hi again") })
 
         val ids = s.messages.map { it.id }
         assertEquals("every message must have a unique list key", ids.size, ids.toSet().size)
@@ -67,9 +67,9 @@ class ChatReducerTest {
     // structured result should survive as text on the tool card.
     @Test fun tool_complete_with_object_result_does_not_crash() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.search") })
-        s = reduce(s, ev("tool.complete") {
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.search") })
+        s = s.reduce(ev("tool.complete") {
             put("tool_id", "t1")
             putJsonObject("result") { put("unread", 3); put("subject", "Citizenship update") }
         })
@@ -80,9 +80,9 @@ class ChatReducerTest {
 
     @Test fun tool_complete_with_array_result_does_not_crash() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.list") })
-        s = reduce(s, ev("tool.complete") {
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name", "gmail.list") })
+        s = s.reduce(ev("tool.complete") {
             put("tool_id", "t1")
             putJsonArray("result") { add("a@x.com"); add("b@y.com") }
         })
@@ -92,33 +92,33 @@ class ChatReducerTest {
     // The same non-primitive hazard applies to message text fields, not just tool results.
     @Test fun message_complete_with_object_text_does_not_crash() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "gemma") })
-        s = reduce(s, ev("message.complete") { putJsonObject("text") { put("v", "hi") } })
+        s = s.reduce(ev("message.start") { put("message_id", "gemma") })
+        s = s.reduce(ev("message.complete") { putJsonObject("text") { put("v", "hi") } })
         assertFalse(s.isGenerating)
     }
 
     @Test fun approval_request_sets_pending() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("approval.request") { put("prompt", "Run rm -rf?") })
-        assertEquals("Run rm -rf?", s.pendingApproval?.prompt)
+        s = s.reduce(ev("approval.request") { put("command", "rm -rf?") })
+        assertEquals("rm -rf?", s.pendingApproval?.command)
     }
 
     @Test fun thinking_delta_accumulates() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("reasoning.delta") { put("text","hmm ") })
-        s = reduce(s, ev("reasoning.delta") { put("text","ok") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("reasoning.delta") { put("text","hmm ") })
+        s = s.reduce(ev("reasoning.delta") { put("text","ok") })
         assertEquals("hmm ok", s.messages.last().thinking)
     }
 
     // T8b: tool.complete arriving AFTER message.complete must still update the tool card.
     @Test fun late_tool_complete_after_message_complete_is_not_dropped() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("tool.start") { put("tool_id", "t1"); put("name","search") })
-        s = reduce(s, ev("message.complete") { put("text","done") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("tool.start") { put("tool_id", "t1"); put("name","search") })
+        s = s.reduce(ev("message.complete") { put("text","done") })
         // At this point the assistant message is no longer streaming.
-        s = reduce(s, ev("tool.complete") { put("tool_id", "t1"); put("result", "done") })
+        s = s.reduce(ev("tool.complete") { put("tool_id", "t1"); put("result", "done") })
         val tools = s.messages.last().tools
         assertEquals(1, tools.size)
         assertEquals(ToolStatus.DONE, tools[0].status)
@@ -128,8 +128,8 @@ class ChatReducerTest {
     // I3: markInterrupted closes the streaming message and clears isGenerating.
     @Test fun markInterrupted_with_streaming_message() {
         var s = ChatUiState.empty()
-        s = reduce(s, ev("message.start") { put("message_id", "a1") })
-        s = reduce(s, ev("message.delta") { put("text","partial") })
+        s = s.reduce(ev("message.start") { put("message_id", "a1") })
+        s = s.reduce(ev("message.delta") { put("text","partial") })
         assertTrue(s.isGenerating)
         assertTrue(s.messages.last().isStreaming)
 

--- a/app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt
@@ -1,0 +1,24 @@
+package com.hermes.client.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SlideToConfirmStateTest {
+    @Test fun progress_is_clamped_0_to_1() {
+        assertEquals(0f, slideProgress(dragPx = -50f, trackPx = 100f), 0.001f)
+        assertEquals(0.5f, slideProgress(dragPx = 50f, trackPx = 100f), 0.001f)
+        assertEquals(1f, slideProgress(dragPx = 150f, trackPx = 100f), 0.001f)
+    }
+
+    @Test fun confirmed_only_past_threshold() {
+        assertFalse(isConfirmed(0.89f))
+        assertTrue(isConfirmed(0.90f))
+        assertTrue(isConfirmed(1f))
+    }
+
+    @Test fun zero_track_is_safe() {
+        assertEquals(0f, slideProgress(dragPx = 10f, trackPx = 0f), 0.001f)
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/sessions/ProjectDerivationTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/ProjectDerivationTest.kt
@@ -1,0 +1,98 @@
+package com.hermes.client.ui.sessions
+
+import com.hermes.client.domain.Session
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectDerivationTest {
+    private fun s(
+        id: String,
+        profile: String,
+        repo: String?,
+        lastActive: Long?,
+    ) = Session(
+        id = id, title = id, model = null, provider = null, messageCount = 1,
+        profile = profile, lastActive = lastActive, gitRepoRoot = repo,
+    )
+
+    @Test fun groups_sessions_by_repo_across_profiles() {
+        val out = deriveProjectsFromSessions(
+            listOf(
+                s("a", "personal", "/u/andrew/personal/travel-business", 100),
+                s("b", "personal", "/u/andrew/personal/travel-business", 200),
+                s("c", "dito", "/u/andrew/work/clients/dito/Southington", 150),
+            ),
+        )
+        // Two repo-projects (travel-business has 2 sessions, Southington 1), no loose group.
+        assertEquals(2, out.size)
+        val travel = out.single { it.id == "/u/andrew/personal/travel-business" }
+        assertEquals("travel-business", travel.label)
+        assertEquals(2, travel.sessionCount)
+        assertEquals(2, travel.repos.single().lanes.single().sessions.size)
+    }
+
+    @Test fun spans_profiles_within_one_repo() {
+        val out = deriveProjectsFromSessions(
+            listOf(
+                s("p", "personal", "/u/shared", 10),
+                s("o", "odos", "/u/shared", 20),
+            ),
+        )
+        val proj = out.single()
+        assertEquals(2, proj.sessionCount)
+        // Sessions retain their own profile so the UI can badge tenants / open against the right DB.
+        assertEquals(setOf("personal", "odos"), proj.repos.single().lanes.single().sessions.map { it.profile }.toSet())
+    }
+
+    @Test fun sessions_without_a_repo_collapse_into_no_project_last() {
+        val out = deriveProjectsFromSessions(
+            listOf(
+                s("x", "personal", "/u/andrew/personal/inbound", 300),
+                s("loose1", "personal", null, 50),
+                s("loose2", "odos", "", 60),
+            ),
+        )
+        assertEquals(2, out.size)
+        assertEquals("__no_project__", out.last().id) // loose group sorts last
+        assertEquals("No project", out.last().label)
+        assertEquals(2, out.last().sessionCount) // null AND blank repo both loose
+    }
+
+    @Test fun orders_projects_newest_first_and_previews_recent() {
+        val out = deriveProjectsFromSessions(
+            listOf(
+                s("old", "personal", "/u/a", 100),
+                s("new", "personal", "/u/b", 999),
+                s("b2", "personal", "/u/b", 500),
+            ),
+        )
+        assertEquals(listOf("/u/b", "/u/a"), out.map { it.id }) // /u/b more recent → first
+        assertEquals(listOf("new", "b2"), out.first().previewSessions.map { it.id }) // recent-first previews
+    }
+
+    @Test fun falls_back_to_cwd_when_no_git_repo_root() {
+        val out = deriveProjectsFromSessions(
+            listOf(
+                Session(
+                    id = "a", title = "a", model = null, provider = null, messageCount = 1,
+                    profile = "personal", gitRepoRoot = null, cwd = "/u/andrew/personal/travel-business",
+                ),
+                // Same repo, one with git root set, one only cwd → still one project (git root wins as key).
+                Session(
+                    id = "b", title = "b", model = null, provider = null, messageCount = 1,
+                    profile = "personal", gitRepoRoot = "/u/andrew/personal/flights", cwd = "/u/andrew/personal/flights/sub",
+                ),
+            ),
+        )
+        assertEquals(
+            setOf("/u/andrew/personal/travel-business", "/u/andrew/personal/flights"),
+            out.map { it.id }.toSet(),
+        )
+        assertEquals("travel-business", out.single { it.id == "/u/andrew/personal/travel-business" }.label)
+    }
+
+    @Test fun empty_input_yields_no_projects() {
+        assertTrue(deriveProjectsFromSessions(emptyList()).isEmpty())
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt
@@ -55,4 +55,14 @@ class SessionGroupingTest {
         assertFalse("a sibling workspace stays expanded", docs.collapsed)
         assertEquals(listOf("c"), docs.sessions.map { it.id })
     }
+
+    private fun s(id: String, lastActive: Long?) = com.hermes.client.domain.Session(
+        id = id, title = id, model = null, provider = null, messageCount = 1,
+        profile = "personal", lastActive = lastActive,
+    )
+
+    @org.junit.Test fun sessionsByRecency_orders_newest_first_nulls_last() {
+        val out = sessionsByRecency(listOf(s("a", 100), s("b", null), s("c", 300))).map { it.id }
+        org.junit.Assert.assertEquals(listOf("c", "a", "b"), out)
+    }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -30,6 +31,8 @@ class SessionsViewModelTest {
     private val profileManager = mockk<ProfileManager>(relaxed = true)
     private val pinStore = mockk<PinStore>(relaxed = true)
     private val groupExpansion = mockk<com.hermes.client.data.repository.GroupExpansionStore>(relaxed = true)
+    private val projects = mockk<com.hermes.client.data.repository.ProjectsRepository>(relaxed = true)
+    private val viewModeStore = mockk<com.hermes.client.data.repository.ViewModeStore>(relaxed = true)
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -37,6 +40,7 @@ class SessionsViewModelTest {
         every { profileManager.active } returns MutableStateFlow<String?>("personal")
         every { pinStore.pinned } returns MutableStateFlow<Set<String>>(emptySet())
         every { groupExpansion.collapsed } returns MutableStateFlow<Set<String>>(emptySet())
+        every { viewModeStore.mode } returns MutableStateFlow(ViewMode.SESSIONS)
     }
 
     private fun session(id: String, title: String, profile: String = "personal") = Session(
@@ -44,7 +48,7 @@ class SessionsViewModelTest {
         messageCount = 1, profile = profile, workspace = "No workspace", source = "hermes-dispatch",
     )
 
-    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore, groupExpansion)
+    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore, groupExpansion, projects, viewModeStore)
 
     // Regression: a session created or updated while the user was in a chat must appear once
     // the list is re-fetched. The Sessions screen calls refresh() on ON_RESUME (the "sessions"
@@ -194,5 +198,60 @@ class SessionsViewModelTest {
         vm.toggleGroup("p:odos")
         advanceUntilIdle()
         io.mockk.coVerify { groupExpansion.toggle("p:odos") }
+    }
+
+    @Test fun setViewMode_persists_and_loads_tree_on_first_projects_entry() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        coEvery { projects.tree() } returns com.hermes.client.domain.ProjectTree(
+            projects = listOf(
+                com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList()),
+            ),
+            activeId = "p1",
+        )
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.setViewMode(ViewMode.PROJECTS)
+        advanceUntilIdle()
+
+        io.mockk.coVerify { viewModeStore.set(ViewMode.PROJECTS) }
+        io.mockk.coVerify { projects.tree() }
+        assertEquals(listOf("p1"), vm.projectsState.value.tree.map { it.id })
+    }
+
+    @Test fun loadProjectTree_sets_error_on_failure() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        coEvery { projects.tree() } throws RuntimeException("rpc down")
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.loadProjectTree()
+        advanceUntilIdle()
+
+        assertFalse(vm.projectsState.value.loading)
+        assertTrue(vm.projectsState.value.error != null)
+    }
+
+    @Test fun enterProject_hydrates_scope_then_exit_clears_it() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val overview = com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList())
+        val hydrated = overview.copy(
+            repos = listOf(
+                com.hermes.client.domain.ProjectRepo("r", "alpha", null, 1, listOf(
+                    com.hermes.client.domain.ProjectLane("main", "main", null, true, listOf(session("s1", "Hi"))),
+                )),
+            ),
+        )
+        coEvery { projects.projectSessions("p1") } returns hydrated
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.enterProject(overview)
+        advanceUntilIdle()
+        assertEquals("p1", vm.projectsState.value.scope?.id)
+        assertEquals("s1", vm.projectsState.value.scope?.repos?.single()?.lanes?.single()?.sessions?.single()?.id)
+
+        vm.exitProject()
+        assertNull(vm.projectsState.value.scope)
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -31,7 +31,6 @@ class SessionsViewModelTest {
     private val profileManager = mockk<ProfileManager>(relaxed = true)
     private val pinStore = mockk<PinStore>(relaxed = true)
     private val groupExpansion = mockk<com.hermes.client.data.repository.GroupExpansionStore>(relaxed = true)
-    private val projects = mockk<com.hermes.client.data.repository.ProjectsRepository>(relaxed = true)
     private val viewModeStore = mockk<com.hermes.client.data.repository.ViewModeStore>(relaxed = true)
     // Controllable so tests can flip the persisted view mode (drives the VM's launch/toggle load).
     private val modeFlow = MutableStateFlow(ViewMode.SESSIONS)
@@ -50,7 +49,12 @@ class SessionsViewModelTest {
         messageCount = 1, profile = profile, workspace = "No workspace", source = "hermes-dispatch",
     )
 
-    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore, groupExpansion, projects, viewModeStore)
+    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore, groupExpansion, viewModeStore)
+
+    private fun repoSession(id: String, repo: String?, profile: String = "personal") = Session(
+        id = id, title = id, model = null, provider = null, messageCount = 1,
+        profile = profile, source = "tui", gitRepoRoot = repo,
+    )
 
     // Regression: a session created or updated while the user was in a chat must appear once
     // the list is re-fetched. The Sessions screen calls refresh() on ON_RESUME (the "sessions"
@@ -213,46 +217,40 @@ class SessionsViewModelTest {
         io.mockk.coVerify { viewModeStore.set(ViewMode.PROJECTS) }
     }
 
-    @Test fun tree_loads_when_view_mode_becomes_projects() = runTest {
-        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
-        coEvery { projects.tree() } returns com.hermes.client.domain.ProjectTree(
-            projects = listOf(
-                com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList()),
-            ),
-            activeId = "p1",
+    @Test fun projects_derive_from_cross_profile_sessions_when_view_mode_becomes_projects() = runTest {
+        // Two profiles, two repos → two projects derived client-side (no gateway call).
+        coEvery { sessionRepo.listAllProfiles() } returns listOf(
+            repoSession("a", "/u/andrew/personal/travel-business", profile = "personal"),
+            repoSession("b", "/u/andrew/work/clients/dito/Southington", profile = "dito"),
         )
         val vm = buildVm()
         advanceUntilIdle()
 
-        // The persisted mode flips to Projects (what ViewModeStore emits after set()).
-        modeFlow.value = ViewMode.PROJECTS
+        modeFlow.value = ViewMode.PROJECTS // persisted mode flips to Projects
         advanceUntilIdle()
 
-        io.mockk.coVerify { projects.tree() }
-        assertEquals(listOf("p1"), vm.projectsState.value.tree.map { it.id })
+        assertEquals(
+            setOf("/u/andrew/personal/travel-business", "/u/andrew/work/clients/dito/Southington"),
+            vm.projectsState.value.tree.map { it.id }.toSet(),
+        )
     }
 
-    // Regression: a cold launch restored into Projects mode must fetch the tree, not show a
+    // Regression: a cold launch restored into Projects mode must build the tree, not show a
     // spurious "No projects". Previously only a toggle tap loaded it.
-    @Test fun tree_loads_on_cold_launch_when_persisted_mode_is_projects() = runTest {
-        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
-        coEvery { projects.tree() } returns com.hermes.client.domain.ProjectTree(
-            projects = listOf(
-                com.hermes.client.domain.Project("p9", "Beta", null, null, true, 1, null, emptyList(), emptyList()),
-            ),
-            activeId = null,
+    @Test fun projects_build_on_cold_launch_when_persisted_mode_is_projects() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns listOf(
+            repoSession("x", "/u/andrew/personal/inbound", profile = "personal"),
         )
         modeFlow.value = ViewMode.PROJECTS // persisted as Projects before the VM is even built
         val vm = buildVm()
         advanceUntilIdle()
 
-        io.mockk.coVerify { projects.tree() }
-        assertEquals(listOf("p9"), vm.projectsState.value.tree.map { it.id })
+        assertEquals(listOf("/u/andrew/personal/inbound"), vm.projectsState.value.tree.map { it.id })
     }
 
     @Test fun loadProjectTree_sets_error_on_failure() = runTest {
-        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
-        coEvery { projects.tree() } throws RuntimeException("rpc down")
+        // First call (Sessions init refresh) succeeds; the Projects build then fails.
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList() andThenThrows RuntimeException("net down")
         val vm = buildVm()
         advanceUntilIdle()
 
@@ -263,23 +261,24 @@ class SessionsViewModelTest {
         assertTrue(vm.projectsState.value.error != null)
     }
 
-    @Test fun enterProject_hydrates_scope_then_exit_clears_it() = runTest {
+    @Test fun enterProject_sets_scope_then_exit_clears_it() = runTest {
         coEvery { sessionRepo.listAllProfiles() } returns emptyList()
-        val overview = com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList())
-        val hydrated = overview.copy(
+        // A derived project already carries its sessions — enterProject just scopes to it (no fetch).
+        val project = com.hermes.client.domain.Project(
+            "/u/andrew/p", "p", "/u/andrew/p", null, true, 1, null,
             repos = listOf(
-                com.hermes.client.domain.ProjectRepo("r", "alpha", null, 1, listOf(
-                    com.hermes.client.domain.ProjectLane("main", "main", null, true, listOf(session("s1", "Hi"))),
+                com.hermes.client.domain.ProjectRepo("/u/andrew/p", "p", "/u/andrew/p", 1, listOf(
+                    com.hermes.client.domain.ProjectLane("all", "", null, true, listOf(session("s1", "Hi"))),
                 )),
             ),
+            previewSessions = emptyList(),
         )
-        coEvery { projects.projectSessions("p1") } returns hydrated
         val vm = buildVm()
         advanceUntilIdle()
 
-        vm.enterProject(overview)
+        vm.enterProject(project)
         advanceUntilIdle()
-        assertEquals("p1", vm.projectsState.value.scope?.id)
+        assertEquals("/u/andrew/p", vm.projectsState.value.scope?.id)
         assertEquals("s1", vm.projectsState.value.scope?.repos?.single()?.lanes?.single()?.sessions?.single()?.id)
 
         vm.exitProject()
@@ -291,29 +290,4 @@ class SessionsViewModelTest {
     // after enter would let the delayed fetch complete and set scope back to the hydrated
     // project (looking like the user can't leave the detail view). This test verifies the race
     // is fixed: exitProject cancels the pending fetch, scope stays null.
-    @Test fun exitProject_cancels_in_flight_enterProject_so_stale_result_does_not_resurrect_scope() = runTest {
-        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
-        val overview = com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList())
-        val hydrated = overview.copy(
-            repos = listOf(
-                com.hermes.client.domain.ProjectRepo("r", "alpha", null, 1, listOf(
-                    com.hermes.client.domain.ProjectLane("main", "main", null, true, listOf(session("s1", "Hi"))),
-                )),
-            ),
-        )
-        // Mock projectSessions with a delay so it's still in flight when exitProject runs
-        coEvery { projects.projectSessions("p1") } coAnswers {
-            kotlinx.coroutines.delay(1000)
-            hydrated
-        }
-        val vm = buildVm()
-        advanceUntilIdle()
-
-        vm.enterProject(overview)
-        vm.exitProject()
-        advanceUntilIdle()
-
-        assertNull(vm.projectsState.value.scope)
-        assertFalse(vm.projectsState.value.scopeLoading)
-    }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -254,4 +254,35 @@ class SessionsViewModelTest {
         vm.exitProject()
         assertNull(vm.projectsState.value.scope)
     }
+
+    // Regression: exitProject must cancel an in-flight enterProject so a stale projectSessions
+    // result does NOT resurrect the scope. The old code had no job tracking, so rapid exit
+    // after enter would let the delayed fetch complete and set scope back to the hydrated
+    // project (looking like the user can't leave the detail view). This test verifies the race
+    // is fixed: exitProject cancels the pending fetch, scope stays null.
+    @Test fun exitProject_cancels_in_flight_enterProject_so_stale_result_does_not_resurrect_scope() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val overview = com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList())
+        val hydrated = overview.copy(
+            repos = listOf(
+                com.hermes.client.domain.ProjectRepo("r", "alpha", null, 1, listOf(
+                    com.hermes.client.domain.ProjectLane("main", "main", null, true, listOf(session("s1", "Hi"))),
+                )),
+            ),
+        )
+        // Mock projectSessions with a delay so it's still in flight when exitProject runs
+        coEvery { projects.projectSessions("p1") } coAnswers {
+            kotlinx.coroutines.delay(1000)
+            hydrated
+        }
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.enterProject(overview)
+        vm.exitProject()
+        advanceUntilIdle()
+
+        assertNull(vm.projectsState.value.scope)
+        assertFalse(vm.projectsState.value.scopeLoading)
+    }
 }

--- a/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
@@ -33,6 +33,8 @@ class SessionsViewModelTest {
     private val groupExpansion = mockk<com.hermes.client.data.repository.GroupExpansionStore>(relaxed = true)
     private val projects = mockk<com.hermes.client.data.repository.ProjectsRepository>(relaxed = true)
     private val viewModeStore = mockk<com.hermes.client.data.repository.ViewModeStore>(relaxed = true)
+    // Controllable so tests can flip the persisted view mode (drives the VM's launch/toggle load).
+    private val modeFlow = MutableStateFlow(ViewMode.SESSIONS)
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -40,7 +42,7 @@ class SessionsViewModelTest {
         every { profileManager.active } returns MutableStateFlow<String?>("personal")
         every { pinStore.pinned } returns MutableStateFlow<Set<String>>(emptySet())
         every { groupExpansion.collapsed } returns MutableStateFlow<Set<String>>(emptySet())
-        every { viewModeStore.mode } returns MutableStateFlow(ViewMode.SESSIONS)
+        every { viewModeStore.mode } returns modeFlow
     }
 
     private fun session(id: String, title: String, profile: String = "personal") = Session(
@@ -200,7 +202,18 @@ class SessionsViewModelTest {
         io.mockk.coVerify { groupExpansion.toggle("p:odos") }
     }
 
-    @Test fun setViewMode_persists_and_loads_tree_on_first_projects_entry() = runTest {
+    @Test fun setViewMode_persists_the_mode() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.setViewMode(ViewMode.PROJECTS)
+        advanceUntilIdle()
+
+        io.mockk.coVerify { viewModeStore.set(ViewMode.PROJECTS) }
+    }
+
+    @Test fun tree_loads_when_view_mode_becomes_projects() = runTest {
         coEvery { sessionRepo.listAllProfiles() } returns emptyList()
         coEvery { projects.tree() } returns com.hermes.client.domain.ProjectTree(
             projects = listOf(
@@ -211,12 +224,30 @@ class SessionsViewModelTest {
         val vm = buildVm()
         advanceUntilIdle()
 
-        vm.setViewMode(ViewMode.PROJECTS)
+        // The persisted mode flips to Projects (what ViewModeStore emits after set()).
+        modeFlow.value = ViewMode.PROJECTS
         advanceUntilIdle()
 
-        io.mockk.coVerify { viewModeStore.set(ViewMode.PROJECTS) }
         io.mockk.coVerify { projects.tree() }
         assertEquals(listOf("p1"), vm.projectsState.value.tree.map { it.id })
+    }
+
+    // Regression: a cold launch restored into Projects mode must fetch the tree, not show a
+    // spurious "No projects". Previously only a toggle tap loaded it.
+    @Test fun tree_loads_on_cold_launch_when_persisted_mode_is_projects() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        coEvery { projects.tree() } returns com.hermes.client.domain.ProjectTree(
+            projects = listOf(
+                com.hermes.client.domain.Project("p9", "Beta", null, null, true, 1, null, emptyList(), emptyList()),
+            ),
+            activeId = null,
+        )
+        modeFlow.value = ViewMode.PROJECTS // persisted as Projects before the VM is even built
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        io.mockk.coVerify { projects.tree() }
+        assertEquals(listOf("p9"), vm.projectsState.value.tree.map { it.id })
     }
 
     @Test fun loadProjectTree_sets_error_on_failure() = runTest {

--- a/docs/superpowers/plans/2026-07-10-tiered-approvals.md
+++ b/docs/superpowers/plans/2026-07-10-tiered-approvals.md
@@ -1,0 +1,721 @@
+# Touch-native Tiered Approvals — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the broken approval wire format and give agent approvals a touch-native, two-tier bottom-sheet UX on the phone.
+
+**Architecture:** Parse the real `approval.request` fields (`command`, `description`, `pattern_keys`, `allow_permanent`) into an expanded `ApprovalRequest`; respond with the gateway's scoped `approval.respond {choice}` (plus a derived `approved` for version-skew safety). A pure tier layer maps `allow_permanent` → Standard/Elevated and the allowed scopes; a `ModalBottomSheet` renders the tiers, with a reusable `SlideToConfirm` gating the Elevated *Allow*. Notifications become tier-aware. No new gateway endpoints.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, kotlinx.serialization, JUnit + MockK.
+
+## Global Constraints
+
+- NO new gateway endpoints — reuse `approval.respond {choice: once|session|always|deny, all}` and the existing request fields.
+- Material3; per-tenant accent via `LocalProfileAccent.current` (`ProfileAccentColors(accent, onAccent)`).
+- NO AI/assistant attribution in commits, files, or PRs.
+- Run `gitleaks git --no-banner --redact` before every push; work lands on `feature/tiered-approvals` → PR into `dev`.
+- Build env: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. Compile `:app:compileDebugKotlin`; unit tests `:app:testDebugUnitTest`; beta `:app:assembleBeta`.
+- Spec: `docs/superpowers/specs/2026-07-10-tiered-approvals-design.md`.
+
+## File map
+
+- Create `app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt` — `ApprovalChoice`, `ApprovalTier`, `tierFor`, `allowedScopes` (pure).
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt` — expand `ApprovalRequest`; parse the new fields in the `approval.request` reduce.
+- Modify `app/src/main/java/com/hermes/client/data/network/ServerEvent.kt` — add `bool` + `strList` payload helpers.
+- Modify `app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt` — `respondApproval(sessionId, choice)`.
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt` — `respondApproval(choice)` replaces `approve(Boolean)`.
+- Create `app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt` — reusable slide-to-confirm + pure state holder.
+- Create `app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt` — the bottom sheet.
+- Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt` — replace `ApprovalDialog` with `ApprovalSheet`.
+- Remove `ApprovalDialog` from `app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt`.
+- Modify `notifications/NotificationMapper.kt`, `NotificationModels.kt`, `NotificationActionReceiver.kt` — tier-aware actions + choice-based response.
+
+---
+
+### Task 1: Tier + choice model (pure)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt`
+
+**Interfaces:**
+- Consumes: `ApprovalRequest` (Task 2 expands it, but Task 1 only needs `allowPermanent: Boolean` — define `tierFor` against that field; both tasks land before compile of consumers).
+- Produces: `enum ApprovalChoice(val wire: String)`, `enum ApprovalTier`, `fun tierFor(allowPermanent: Boolean): ApprovalTier`, `fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApprovalTierTest {
+    @Test fun choice_wire_values() {
+        assertEquals("once", ApprovalChoice.ONCE.wire)
+        assertEquals("session", ApprovalChoice.SESSION.wire)
+        assertEquals("always", ApprovalChoice.ALWAYS.wire)
+        assertEquals("deny", ApprovalChoice.DENY.wire)
+    }
+
+    @Test fun allow_permanent_true_is_standard() {
+        assertEquals(ApprovalTier.STANDARD, tierFor(allowPermanent = true))
+    }
+
+    @Test fun allow_permanent_false_is_elevated() {
+        assertEquals(ApprovalTier.ELEVATED, tierFor(allowPermanent = false))
+    }
+
+    @Test fun standard_offers_once_session_always() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS),
+            allowedScopes(ApprovalTier.STANDARD),
+        )
+    }
+
+    @Test fun elevated_offers_only_once_and_session() {
+        assertEquals(
+            listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION),
+            allowedScopes(ApprovalTier.ELEVATED),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalTierTest"`
+Expected: FAIL — unresolved reference `ApprovalChoice` / `tierFor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+/** The scoped decision the gateway understands: approval.respond {choice}. */
+enum class ApprovalChoice(val wire: String) {
+    ONCE("once"), SESSION("session"), ALWAYS("always"), DENY("deny")
+}
+
+/** Risk tier, derived from the gateway's `allow_permanent` bit (false = Tirith-flagged). */
+enum class ApprovalTier { STANDARD, ELEVATED }
+
+fun tierFor(allowPermanent: Boolean): ApprovalTier =
+    if (allowPermanent) ApprovalTier.STANDARD else ApprovalTier.ELEVATED
+
+/** Allow-scopes offered per tier (DENY is always available separately). */
+fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice> = when (tier) {
+    ApprovalTier.STANDARD -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION, ApprovalChoice.ALWAYS)
+    ApprovalTier.ELEVATED -> listOf(ApprovalChoice.ONCE, ApprovalChoice.SESSION)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalTierTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ApprovalTier.kt app/src/test/java/com/hermes/client/ui/chat/ApprovalTierTest.kt
+git commit -m "feat(approvals): tier + choice model (allow_permanent -> Standard/Elevated + scopes)"
+```
+
+---
+
+### Task 2: Parse the real approval.request fields
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/network/ServerEvent.kt` (add `bool`, `strList`)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt` (expand `ApprovalRequest`, line ~10; update the `"approval.request"` reduce, line ~86)
+- Test: `app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt`
+
+**Interfaces:**
+- Consumes: `ServerEvent` (`str`, and new `bool`/`strList`), `ChatUiState.reduce`.
+- Produces: `data class ApprovalRequest(command, description, patternKeys: List<String>, allowPermanent: Boolean)`; `ServerEvent.bool(key): Boolean?`; `ServerEvent.strList(key): List<String>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import com.hermes.client.data.network.ServerEvent
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApprovalParseTest {
+    private fun approvalEvent(payload: JsonObject) = ServerEvent("approval.request", "s1", payload)
+
+    @Test fun parses_command_description_patterns_and_allow_permanent() {
+        val e = approvalEvent(buildJsonObject {
+            put("session_id", "s1")
+            put("command", "rm -rf /tmp/x")
+            put("description", "recursive delete")
+            putJsonArray("pattern_keys") { add("recursive delete"); add("force") }
+            put("allow_permanent", true)
+        })
+        val state = ChatUiState().reduce(e)
+        val req = state.pendingApproval!!
+        assertEquals("rm -rf /tmp/x", req.command)
+        assertEquals("recursive delete", req.description)
+        assertEquals(listOf("recursive delete", "force"), req.patternKeys)
+        assertTrue(req.allowPermanent)
+    }
+
+    @Test fun missing_fields_degrade_safely() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject { put("session_id", "s1") })).pendingApproval!!
+        assertEquals("", req.command)
+        assertEquals("", req.description)
+        assertEquals(emptyList<String>(), req.patternKeys)
+        assertFalse(req.allowPermanent) // safe default: no "Always"
+    }
+
+    @Test fun single_pattern_key_is_used_when_array_absent() {
+        val req = ChatUiState().reduce(approvalEvent(buildJsonObject {
+            put("session_id", "s1"); put("pattern_key", "force push")
+        })).pendingApproval!!
+        assertEquals(listOf("force push"), req.patternKeys)
+    }
+}
+```
+
+Note: `buildJsonObject { putJsonArray("pattern_keys") { add("x") } }` requires `import kotlinx.serialization.json.add`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalParseTest"`
+Expected: FAIL — `ApprovalRequest` has no `command` etc.; `reduce` still reads `prompt`.
+
+- [ ] **Step 3a: Add payload helpers to `ServerEvent.kt`**
+
+Append after the existing `objOrEmpty` helper:
+
+```kotlin
+internal fun ServerEvent.bool(key: String): Boolean? =
+    (payload[key] as? JsonPrimitive)?.booleanOrNull
+
+internal fun ServerEvent.strList(key: String): List<String> =
+    (payload[key] as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()
+```
+
+Add imports at the top of `ServerEvent.kt`:
+```kotlin
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.booleanOrNull
+```
+
+- [ ] **Step 3b: Expand `ApprovalRequest` and update the reduce in `ChatUiState.kt`**
+
+Replace the old model (`data class ApprovalRequest(val prompt: String)`) with:
+```kotlin
+data class ApprovalRequest(
+    val command: String,
+    val description: String,
+    val patternKeys: List<String>,
+    val allowPermanent: Boolean,
+)
+```
+
+Replace the `"approval.request"` branch of `reduce` (was `ApprovalRequest(event.str("prompt") ?: "")`) with:
+```kotlin
+"approval.request" -> state.copy(
+    pendingApproval = ApprovalRequest(
+        command = event.str("command") ?: "",
+        description = event.str("description") ?: "",
+        patternKeys = event.strList("pattern_keys")
+            .ifEmpty { event.str("pattern_key")?.let { listOf(it) } ?: emptyList() },
+        allowPermanent = event.bool("allow_permanent") ?: false,
+    ),
+)
+```
+Add the imports used: `import com.hermes.client.data.network.bool` and `import com.hermes.client.data.network.strList` (alongside the existing `str` import).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ApprovalParseTest"`
+Expected: PASS (3 tests). (`ChatScreen.kt`/`ChatViewModel.kt` won't compile yet — they still reference the old model/`approve`; Tasks 3 & 5 fix them. Run the targeted test class, not the whole build, until then.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/network/ServerEvent.kt app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt app/src/test/java/com/hermes/client/ui/chat/ApprovalParseTest.kt
+git commit -m "feat(approvals): parse real approval.request fields (command/description/pattern_keys/allow_permanent)"
+```
+
+---
+
+### Task 3: Scoped response (choice, not boolean)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt` (`respondApproval`, ~line 126)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt` (`approve`, ~line 244)
+- Test: `app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt`
+
+**Interfaces:**
+- Consumes: `ApprovalChoice` (Task 1), `HermesGatewayClient.call(method, params): JsonElement`.
+- Produces: `suspend fun ChatRepository.respondApproval(sessionId: String, choice: ApprovalChoice)`; `fun ChatViewModel.respondApproval(choice: ApprovalChoice)`.
+
+- [ ] **Step 1: Write the failing test** (mirror the existing ChatRepository test style — MockK the client, capture the params)
+
+```kotlin
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import com.hermes.client.ui.chat.ApprovalChoice
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RespondApprovalTest {
+    private val client = mockk<HermesGatewayClient>(relaxed = true)
+    private val repo = ChatRepository(client) // match the real ctor; add other relaxed deps if needed
+
+    @Test fun once_sends_choice_once_and_approved_true() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.ONCE)
+        assertEquals("s1", params.captured["session_id"]!!.jsonPrimitive.content)
+        assertEquals("once", params.captured["choice"]!!.jsonPrimitive.content)
+        assertTrue(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test fun deny_sends_choice_deny_and_approved_false() = runTest {
+        val params = slot<JsonObject>()
+        coEvery { client.call("approval.respond", capture(params)) } returns JsonPrimitive("ok")
+        repo.respondApproval("s1", ApprovalChoice.DENY)
+        assertEquals("deny", params.captured["choice"]!!.jsonPrimitive.content)
+        assertFalse(params.captured["approved"]!!.jsonPrimitive.boolean)
+    }
+}
+```
+(If `ChatRepository`'s constructor takes more than `client`, construct it the way the existing repository tests do — check `app/src/test/.../ChatRepositoryTest*.kt` for the real signature and reuse it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.RespondApprovalTest"`
+Expected: FAIL — `respondApproval(String, ApprovalChoice)` doesn't exist.
+
+- [ ] **Step 3a: Change `ChatRepository.respondApproval`**
+
+```kotlin
+suspend fun respondApproval(sessionId: String, choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    client.call("approval.respond", buildJsonObject {
+        put("session_id", sessionId)
+        put("choice", choice.wire)
+        put("approved", choice != com.hermes.client.ui.chat.ApprovalChoice.DENY)
+    })
+}
+```
+
+- [ ] **Step 3b: Change `ChatViewModel.approve` → `respondApproval`**
+
+```kotlin
+fun respondApproval(choice: com.hermes.client.ui.chat.ApprovalChoice) {
+    _state.value = _state.value.copy(pendingApproval = null)
+    viewModelScope.launch { runCatching { chat.respondApproval(sessionId, choice) } }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.RespondApprovalTest"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt app/src/test/java/com/hermes/client/data/repository/RespondApprovalTest.kt
+git commit -m "feat(approvals): scoped approval.respond {choice} (+ derived approved) replacing the boolean"
+```
+
+---
+
+### Task 4: Reusable SlideToConfirm
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt`
+
+**Interfaces:**
+- Produces: pure `slideProgress(dragPx: Float, trackPx: Float): Float` (0f..1f) and `isConfirmed(progress: Float): Boolean` (>= 0.9f); `@Composable fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier: Modifier = Modifier)`.
+
+- [ ] **Step 1: Write the failing test** (pure state logic only — no Compose UI test)
+
+```kotlin
+package com.hermes.client.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SlideToConfirmStateTest {
+    @Test fun progress_is_clamped_0_to_1() {
+        assertEquals(0f, slideProgress(dragPx = -50f, trackPx = 100f), 0.001f)
+        assertEquals(0.5f, slideProgress(dragPx = 50f, trackPx = 100f), 0.001f)
+        assertEquals(1f, slideProgress(dragPx = 150f, trackPx = 100f), 0.001f)
+    }
+
+    @Test fun confirmed_only_past_threshold() {
+        assertFalse(isConfirmed(0.89f))
+        assertTrue(isConfirmed(0.90f))
+        assertTrue(isConfirmed(1f))
+    }
+
+    @Test fun zero_track_is_safe() {
+        assertEquals(0f, slideProgress(dragPx = 10f, trackPx = 0f), 0.001f)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.components.SlideToConfirmStateTest"`
+Expected: FAIL — unresolved `slideProgress`/`isConfirmed`.
+
+- [ ] **Step 3: Implement `SlideToConfirm.kt`**
+
+```kotlin
+package com.hermes.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+
+// Pure, unit-tested. Progress along the track (0f..1f).
+fun slideProgress(dragPx: Float, trackPx: Float): Float =
+    if (trackPx <= 0f) 0f else dragPx.coerceIn(0f, trackPx) / trackPx
+
+fun isConfirmed(progress: Float): Boolean = progress >= 0.9f
+
+/** Drag the thumb across the track to confirm a deliberate (dangerous) action. */
+@Composable
+fun SlideToConfirm(label: String, accent: Color, onConfirm: () -> Unit, modifier: Modifier = Modifier) {
+    var trackPx by remember { mutableFloatStateOf(0f) }
+    var dragPx by remember { mutableFloatStateOf(0f) }
+    val progress = slideProgress(dragPx, trackPx)
+    Box(
+        modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .onSizeChanged { trackPx = max(0f, it.width.toFloat() - 56f * 3) } // minus thumb width (~56dp) in px approx
+            .background(accent.copy(alpha = 0.15f), CircleShape),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(label, modifier = Modifier.fillMaxWidth(), color = accent)
+        Box(
+            Modifier
+                .size(56.dp)
+                .background(accent, CircleShape)
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = { if (isConfirmed(slideProgress(dragPx, trackPx))) onConfirm() else dragPx = 0f },
+                        onHorizontalDrag = { _, delta -> dragPx = (dragPx + delta).coerceIn(0f, trackPx) },
+                    )
+                },
+            contentAlignment = Alignment.Center,
+        ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = Color.White) }
+    }
+}
+```
+(Note: exact thumb-offset math for the visual position can be refined during Task 5 on-device polish — the *behavior* under test is `slideProgress` + `isConfirmed`, which drive confirmation. If the offset expression is awkward, translate the thumb by `dragPx` via `Modifier.offset { IntOffset(dragPx.roundToInt(), 0) }` and set `trackPx` from the box width minus the thumb width.)
+
+- [ ] **Step 4: Run test to verify it passes; then compile**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.components.SlideToConfirmStateTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/components/SlideToConfirm.kt app/src/test/java/com/hermes/client/ui/components/SlideToConfirmStateTest.kt
+git commit -m "feat(ui): reusable SlideToConfirm (pure progress/confirm logic + composable)"
+```
+
+---
+
+### Task 5: Approval bottom sheet + wire into ChatScreen
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt` (~line 490, `pendingApproval` block)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt` (remove `ApprovalDialog`)
+
+**Interfaces:**
+- Consumes: `ApprovalRequest` (Task 2), `ApprovalTier`/`ApprovalChoice`/`tierFor`/`allowedScopes` (Task 1), `SlideToConfirm` (Task 4), `LocalProfileAccent.current` (`ProfileAccentColors(accent, onAccent)`).
+- Produces: `@Composable fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onDismiss: () -> Unit)`.
+
+- [ ] **Step 1: Implement `ApprovalSheet.kt`** (Compose UI — verified on-device in Task 7, not unit-tested)
+
+```kotlin
+package com.hermes.client.ui.chat
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.components.SlideToConfirm
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onDismiss: () -> Unit) {
+    val accent = LocalProfileAccent.current
+    val tier = tierFor(req.allowPermanent)
+    val error = MaterialTheme.colorScheme.error
+    val badge = if (tier == ApprovalTier.ELEVATED) error else accent.accent
+    val label = req.patternKeys.firstOrNull()?.let { " · $it" } ?: ""
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text(
+                (if (tier == ApprovalTier.ELEVATED) "Elevated" else "Approval needed") + label,
+                style = MaterialTheme.typography.titleMedium,
+                color = badge,
+            )
+            if (req.command.isNotBlank()) {
+                Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 12.dp)) {
+                    Text(req.command, fontFamily = FontFamily.Monospace, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+            if (req.description.isNotBlank()) {
+                Text(req.description, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(bottom = 16.dp))
+            }
+
+            if (tier == ApprovalTier.STANDARD) {
+                Button(
+                    onClick = { onRespond(ApprovalChoice.ONCE) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = accent.accent, contentColor = accent.onAccent),
+                ) { Text("Allow once") }
+                OutlinedButton(onClick = { onRespond(ApprovalChoice.SESSION) }, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) { Text("Allow this run") }
+                OutlinedButton(onClick = { onRespond(ApprovalChoice.ALWAYS) }, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) { Text("Always allow") }
+                TextButton(onClick = { onRespond(ApprovalChoice.DENY) }, modifier = Modifier.fillMaxWidth()) { Text("Deny") }
+            } else {
+                // Elevated: Deny is prominent; Allow requires a deliberate slide.
+                var thisRun by remember { mutableStateOf(false) }
+                Button(
+                    onClick = { onRespond(ApprovalChoice.DENY) },
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = error),
+                ) { Text("Deny") }
+                TextButton(onClick = { thisRun = !thisRun }, modifier = Modifier.fillMaxWidth()) {
+                    Text(if (thisRun) "Scope: allow for this run" else "Scope: allow once")
+                }
+                SlideToConfirm(
+                    label = if (thisRun) "  → slide to allow this run" else "  → slide to allow once",
+                    accent = accent.accent,
+                    onConfirm = { onRespond(if (thisRun) ApprovalChoice.SESSION else ApprovalChoice.ONCE) },
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `ChatScreen.kt`** — replace the `ApprovalDialog(...)` block:
+
+```kotlin
+state.pendingApproval?.let { req ->
+    ApprovalSheet(
+        req = req,
+        onRespond = { vm.respondApproval(it) },
+        onDismiss = { /* keep pending: do nothing until the user chooses */ },
+    )
+}
+```
+
+- [ ] **Step 3: Remove `ApprovalDialog` from `ChatComponents.kt`** (it's now unused; delete the function + any now-unused imports it introduced, e.g. `AlertDialog`, if nothing else uses them).
+
+- [ ] **Step 4: Compile + assembleBeta**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest :app:assembleBeta`
+Expected: BUILD SUCCESSFUL; all prior unit tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+git commit -m "feat(approvals): touch-native tiered approval bottom sheet (Standard scopes + Elevated slide-to-allow)"
+```
+
+---
+
+### Task 6: Tier-aware notifications
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationModels.kt` (add `ACTION_ALLOW_ONCE`; note `allowPermanent` need)
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt` (approval branch → tier-aware actions)
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt` (send `ApprovalChoice`)
+- Test: `app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `ServerEvent.bool` (Task 2), `ApprovalChoice` (Task 1), `tierFor` (Task 1).
+- Produces: approval `NotificationSpec` whose actions depend on `tierFor(event.bool("allow_permanent") ?: false)`: **Standard** → `NotifAction("Allow once", ACTION_ALLOW_ONCE, sid)` + `NotifAction("Deny", ACTION_DENY, sid)`; **Elevated** → `NotifAction("Deny", ACTION_DENY, sid)` only (tap opens the app). Add `const val ACTION_ALLOW_ONCE = "allow_once"`.
+
+- [ ] **Step 1: Write the failing tests** (extend `NotificationMapperTest`)
+
+```kotlin
+@Test fun standard_approval_offers_allow_once_and_deny() {
+    val e = ServerEvent("approval.request", "s1", buildJsonObject {
+        put("session_id", "s1"); put("command", "git push -f"); put("allow_permanent", true)
+    })
+    val spec = toNotificationSpec(e, on, appInForeground = false)!!
+    assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
+}
+
+@Test fun elevated_approval_offers_deny_only() {
+    val e = ServerEvent("approval.request", "s1", buildJsonObject {
+        put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
+    })
+    val spec = toNotificationSpec(e, on, appInForeground = false)!!
+    assertEquals(listOf(Notif.ACTION_DENY), spec.actions.map { it.action })
+}
+```
+(Reuse the file's existing `on` prefs + imports; add `com.hermes.client.data.network.ServerEvent`, `buildJsonObject`, `put` if not present.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.notifications.NotificationMapperTest"`
+Expected: FAIL — `ACTION_ALLOW_ONCE` missing / actions still `[approve, deny]`.
+
+- [ ] **Step 3a: `NotificationModels.kt`** — add:
+```kotlin
+const val ACTION_ALLOW_ONCE = "allow_once"
+```
+(Keep `ACTION_APPROVE`/`ACTION_DENY`; `ACTION_APPROVE` may become unused — remove if nothing references it after Task 6.)
+
+- [ ] **Step 3b: `NotificationMapper.kt`** — replace the `EVENT_APPROVAL` branch's fixed `actions = listOf(Approve, Deny)` with tier-aware actions. The mapper takes the `ServerEvent`, so compute the tier inline:
+```kotlin
+Notif.EVENT_APPROVAL -> if (!prefs.approvals) null else {
+    val elevated = tierFor(event.bool("allow_permanent") ?: false) == ApprovalTier.ELEVATED
+    NotificationSpec(
+        id = id,
+        channelId = Notif.CHANNEL_APPROVALS,
+        title = "Approval needed",
+        body = event.str("description")?.ifBlank { null }
+            ?: event.str("command")?.ifBlank { null }
+            ?: "The agent is waiting for your approval.",
+        route = "chat/$sid",
+        actions = if (elevated) listOf(NotifAction("Deny", Notif.ACTION_DENY, sid))
+                  else listOf(NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid), NotifAction("Deny", Notif.ACTION_DENY, sid)),
+        groupKey = "approval",
+    )
+}
+```
+Add imports: `com.hermes.client.data.network.bool`, `com.hermes.client.ui.chat.tierFor`, `com.hermes.client.ui.chat.ApprovalTier`.
+
+- [ ] **Step 3c: `NotificationActionReceiver.kt`** — map the action to a choice:
+```kotlin
+val choice = when (intent.action) {
+    Notif.ACTION_ALLOW_ONCE -> com.hermes.client.ui.chat.ApprovalChoice.ONCE
+    else -> com.hermes.client.ui.chat.ApprovalChoice.DENY
+}
+...
+runCatching { withTimeout(8_000) { chat.respondApproval(sid, choice) } }
+```
+(Update the `DebugLog.log` line to log `choice` instead of `approve`.)
+
+- [ ] **Step 4: Run tests + full build**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest :app:assembleBeta`
+Expected: BUILD SUCCESSFUL; NotificationMapperTest passes including the 2 new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/ app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+git commit -m "feat(approvals): tier-aware notification actions (Standard: Allow once/Deny; Elevated: Deny/Open)"
+```
+
+---
+
+### Task 7: On-device verification
+
+**Files:** none (verification only). Uses the harness mock `$CLAUDE_JOB_DIR/tmp/mockgw.py` (working `/api/ws`).
+
+- [ ] **Step 1: Patch the mock** to emit two approvals after connect — a Standard one and an Elevated one:
+```python
+# Standard (offers Once/Session/Always; notification Allow once + Deny)
+{"method":"event","params":{"type":"approval.request","payload":{"session_id":"titletest",
+  "command":"git push --force origin main","description":"force push to a protected branch",
+  "pattern_keys":["force push"],"allow_permanent":True}}}
+# Elevated (Tirith-flagged; slide-to-allow, Deny primary; notification Deny only)
+{"method":"event","params":{"type":"approval.request","payload":{"session_id":"titletest",
+  "command":"rm -rf /var/data","description":"recursive delete of a data directory",
+  "pattern_keys":["recursive delete"],"allow_permanent":False}}}
+```
+Log the `approval.respond` params the app sends back (the mock's RPC read loop) so the chosen `choice` is observable.
+
+- [ ] **Step 2: Build + install + drive** (emulator `hermes_test`):
+  - Boot emulator; `assembleBeta`; install `app-beta.apk`; open a chat on the `titletest` session.
+  - Emit the **Standard** approval → confirm the bottom sheet shows the command (monospace), "Approval needed · force push", and **Allow once / Allow this run / Always allow / Deny**. Tap **Allow this run** → mock log shows `approval.respond {choice:"session", approved:true}`.
+  - Emit the **Elevated** approval → confirm the sheet shows "Elevated · recursive delete", **Deny** prominent, **no Always**, and a **slide-to-allow** track. Slide it → mock log shows `{choice:"once", approved:true}`. Re-emit and tap **Deny** → `{choice:"deny", approved:false}`.
+  - Background the app + re-emit each; pull the shade: **Standard** notification shows **Allow once + Deny**; **Elevated** shows **Deny** only. Tap Standard **Allow once** → mock log `{choice:"once"}`.
+  - Screenshot both sheets + both notifications.
+
+- [ ] **Step 3: Record results** in the PR description (screenshots + the observed `choice` values). No commit (verification only).
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** wire-format fix (Tasks 2–3), tier model (Task 1), bottom sheet both tiers (Task 5), SlideToConfirm (Task 4), tier-aware notifications (Task 6), send both `choice`+`approved` (Task 3), on-device both tiers (Task 7). Out-of-scope items (`all`, new gateway fields) intentionally excluded. ✓
+- **Placeholder scan:** none — every code step has complete code; the two soft spots (SlideToConfirm thumb-offset math, ChatRepository ctor shape) are called out with the exact fallback and where to confirm. ✓
+- **Type consistency:** `ApprovalChoice`/`ApprovalTier`/`tierFor(Boolean)`/`allowedScopes` (Task 1) are used unchanged in Tasks 3/5/6; `ApprovalRequest(command, description, patternKeys, allowPermanent)` (Task 2) is consumed unchanged in Task 5; `respondApproval(sessionId, ApprovalChoice)` (Task 3) is called in Task 5 (`vm.respondApproval`) and Task 6 (`chat.respondApproval`). ✓

--- a/docs/superpowers/plans/2026-07-13-session-project-view-toggle.md
+++ b/docs/superpowers/plans/2026-07-13-session-project-view-toggle.md
@@ -1,0 +1,1202 @@
+# Session ⇆ Project view toggle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a segmented Sessions ⇆ Projects toggle to the Android Chats screen, where Projects renders the gateway's real server-authoritative project tree (`projects.tree` / `projects.project_sessions`) with drill-in, browse-only.
+
+**Architecture:** Sessions mode = a flat, most-recent-first list built from the existing cross-profile REST session data. Projects mode = two new WS JSON-RPC calls over the already-live gateway socket, parsed into domain types and rendered as project cards → drill-in session list. No gateway changes; consume existing RPCs read-only.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3 (`SingleChoiceSegmentedButtonRow`), Hilt, MVVM + StateFlow, kotlinx.serialization, DataStore Preferences, JUnit + MockK + kotlinx-coroutines-test.
+
+## Global Constraints
+
+- No AI/assistant attribution in commits, files, or PRs (no "Co-Authored-By", "Generated with", "Claude", 🤖).
+- Branch `feature/project-view-toggle` off `dev`; PR into `dev`. Never push to `main`. Run `gitleaks git --no-banner --redact` before every push.
+- NO gateway changes. Consume only the existing `projects.tree` and `projects.project_sessions` RPCs.
+- Browse-only: no project create/edit/archive/delete on mobile.
+- Material3; per-tenant accent via `LocalProfileAccent.current` (`.accent` / `.onAccent`).
+- Projects mode is single-profile (the connected gateway's bound profile); `projects.tree` takes no profile param. Hide the profile switcher and show a `Projects · <profile>` caption in Projects mode.
+- Build with `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. Gates: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`.
+- `icon` (gateway codicon name) is intentionally NOT consumed in v1 (YAGNI) — it is ignored by the DTO (unknown key) and absent from the domain model. Projects render with a folder glyph tinted by `color`/accent.
+
+---
+
+## File Structure
+
+- `app/src/main/java/com/hermes/client/data/network/Dtos.kt` *(modify)* — add project-tree DTOs; add `git_branch`/`git_repo_root` to the reused `SessionDto`.
+- `app/src/main/java/com/hermes/client/domain/Models.kt` *(modify)* — add `ProjectTree`, `Project`, `ProjectRepo`, `ProjectLane`; extend `Session` with `cwd`, `gitBranch`, `gitRepoRoot`.
+- `app/src/main/java/com/hermes/client/domain/Mappers.kt` *(modify)* — project DTO→domain mappers; set the new `Session` fields.
+- `app/src/main/java/com/hermes/client/data/repository/ProjectsRepository.kt` *(create)* — `tree()`, `projectSessions(id)`.
+- `app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt` *(create)* — persisted view-mode preference.
+- `app/src/main/java/com/hermes/client/di/AppModule.kt` *(modify)* — provide `ProjectsRepository`, `ViewModeStore`.
+- `app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt` *(modify)* — `ViewMode`, `viewMode`, projects state + actions.
+- `app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt` *(modify)* — pure `sessionsByRecency` helper.
+- `app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt` *(create)* — project card + drill-in composables.
+- `app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt` *(modify)* — toggle, caption, branch body.
+- Tests: `ProjectMappersTest.kt`, `ProjectsRepositoryTest.kt` *(create)*; `SessionsViewModelTest.kt`, `SessionGroupingTest.kt` *(modify)*.
+
+---
+
+## Task 1: Project DTOs, domain types, and mappers (pure)
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/network/Dtos.kt`
+- Modify: `app/src/main/java/com/hermes/client/domain/Models.kt`
+- Modify: `app/src/main/java/com/hermes/client/domain/Mappers.kt`
+- Test: `app/src/test/java/com/hermes/client/domain/ProjectMappersTest.kt` *(create)*
+
+**Interfaces:**
+- Produces:
+  - DTOs (in `com.hermes.client.data.network`): `ProjectTreeDto`, `ProjectNodeDto`, `RepoDto`, `LaneDto`, `ProjectSessionsResultDto`; `SessionDto` gains `gitBranch`, `gitRepoRoot`.
+  - Domain (in `com.hermes.client.domain`): `data class ProjectTree(val projects: List<Project>, val activeId: String?)`, `Project`, `ProjectRepo`, `ProjectLane`; `Session` gains `cwd: String?`, `gitBranch: String?`, `gitRepoRoot: String?`.
+  - Mappers: `ProjectTreeDto.toDomain(): ProjectTree`, `ProjectNodeDto.toDomain(): Project`, `RepoDto.toDomain(): ProjectRepo`, `LaneDto.toDomain(): ProjectLane`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/hermes/client/domain/ProjectMappersTest.kt`:
+
+```kotlin
+package com.hermes.client.domain
+
+import com.hermes.client.data.network.ProjectSessionsResultDto
+import com.hermes.client.data.network.ProjectTreeDto
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectMappersTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val treeJson = """
+    {
+      "projects": [
+        {
+          "id": "p_ab12", "label": "Roam and Trail", "path": "/u/andrew/roam-and-trail",
+          "color": "#4F8A10", "icon": "root-folder", "isAuto": false,
+          "sessionCount": 3, "lastActive": 1752000000.0,
+          "repos": [
+            { "id": "/u/andrew/roam-and-trail", "label": "roam-and-trail", "path": "/u/andrew/roam-and-trail",
+              "sessionCount": 3,
+              "groups": [
+                { "id": "main", "label": "main", "path": "/u/andrew/roam-and-trail",
+                  "isMain": true, "isKanban": false, "sessions": [] }
+              ] }
+          ],
+          "previewSessions": [
+            { "id": "s1", "title": "Affiliate setup", "model": "gpt", "last_active": 1752000000.0,
+              "message_count": 4, "cwd": "/u/andrew/roam-and-trail",
+              "git_branch": "main", "git_repo_root": "/u/andrew/roam-and-trail", "source": "hermes-dispatch" }
+          ]
+        },
+        {
+          "id": "/u/andrew/inbound", "label": "inbound", "path": "/u/andrew/inbound",
+          "isAuto": true, "sessionCount": 1, "lastActive": 1751990000.0,
+          "repos": [],
+          "previewSessions": [ { "id": "s2", "title": "Flight tracker", "message_count": 2 } ]
+        }
+      ],
+      "active_id": "p_ab12",
+      "scoped_session_ids": ["s1", "s2"]
+    }
+    """.trimIndent()
+
+    @Test fun maps_full_tree_including_repos_lanes_and_previews() {
+        val tree = json.decodeFromString(ProjectTreeDto.serializer(), treeJson).toDomain()
+
+        assertEquals("p_ab12", tree.activeId)
+        assertEquals(2, tree.projects.size)
+
+        val explicit = tree.projects[0]
+        assertEquals("Roam and Trail", explicit.label)
+        assertEquals("#4F8A10", explicit.color)
+        assertEquals(false, explicit.isAuto)
+        assertEquals(3, explicit.sessionCount)
+        assertEquals(1, explicit.repos.size)
+        assertEquals("roam-and-trail", explicit.repos[0].label)
+        assertEquals(1, explicit.repos[0].lanes.size)
+        assertTrue(explicit.repos[0].lanes[0].isMain)
+        // preview session mapped through Session.toDomain
+        assertEquals("Affiliate setup", explicit.previewSessions.single().title)
+        assertEquals("main", explicit.previewSessions.single().gitBranch)
+        assertEquals("/u/andrew/roam-and-trail", explicit.previewSessions.single().cwd)
+    }
+
+    @Test fun auto_project_has_null_color_and_no_repos() {
+        val tree = json.decodeFromString(ProjectTreeDto.serializer(), treeJson).toDomain()
+        val auto = tree.projects[1]
+        assertEquals("inbound", auto.label)
+        assertNull(auto.color)
+        assertTrue(auto.isAuto)
+        assertTrue(auto.repos.isEmpty())
+        assertEquals("Flight tracker", auto.previewSessions.single().title)
+    }
+
+    @Test fun project_sessions_result_hydrates_lane_sessions() {
+        val projJson = """
+        { "project": { "id": "p_ab12", "label": "Roam and Trail", "path": "/u/andrew/roam-and-trail",
+          "isAuto": false, "sessionCount": 1, "lastActive": 1752000000.0,
+          "repos": [ { "id": "r", "label": "roam-and-trail", "path": "/u/andrew/roam-and-trail",
+            "sessionCount": 1, "groups": [ { "id": "main", "label": "main", "path": "/u",
+              "isMain": true, "isKanban": false,
+              "sessions": [ { "id": "s1", "title": "Affiliate setup", "model": "gpt",
+                "last_active": 1752000000.0, "message_count": 4 } ] } ] } ],
+          "previewSessions": [] } }
+        """.trimIndent()
+
+        val project = json.decodeFromString(ProjectSessionsResultDto.serializer(), projJson).project!!.toDomain()
+        assertEquals("Affiliate setup", project.repos.single().lanes.single().sessions.single().title)
+    }
+
+    @Test fun missing_project_maps_to_null() {
+        val project = json.decodeFromString(ProjectSessionsResultDto.serializer(), """{"project":null}""").project
+        assertNull(project)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.domain.ProjectMappersTest"`
+Expected: FAIL to COMPILE — `ProjectTreeDto`, `ProjectSessionsResultDto`, `toDomain`, `Session.gitBranch`, `Session.cwd` unresolved.
+
+- [ ] **Step 3: Add the DTOs**
+
+In `app/src/main/java/com/hermes/client/data/network/Dtos.kt`, add `gitBranch`/`gitRepoRoot` to `SessionDto` (append inside the existing class, after `source`):
+
+```kotlin
+    @SerialName("git_branch") val gitBranch: String? = null,
+    @SerialName("git_repo_root") val gitRepoRoot: String? = null,
+```
+
+Then append these new DTOs to the file:
+
+```kotlin
+/**
+ * Gateway `projects.tree` result. Single-profile (the connected gateway's bound profile).
+ * `scoped_session_ids` is parsed but unused in v1 (Sessions mode shows the flat REST list
+ * independently). `icon` is an unknown key here and intentionally ignored (YAGNI).
+ */
+@Serializable data class ProjectTreeDto(
+    val projects: List<ProjectNodeDto> = emptyList(),
+    @SerialName("active_id") val activeId: String? = null,
+)
+
+@Serializable data class ProjectNodeDto(
+    val id: String,
+    val label: String = "",
+    val path: String? = null,
+    val color: String? = null,
+    val isAuto: Boolean = false,
+    val sessionCount: Int = 0,
+    val lastActive: Double? = null,
+    val repos: List<RepoDto> = emptyList(),
+    // On projects.tree these are up to preview_limit newest rows; on project_sessions it's empty.
+    val previewSessions: List<SessionDto> = emptyList(),
+)
+
+@Serializable data class RepoDto(
+    val id: String,
+    val label: String = "",
+    val path: String? = null,
+    val sessionCount: Int = 0,
+    // Gateway calls the branch lanes "groups".
+    val groups: List<LaneDto> = emptyList(),
+)
+
+@Serializable data class LaneDto(
+    val id: String,
+    val label: String = "",
+    val path: String? = null,
+    val isMain: Boolean = false,
+    // Lane sessions are empty on projects.tree (counts only) and hydrated on project_sessions.
+    val sessions: List<SessionDto> = emptyList(),
+)
+
+/** Gateway `projects.project_sessions` result — a single hydrated node (or null). */
+@Serializable data class ProjectSessionsResultDto(
+    val project: ProjectNodeDto? = null,
+)
+```
+
+- [ ] **Step 4: Add the domain types**
+
+In `app/src/main/java/com/hermes/client/domain/Models.kt`, extend `Session` — add these three fields after `lastActive` (keep the trailing comma style):
+
+```kotlin
+    // Full working directory (not just the basename in [workspace]); null when the session has none.
+    val cwd: String? = null,
+    // Git context resolved server-side, present on project-tree session rows; null otherwise.
+    val gitBranch: String? = null,
+    val gitRepoRoot: String? = null,
+```
+
+Then append the project domain types to the file:
+
+```kotlin
+/** A server-authoritative project (explicit user project or an auto git-repo/discovered project). */
+data class Project(
+    val id: String,
+    val label: String,
+    val path: String?,
+    // Hex string like "#RRGGBB" for explicit projects; null for auto/discovered (render with accent).
+    val color: String?,
+    val isAuto: Boolean,
+    val sessionCount: Int,
+    val lastActive: Long?,
+    val repos: List<ProjectRepo>,
+    // Newest sessions for the overview card; empty after drill-in (lanes carry the full set then).
+    val previewSessions: List<Session>,
+)
+
+data class ProjectRepo(
+    val id: String,
+    val label: String,
+    val path: String?,
+    val sessionCount: Int,
+    val lanes: List<ProjectLane>,
+)
+
+data class ProjectLane(
+    val id: String,
+    val label: String,
+    val path: String?,
+    val isMain: Boolean,
+    val sessions: List<Session>,
+)
+
+data class ProjectTree(
+    val projects: List<Project>,
+    val activeId: String?,
+)
+```
+
+- [ ] **Step 5: Add the mappers**
+
+In `app/src/main/java/com/hermes/client/domain/Mappers.kt`, add the new imports at the top:
+
+```kotlin
+import com.hermes.client.data.network.LaneDto
+import com.hermes.client.data.network.ProjectNodeDto
+import com.hermes.client.data.network.ProjectTreeDto
+import com.hermes.client.data.network.RepoDto
+```
+
+Update `SessionDto.toDomain()` — add the three new fields (place after `source = source,`):
+
+```kotlin
+    cwd = cwd?.ifBlank { null },
+    gitBranch = gitBranch?.ifBlank { null },
+    gitRepoRoot = gitRepoRoot?.ifBlank { null },
+```
+
+Append the project mappers:
+
+```kotlin
+fun ProjectTreeDto.toDomain() = ProjectTree(
+    projects = projects.map { it.toDomain() },
+    activeId = activeId,
+)
+
+fun ProjectNodeDto.toDomain() = Project(
+    id = id,
+    label = label,
+    path = path,
+    color = color?.ifBlank { null },
+    isAuto = isAuto,
+    sessionCount = sessionCount,
+    lastActive = com.hermes.client.ui.util.secondsToEpochMs(lastActive),
+    repos = repos.map { it.toDomain() },
+    previewSessions = previewSessions.map { it.toDomain() },
+)
+
+fun RepoDto.toDomain() = ProjectRepo(
+    id = id,
+    label = label,
+    path = path,
+    sessionCount = sessionCount,
+    lanes = groups.map { it.toDomain() },
+)
+
+fun LaneDto.toDomain() = ProjectLane(
+    id = id,
+    label = label,
+    path = path,
+    isMain = isMain,
+    sessions = sessions.map { it.toDomain() },
+)
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.domain.ProjectMappersTest"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/network/Dtos.kt \
+        app/src/main/java/com/hermes/client/domain/Models.kt \
+        app/src/main/java/com/hermes/client/domain/Mappers.kt \
+        app/src/test/java/com/hermes/client/domain/ProjectMappersTest.kt
+git commit -m "feat(projects): project-tree DTOs, domain types, and mappers"
+```
+
+---
+
+## Task 2: ProjectsRepository (WS JSON-RPC)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/data/repository/ProjectsRepository.kt`
+- Modify: `app/src/main/java/com/hermes/client/di/AppModule.kt`
+- Test: `app/src/test/java/com/hermes/client/data/repository/ProjectsRepositoryTest.kt` *(create)*
+
+**Interfaces:**
+- Consumes: `HermesGatewayClient.call(method: String, params: JsonObject): JsonElement` (Task-independent, existing); `ProjectTreeDto`, `ProjectSessionsResultDto`, `toDomain()` (Task 1).
+- Produces: `class ProjectsRepository(client, json)` with `suspend fun tree(previewLimit: Int = 3): ProjectTree` and `suspend fun projectSessions(projectId: String): Project?`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/hermes/client/data/repository/ProjectsRepositoryTest.kt`:
+
+```kotlin
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProjectsRepositoryTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test fun tree_calls_projects_tree_and_parses_nodes() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement(
+            """{ "projects": [ { "id": "p1", "label": "Alpha", "isAuto": false, "sessionCount": 2 } ],
+                 "active_id": "p1" }""",
+        )
+        val repo = ProjectsRepository(client, json)
+
+        val tree = repo.tree()
+
+        assertEquals("p1", tree.activeId)
+        assertEquals("Alpha", tree.projects.single().label)
+        coVerify { client.call("projects.tree", any()) }
+    }
+
+    @Test fun tree_passes_preview_limit_param() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement("""{"projects":[]}""")
+        val repo = ProjectsRepository(client, json)
+
+        repo.tree(previewLimit = 5)
+
+        coVerify { client.call("projects.tree", match { it["preview_limit"]!!.jsonPrimitive.content == "5" }) }
+    }
+
+    @Test fun projectSessions_calls_rpc_with_id_and_parses_project() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement(
+            """{ "project": { "id": "p1", "label": "Alpha", "isAuto": false, "sessionCount": 1,
+                 "repos": [], "previewSessions": [] } }""",
+        )
+        val repo = ProjectsRepository(client, json)
+
+        val project = repo.projectSessions("p1")
+
+        assertEquals("Alpha", project?.label)
+        coVerify { client.call("projects.project_sessions", match { it["project_id"]!!.jsonPrimitive.content == "p1" }) }
+    }
+
+    @Test fun projectSessions_returns_null_when_project_absent() = runTest {
+        val client = mockk<HermesGatewayClient>(relaxed = true)
+        coEvery { client.call(any(), any()) } returns json.parseToJsonElement("""{"project":null}""")
+        val repo = ProjectsRepository(client, json)
+
+        assertNull(repo.projectSessions("nope"))
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.ProjectsRepositoryTest"`
+Expected: FAIL to COMPILE — `ProjectsRepository` unresolved.
+
+- [ ] **Step 3: Create the repository**
+
+Create `app/src/main/java/com/hermes/client/data/repository/ProjectsRepository.kt`:
+
+```kotlin
+package com.hermes.client.data.repository
+
+import com.hermes.client.data.network.HermesGatewayClient
+import com.hermes.client.data.network.ProjectSessionsResultDto
+import com.hermes.client.data.network.ProjectTreeDto
+import com.hermes.client.domain.Project
+import com.hermes.client.domain.ProjectTree
+import com.hermes.client.domain.toDomain
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Browse-only access to the gateway's server-authoritative project tree over WS JSON-RPC.
+ * Single-profile: `projects.tree` reflects the connected gateway's bound profile and takes no
+ * profile param (see the design's profile-scoping note). Piggybacks on the socket the sessions
+ * screen already opens via [ChatRepository.connect].
+ */
+class ProjectsRepository(
+    private val client: HermesGatewayClient,
+    private val json: Json,
+) {
+    /** Fetch the project overview (nodes with counts + up to [previewLimit] preview sessions). */
+    suspend fun tree(previewLimit: Int = 3): ProjectTree {
+        val result = client.call("projects.tree", buildJsonObject { put("preview_limit", previewLimit) })
+        return json.decodeFromJsonElement(ProjectTreeDto.serializer(), result).toDomain()
+    }
+
+    /** Hydrate one project's sessions for drill-in. [projectId] must equal a tree node id. */
+    suspend fun projectSessions(projectId: String): Project? {
+        val result = client.call("projects.project_sessions", buildJsonObject { put("project_id", projectId) })
+        return json.decodeFromJsonElement(ProjectSessionsResultDto.serializer(), result).project?.toDomain()
+    }
+}
+```
+
+- [ ] **Step 4: Wire DI**
+
+In `app/src/main/java/com/hermes/client/di/AppModule.kt`, add after `provideChatRepository`:
+
+```kotlin
+    @Provides
+    @Singleton
+    fun provideProjectsRepository(
+        client: HermesGatewayClient,
+        json: Json,
+    ): com.hermes.client.data.repository.ProjectsRepository =
+        com.hermes.client.data.repository.ProjectsRepository(client, json)
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.ProjectsRepositoryTest"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/repository/ProjectsRepository.kt \
+        app/src/main/java/com/hermes/client/di/AppModule.kt \
+        app/src/test/java/com/hermes/client/data/repository/ProjectsRepositoryTest.kt
+git commit -m "feat(projects): ProjectsRepository over projects.* WS RPC"
+```
+
+---
+
+## Task 3: View-mode persistence + pure recency sort
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt`
+- Modify: `app/src/main/java/com/hermes/client/di/AppModule.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt` *(modify)*
+
+**Interfaces:**
+- Produces:
+  - `enum class ViewMode { SESSIONS, PROJECTS }` (in `com.hermes.client.ui.sessions`, top of `SessionGrouping.kt`).
+  - `class ViewModeStore(context)` with `val mode: Flow<ViewMode>` (default `SESSIONS`) and `suspend fun set(mode: ViewMode)`.
+  - `fun sessionsByRecency(sessions: List<Session>): List<Session>` (newest `lastActive` first; nulls last).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt` (inside the existing test class):
+
+```kotlin
+    private fun s(id: String, lastActive: Long?) = com.hermes.client.domain.Session(
+        id = id, title = id, model = null, provider = null, messageCount = 1,
+        profile = "personal", lastActive = lastActive,
+    )
+
+    @org.junit.Test fun sessionsByRecency_orders_newest_first_nulls_last() {
+        val out = sessionsByRecency(listOf(s("a", 100), s("b", null), s("c", 300))).map { it.id }
+        org.junit.Assert.assertEquals(listOf("c", "a", "b"), out)
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.sessions.SessionGroupingTest"`
+Expected: FAIL to COMPILE — `sessionsByRecency` unresolved.
+
+- [ ] **Step 3: Add `ViewMode` + `sessionsByRecency`**
+
+At the TOP of `app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt` (below the package line, above `WorkspaceGroup`):
+
+```kotlin
+/** Which list the Chats screen shows: a flat recency list, or the gateway's project tree. */
+enum class ViewMode { SESSIONS, PROJECTS }
+```
+
+At the BOTTOM of the same file:
+
+```kotlin
+/** Flat, most-recent-first order for Sessions mode. Sessions with no [Session.lastActive] sort last. */
+fun sessionsByRecency(sessions: List<Session>): List<Session> =
+    sessions.sortedByDescending { it.lastActive ?: Long.MIN_VALUE }
+```
+
+- [ ] **Step 4: Create `ViewModeStore`**
+
+Create `app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt`:
+
+```kotlin
+package com.hermes.client.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.hermes.client.ui.sessions.ViewMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.viewModeDataStore by preferencesDataStore(name = "sessions_view_mode")
+
+/** Device-local persisted Chats view mode. Defaults to [ViewMode.SESSIONS]. */
+class ViewModeStore(private val context: Context) {
+    private val key = stringPreferencesKey("view_mode")
+
+    val mode: Flow<ViewMode> = context.viewModeDataStore.data.map { prefs ->
+        when (prefs[key]) {
+            ViewMode.PROJECTS.name -> ViewMode.PROJECTS
+            else -> ViewMode.SESSIONS
+        }
+    }
+
+    suspend fun set(mode: ViewMode) {
+        context.viewModeDataStore.edit { it[key] = mode.name }
+    }
+}
+```
+
+- [ ] **Step 5: Wire DI**
+
+In `app/src/main/java/com/hermes/client/di/AppModule.kt`, add after `provideGroupExpansionStore`:
+
+```kotlin
+    @Provides
+    @Singleton
+    fun provideViewModeStore(
+        @ApplicationContext context: Context,
+    ): com.hermes.client.data.repository.ViewModeStore =
+        com.hermes.client.data.repository.ViewModeStore(context)
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.sessions.SessionGroupingTest"`
+Expected: PASS (existing tests + the new one).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/repository/ViewModeStore.kt \
+        app/src/main/java/com/hermes/client/di/AppModule.kt \
+        app/src/main/java/com/hermes/client/ui/sessions/SessionGrouping.kt \
+        app/src/test/java/com/hermes/client/ui/sessions/SessionGroupingTest.kt
+git commit -m "feat(projects): ViewMode + persistence + recency sort"
+```
+
+---
+
+## Task 4: ViewModel — view mode + projects state and actions
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: `ProjectsRepository.tree()`, `ProjectsRepository.projectSessions(id)` (Task 2); `ViewModeStore.mode`, `ViewModeStore.set` (Task 3); `ViewMode` (Task 3); `Project` (Task 1).
+- Produces (on `SessionsViewModel`): `val viewMode: StateFlow<ViewMode>`; `val projectsState: StateFlow<ProjectsUiState>`; `fun setViewMode(mode: ViewMode)`; `fun loadProjectTree()`; `fun enterProject(project: Project)`; `fun exitProject()`. New constructor params appended: `projects: ProjectsRepository, viewModeStore: ViewModeStore`.
+- Produces: `data class ProjectsUiState(tree, loading, error, scope, scopeLoading)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt`.
+
+Add two mocked deps (after the `groupExpansion` field, line ~32):
+
+```kotlin
+    private val projects = mockk<com.hermes.client.data.repository.ProjectsRepository>(relaxed = true)
+    private val viewModeStore = mockk<com.hermes.client.data.repository.ViewModeStore>(relaxed = true)
+```
+
+In `setUp()` add a default stub (after the `groupExpansion.collapsed` stub):
+
+```kotlin
+        every { viewModeStore.mode } returns MutableStateFlow(ViewMode.SESSIONS)
+```
+
+Update `buildVm()` to pass the new deps:
+
+```kotlin
+    private fun buildVm() = SessionsViewModel(sessionRepo, chatRepo, profileManager, pinStore, groupExpansion, projects, viewModeStore)
+```
+
+Add these tests to the class:
+
+```kotlin
+    @Test fun setViewMode_persists_and_loads_tree_on_first_projects_entry() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        coEvery { projects.tree() } returns com.hermes.client.domain.ProjectTree(
+            projects = listOf(
+                com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList()),
+            ),
+            activeId = "p1",
+        )
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.setViewMode(ViewMode.PROJECTS)
+        advanceUntilIdle()
+
+        io.mockk.coVerify { viewModeStore.set(ViewMode.PROJECTS) }
+        io.mockk.coVerify { projects.tree() }
+        assertEquals(listOf("p1"), vm.projectsState.value.tree.map { it.id })
+    }
+
+    @Test fun loadProjectTree_sets_error_on_failure() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        coEvery { projects.tree() } throws RuntimeException("rpc down")
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.loadProjectTree()
+        advanceUntilIdle()
+
+        assertFalse(vm.projectsState.value.loading)
+        assertTrue(vm.projectsState.value.error != null)
+    }
+
+    @Test fun enterProject_hydrates_scope_then_exit_clears_it() = runTest {
+        coEvery { sessionRepo.listAllProfiles() } returns emptyList()
+        val overview = com.hermes.client.domain.Project("p1", "Alpha", null, null, false, 2, null, emptyList(), emptyList())
+        val hydrated = overview.copy(
+            repos = listOf(
+                com.hermes.client.domain.ProjectRepo("r", "alpha", null, 1, listOf(
+                    com.hermes.client.domain.ProjectLane("main", "main", null, true, listOf(session("s1", "Hi"))),
+                )),
+            ),
+        )
+        coEvery { projects.projectSessions("p1") } returns hydrated
+        val vm = buildVm()
+        advanceUntilIdle()
+
+        vm.enterProject(overview)
+        advanceUntilIdle()
+        assertEquals("p1", vm.projectsState.value.scope?.id)
+        assertEquals("s1", vm.projectsState.value.scope?.repos?.single()?.lanes?.single()?.sessions?.single()?.id)
+
+        vm.exitProject()
+        assertNull(vm.projectsState.value.scope)
+    }
+```
+
+Add the import needed for `assertNull`:
+
+```kotlin
+import org.junit.Assert.assertNull
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.sessions.SessionsViewModelTest"`
+Expected: FAIL to COMPILE — new constructor params / `viewMode` / `projectsState` / `setViewMode` / `enterProject` unresolved.
+
+- [ ] **Step 3: Extend the ViewModel**
+
+In `app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt`:
+
+Add imports:
+
+```kotlin
+import com.hermes.client.data.repository.ProjectsRepository
+import com.hermes.client.data.repository.ViewModeStore
+import com.hermes.client.domain.Project
+```
+
+Add the projects UI-state type below `SessionsUiState`:
+
+```kotlin
+/** Projects-mode state: [tree] is the overview; [scope] is the drilled-in hydrated project (null = overview). */
+data class ProjectsUiState(
+    val tree: List<Project> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null,
+    val scope: Project? = null,
+    val scopeLoading: Boolean = false,
+)
+```
+
+Append the two constructor params (after `groupExpansion`):
+
+```kotlin
+    private val projects: ProjectsRepository,
+    private val viewModeStore: ViewModeStore,
+```
+
+Add the state + actions inside the class (e.g. after `toggleGroup`):
+
+```kotlin
+    /** Persisted view mode (Sessions flat list vs the gateway project tree). */
+    val viewMode: StateFlow<ViewMode> =
+        viewModeStore.mode.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ViewMode.SESSIONS)
+
+    private val _projects = MutableStateFlow(ProjectsUiState())
+    val projectsState: StateFlow<ProjectsUiState> = _projects.asStateFlow()
+
+    /** Switch view mode; on the first entry into Projects (empty tree) fetch it. */
+    fun setViewMode(mode: ViewMode) {
+        viewModelScope.launch { viewModeStore.set(mode) }
+        if (mode == ViewMode.PROJECTS && _projects.value.tree.isEmpty() && !_projects.value.loading) {
+            loadProjectTree()
+        }
+    }
+
+    private var projectTreeJob: Job? = null
+
+    /** Fetch the project overview (also the retry entry point). Latest-wins like [refresh]. */
+    fun loadProjectTree() {
+        projectTreeJob?.cancel()
+        projectTreeJob = viewModelScope.launch {
+            _projects.value = _projects.value.copy(loading = true, error = null)
+            try {
+                val tree = projects.tree()
+                _projects.value = _projects.value.copy(loading = false, tree = tree.projects)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _projects.value = _projects.value.copy(loading = false, error = e.message ?: "Failed to load projects")
+            }
+        }
+    }
+
+    /** Drill into a project: hydrate its sessions. Falls back to the overview node on failure. */
+    fun enterProject(project: Project) {
+        viewModelScope.launch {
+            _projects.value = _projects.value.copy(scope = project, scopeLoading = true)
+            val hydrated = runCatching { projects.projectSessions(project.id) }
+                .onFailure { if (it is kotlinx.coroutines.CancellationException) throw it }
+                .getOrNull() ?: project
+            _projects.value = _projects.value.copy(scope = hydrated, scopeLoading = false)
+        }
+    }
+
+    /** Return to the project overview. */
+    fun exitProject() {
+        _projects.value = _projects.value.copy(scope = null)
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.sessions.SessionsViewModelTest"`
+Expected: PASS (existing + 3 new tests).
+
+- [ ] **Step 5: Full unit-test sweep + compile**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL; all unit tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/sessions/SessionsViewModel.kt \
+        app/src/test/java/com/hermes/client/ui/sessions/SessionsViewModelTest.kt
+git commit -m "feat(projects): view-mode + project tree/drill-in state in SessionsViewModel"
+```
+
+---
+
+## Task 5: UI — segmented toggle, flat Sessions mode, Projects overview + drill-in
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt`
+
+**Interfaces:**
+- Consumes: `vm.viewMode`, `vm.projectsState`, `vm.setViewMode`, `vm.loadProjectTree`, `vm.enterProject`, `vm.exitProject` (Task 4); `sessionsByRecency` (Task 3); `Project`, `ProjectLane` (Task 1); existing `SessionRow`, `SectionHeader`, `LocalProfileAccent`, `EmptyState`, `ErrorState`, `LoadingState`, `ProfileSwitcher`.
+- Produces: composables `ProjectOverview`, `ProjectScopeView`, `ProjectCard` in `ProjectList.kt`.
+
+- [ ] **Step 1: Create the Projects composables**
+
+Create `app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt`:
+
+```kotlin
+package com.hermes.client.ui.sessions
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.hermes.client.domain.Project
+import com.hermes.client.domain.Session
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+/** Parse the gateway's "#RRGGBB" project color; fall back to the tenant accent when null/invalid. */
+@Composable
+private fun projectTint(color: String?): Color {
+    val accent = LocalProfileAccent.current.accent
+    return color?.let { runCatching { Color(android.graphics.Color.parseColor(it)) }.getOrNull() } ?: accent
+}
+
+/** Projects overview: one tappable card per project. */
+@Composable
+fun ProjectOverview(projects: List<Project>, onOpenProject: (Project) -> Unit) {
+    LazyColumn(Modifier.fillMaxWidth()) {
+        items(projects, key = { it.id }) { p -> ProjectCard(p, onClick = { onOpenProject(p) }) }
+    }
+}
+
+@Composable
+fun ProjectCard(project: Project, onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(project.label) },
+        supportingContent = {
+            val repos = if (project.isAuto) "auto" else "${project.repos.size} repo${if (project.repos.size == 1) "" else "s"}"
+            Text("${project.sessionCount} session${if (project.sessionCount == 1) "" else "s"} · $repos")
+        },
+        leadingContent = {
+            Icon(Icons.Rounded.Folder, contentDescription = null, tint = projectTint(project.color), modifier = Modifier.size(24.dp))
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
+
+/**
+ * Drill-in for one hydrated project: a back row, then its sessions. A single-lane project renders a
+ * flat list; multi-lane projects show repo/branch sub-headers.
+ */
+@Composable
+fun ProjectScopeView(project: Project, onBack: () -> Unit, onOpenSession: (Session) -> Unit) {
+    val lanes = project.repos.flatMap { repo -> repo.lanes.map { repo to it } }
+    val multi = lanes.size > 1
+    LazyColumn(Modifier.fillMaxWidth()) {
+        item(key = "back") {
+            Row(
+                Modifier.fillMaxWidth().clickable(onClick = onBack).padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Start,
+            ) {
+                Icon(Icons.Rounded.ArrowBack, contentDescription = "Back", tint = LocalProfileAccent.current.accent, modifier = Modifier.padding(end = 8.dp))
+                Text(project.label, style = MaterialTheme.typography.titleSmall, color = LocalProfileAccent.current.accent)
+            }
+        }
+        lanes.forEach { (repo, lane) ->
+            if (multi) {
+                item(key = "lane-${repo.id}-${lane.id}") {
+                    Text(
+                        "${repo.label} · ${lane.label}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 4.dp),
+                    )
+                }
+            }
+            items(lane.sessions, key = { "sess-${it.id}" }) { s ->
+                ListItem(
+                    headlineContent = { Text(s.title) },
+                    supportingContent = { Text(s.model ?: "") },
+                    modifier = Modifier.clickable { onOpenSession(s) },
+                )
+            }
+        }
+        if (lanes.isEmpty()) {
+            item(key = "empty-scope") {
+                Text(
+                    "No sessions in this project.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the toggle + branch the screen body**
+
+In `app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt`:
+
+Add imports:
+
+```kotlin
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+```
+
+Collect the new state (after the existing `collectAsStateWithLifecycle` calls, ~line 75):
+
+```kotlin
+    val viewMode by vm.viewMode.collectAsStateWithLifecycle()
+    val projectsState by vm.projectsState.collectAsStateWithLifecycle()
+```
+
+In the `topBar` `Column`, replace the `if (profiles.size > 1) { ProfileSwitcher(...) }` block with a mode-aware version, and add the segmented toggle below it:
+
+```kotlin
+                // Sessions mode spans all profiles (REST); Projects mode is single-profile (the
+                // gateway's bound profile — projects.tree takes no profile param), so the switcher
+                // would be misleading there. Show a caption instead.
+                if (viewMode == ViewMode.SESSIONS) {
+                    if (profiles.size > 1) {
+                        com.hermes.client.ui.components.ProfileSwitcher(
+                            names = profiles.map { it.name },
+                            active = activeProfile,
+                            onSelect = vm::switchProfile,
+                        )
+                    }
+                } else {
+                    Text(
+                        "Projects · ${activeProfile ?: "default"}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = com.hermes.client.ui.components.AccentChrome.onBar,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                    )
+                }
+                val accent = LocalProfileAccent.current
+                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp)) {
+                    val tabs = listOf(ViewMode.SESSIONS to "Sessions", ViewMode.PROJECTS to "Projects")
+                    tabs.forEachIndexed { i, (mode, label) ->
+                        SegmentedButton(
+                            selected = viewMode == mode,
+                            onClick = { vm.setViewMode(mode) },
+                            shape = SegmentedButtonDefaults.itemShape(i, tabs.size),
+                            colors = SegmentedButtonDefaults.colors(
+                                activeContainerColor = accent.accent,
+                                activeContentColor = accent.onAccent,
+                            ),
+                        ) { Text(label) }
+                    }
+                }
+```
+
+Branch the body. The search field + current `Box { when { … } }` handle Sessions mode; wrap them so they only show in Sessions mode, and render Projects mode otherwise. Replace the `Column(Modifier.padding(padding).fillMaxSize()) { … }` body with:
+
+```kotlin
+        Column(Modifier.padding(padding).fillMaxSize()) {
+            if (viewMode == ViewMode.PROJECTS) {
+                Box(Modifier.fillMaxSize()) {
+                    when {
+                        projectsState.loading && projectsState.tree.isEmpty() ->
+                            com.hermes.client.ui.components.LoadingState()
+                        projectsState.error != null ->
+                            com.hermes.client.ui.components.ErrorState(
+                                message = projectsState.error!!,
+                                onRetry = { vm.loadProjectTree() },
+                            )
+                        projectsState.scope != null ->
+                            ProjectScopeView(
+                                project = projectsState.scope!!,
+                                onBack = { vm.exitProject() },
+                                onOpenSession = { s -> onOpen(s.id) },
+                            )
+                        projectsState.tree.isEmpty() ->
+                            com.hermes.client.ui.components.EmptyState(
+                                title = "No projects",
+                                subtitle = "Projects are created on the desktop app.",
+                                actionLabel = "Reload",
+                                onAction = { vm.loadProjectTree() },
+                            )
+                        else -> ProjectOverview(projectsState.tree, onOpenProject = { vm.enterProject(it) })
+                    }
+                }
+            } else {
+                // ── Sessions mode (flat recency) ─────────────────────────────────────────────
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = vm::onQueryChange,
+                    placeholder = { Text("Search sessions…") },
+                    singleLine = true,
+                    trailingIcon = {
+                        if (query.isNotBlank()) {
+                            IconButton(onClick = { vm.onQueryChange("") }) {
+                                Icon(Icons.Rounded.Close, contentDescription = "Clear search")
+                            }
+                        }
+                    },
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { vm.searchMessages() }),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
+                )
+                Box(Modifier.fillMaxSize()) {
+                    when {
+                        state.loading -> com.hermes.client.ui.components.LoadingState()
+                        state.error != null -> com.hermes.client.ui.components.ErrorState(
+                            message = state.error!!,
+                            onRetry = { vm.refresh() },
+                        )
+                        state.sessions.isEmpty() && query.isBlank() && messageResults.isEmpty() ->
+                            com.hermes.client.ui.components.EmptyState(
+                                title = "No sessions yet",
+                                subtitle = "Start a conversation with the New button.",
+                                actionLabel = "New session",
+                                onAction = { scope.launch { vm.createSession()?.let { onOpen(it) } } },
+                            )
+                        else -> {
+                            val q = query.trim()
+                            val matches = if (q.isEmpty()) state.sessions
+                            else state.sessions.filter {
+                                it.title.contains(q, ignoreCase = true) ||
+                                    it.workspace.contains(q, ignoreCase = true)
+                            }
+                            val isPinned = { s: Session ->
+                                com.hermes.client.data.repository.PinStore.token(s.profile, s.id) in pinnedTokens
+                            }
+                            val pinned = matches.filter(isPinned)
+                            val recent = sessionsByRecency(matches.filterNot(isPinned))
+
+                            LazyColumn {
+                                if (messageResults.isNotEmpty()) {
+                                    item(key = "h-msg") { SectionHeader("Message matches", messageResults.size) }
+                                    items(messageResults) { r ->
+                                        ListItem(
+                                            headlineContent = {
+                                                Text(r.snippet?.take(140)?.replace("\n", " ") ?: r.sessionId)
+                                            },
+                                            supportingContent = { Text(r.model ?: r.role ?: "") },
+                                            modifier = Modifier.clickable { onOpen(r.sessionId) },
+                                        )
+                                        HorizontalDivider()
+                                    }
+                                }
+                                if (q.isNotEmpty() && matches.isEmpty() && messageResults.isEmpty()) {
+                                    item(key = "no-title-match") {
+                                        Text(
+                                            "No titles match \"$q\". Press search on the keyboard to search message text.",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.padding(16.dp),
+                                        )
+                                    }
+                                }
+                                if (pinned.isNotEmpty()) {
+                                    item(key = "h-pinned") { SectionHeader("Pinned", pinned.size, note = "Device only") }
+                                    items(pinned, key = { "p-${it.id}" }) { s ->
+                                        SessionRow(
+                                            session = s, isPinned = true, showProfile = true,
+                                            onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
+                                            onTogglePin = { vm.togglePin(s) },
+                                            onRename = { vm.rename(s, it) },
+                                            onArchive = { vm.archive(s) },
+                                            onDelete = { vm.delete(s) },
+                                            modifier = Modifier.animateItem(),
+                                        )
+                                    }
+                                }
+                                if (recent.isNotEmpty()) {
+                                    item(key = "h-recent") { SectionHeader("Recent", recent.size) }
+                                    items(recent, key = { it.id }) { s ->
+                                        SessionRow(
+                                            session = s, isPinned = false, showProfile = true,
+                                            onOpen = { scope.launch { vm.prepareOpen(s); onOpen(s.id) } },
+                                            onTogglePin = { vm.togglePin(s) },
+                                            onRename = { vm.rename(s, it) },
+                                            onArchive = { vm.archive(s) },
+                                            onDelete = { vm.delete(s) },
+                                            modifier = Modifier.animateItem(),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+```
+
+Note: `showProfile = true` in flat mode (there are no profile headers now, so the tenant prefix stays useful). The old `groupSessions`/`CollapsibleHeader` grouping is removed from the screen; leave the `CollapsibleHeader` composable in the file only if still referenced — otherwise delete it (and the now-unused `collapsedGroups`, `groupSessions` import) to keep the file clean.
+
+- [ ] **Step 3: Compile**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. Fix any unused-symbol / import errors (remove `groupSessions`, `CollapsibleHeader`, `collapsedGroups` if the compiler flags them as unused and the project treats warnings as errors; otherwise leave them).
+
+- [ ] **Step 4: Unit tests still green**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL; all tests pass.
+
+- [ ] **Step 5: Assemble the beta variant**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleBeta`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/sessions/ProjectList.kt \
+        app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+git commit -m "feat(projects): Sessions/Projects toggle, flat sessions, project drill-in UI"
+```
+
+---
+
+## Task 6: On-device verification
+
+**Files:** none (manual verification against a real/mock gateway on the USB-connected device).
+
+- [ ] **Step 1: Install the beta build**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:installBeta`
+Expected: installs `com.hermes.client.beta`.
+
+- [ ] **Step 2: Verify Sessions mode**
+  - Chats opens in **Sessions** mode (default). List is flat, newest first; Pinned section on top; search filters by title/workspace; the profile switcher is visible; tapping a session opens the chat.
+
+- [ ] **Step 3: Verify the toggle + Projects overview**
+  - Tap **Projects**: the profile switcher is replaced by a `Projects · <profile>` caption; project cards render (explicit projects tinted by their color, auto projects with the accent-tinted folder + "auto"); session/repo counts show. Empty gateway → "No projects" state with Reload.
+
+- [ ] **Step 4: Verify drill-in + open**
+  - Tap a project → its sessions appear (single-lane = flat; multi-repo/branch = sub-headers). Tap a session → chat opens. Back row returns to the overview.
+
+- [ ] **Step 5: Verify persistence + accent + errors**
+  - Switch to Projects, navigate away and back (and cold-restart) → still on Projects. Per-tenant accent tints the segmented control, cards, and back row. Kill the gateway and Reload → error/retry row shows in Projects mode while Sessions mode is unaffected.
+
+- [ ] **Step 6: Record results** in the task ledger / PR description (what was exercised, any gaps). No commit.
+
+---
+
+## Notes for the executor
+
+- The pre-flight scan found no plan-vs-spec conflicts. One deliberate refinement of the spec: `icon` is not carried into the domain model (YAGNI) — projects use a folder glyph tinted by `color`/accent. This is intentional, not an omission.
+- Single-profile Projects is by design (the gateway RPC has no profile param). Opening a project-view session relies on the connected gateway's profile matching the active profile; this is the documented limitation, not a bug to fix here.
+- Do not add `all`-pending, project management, or a `profile` param — all explicitly out of scope.

--- a/docs/superpowers/specs/2026-07-10-tiered-approvals-design.md
+++ b/docs/superpowers/specs/2026-07-10-tiered-approvals-design.md
@@ -1,0 +1,154 @@
+# Touch-native tiered approvals — design (Phase 3)
+
+**Status:** approved design, ready for implementation plan
+**Branch:** `feature/tiered-approvals` → PR into `dev`
+**Roadmap:** Phase 3 of `docs/ideas/improvement-roadmap-2026-07-07.md` ("touch-native, tiered approvals")
+
+## Goal
+
+Make agent approvals correct and touch-native on a phone. Today an approval reaches the app when
+the gateway flags a **dangerous** command (low-risk commands are auto-approved server-side), but the
+app's approval UI is broken and shows nothing actionable. Phase 3 fixes the wire format so approvals
+work and show the command, then layers a **two-tier bottom-sheet** interaction on top: a normal
+"Standard" tier and an "Elevated" tier (Tirith-flagged) whose *Allow* requires a deliberate
+slide-to-confirm. No new gateway endpoints — everything uses fields and scopes the gateway already
+sends.
+
+## Current state (why the fix is needed)
+
+- **Request (in):** the app parses `approval.request` by reading a `prompt` payload key
+  (`ChatUiState.kt:86`, `ApprovalRequest(val prompt: String)` at `ChatUiState.kt:10`). The gateway
+  payload has **no `prompt`** — it sends `command`, `pattern_key`, `pattern_keys`, `description`,
+  `allow_permanent` (`tools/approval.py`; emitted via `_emit_approval_request`, `server.py:1150`). So
+  the current in-chat `ApprovalDialog` (`ChatComponents.kt:431`, shown from `ChatScreen.kt:490`)
+  renders an **empty** body.
+- **Response (out):** the app sends `approval.respond {session_id, approved:Boolean}`
+  (`ChatRepository.kt:126`). The gateway's `@method("approval.respond")` (`server.py:10186`) reads
+  **`choice`** (default `"deny"`) and **`all`** and ignores `approved` — so a tapped "Approve"
+  degrades to **deny**.
+- **Notification:** `NotificationMapper.kt` builds Approve/Deny actions whose receiver
+  (`NotificationActionReceiver.kt:21`) calls the same `respondApproval(sid, approve:Boolean)`.
+
+## Gateway capabilities we build on (already exist)
+
+- **Request payload fields:** `command` (redacted), `pattern_key` / `pattern_keys` (danger-category
+  ids, e.g. `"recursive delete"`, `"force push"`), `description` (human danger text),
+  `allow_permanent` (Boolean; `false` = Tirith security scanner flagged it → *Always* must not be
+  offered).
+- **Response scopes:** `approval.respond {choice, all}` with `choice ∈ once | session | always | deny`.
+  `once` = allow this time; `session` = allow for the rest of this run; `always` = permanent allowlist
+  (`config.yaml`); `deny` = block. `all` resolves every pending approval in the session.
+
+## Design
+
+### A. Wire-format fix (foundation)
+
+- Expand the domain model:
+  ```kotlin
+  data class ApprovalRequest(
+      val command: String,
+      val description: String,
+      val patternKeys: List<String>,
+      val allowPermanent: Boolean,
+  )
+  ```
+  Parse from the `approval.request` payload (`command`, `description`, `pattern_keys`,
+  `allow_permanent`; `pattern_key` as a single-element fallback). Missing fields degrade gracefully
+  (empty string / empty list / `allowPermanent=false` — the safe default).
+- Replace the boolean response with a scoped one:
+  ```kotlin
+  enum class ApprovalChoice(val wire: String) { ONCE("once"), SESSION("session"), ALWAYS("always"), DENY("deny") }
+  suspend fun ChatRepository.respondApproval(sessionId: String, choice: ApprovalChoice)
+  // sends {session_id, choice: choice.wire, approved: choice != DENY}
+  ```
+  **Send both `choice` and `approved`** (the derived boolean) so the response works whether the
+  gateway reads the new `choice` field or the old `approved` one — a cheap hedge against the
+  gateway-version skew noted below. The gateway ignores whichever field it doesn't use.
+  `ChatViewModel` exposes `respondApproval(choice: ApprovalChoice)` (replaces `approve(Boolean)`),
+  clearing `pendingApproval` first. `all` is **not** sent in v1 (single approval at a time).
+
+### B. Tier logic (pure, unit-tested)
+
+```kotlin
+enum class ApprovalTier { STANDARD, ELEVATED }
+fun tierFor(req: ApprovalRequest): ApprovalTier = if (req.allowPermanent) STANDARD else ELEVATED
+fun allowedScopes(tier: ApprovalTier): List<ApprovalChoice> = when (tier) {
+    STANDARD -> listOf(ONCE, SESSION, ALWAYS)   // + DENY always available
+    ELEVATED -> listOf(ONCE, SESSION)           // no ALWAYS; DENY primary
+}
+```
+
+### C. Bottom sheet (`ApprovalSheet`, per-tenant accent)
+
+A modal bottom sheet (replaces the center `AlertDialog`), shown from `pendingApproval`:
+- **Header:** tier badge + primary pattern label — e.g. *"Elevated · recursive delete"* (Standard
+  tinted with the profile accent; Elevated tinted with an error/red tone).
+- **Body:** `command` in a scrollable monospace block (it's the redacted command); `description`
+  below it.
+- **Actions (thumb zone):**
+  - **Standard:** filled buttons **Allow once** / **Allow this run** / **Always allow**, and a text
+    **Deny**. Each maps to the `ApprovalChoice` and calls `respondApproval`.
+  - **Elevated:** **Deny** is the prominent (filled) action; *Always* is absent; **Allow** is a
+    `SlideToConfirm` track labelled *"→ slide to allow once"* (with a small toggle for *this run* vs
+    *once*). Completing the slide fires `respondApproval(ONCE|SESSION)`.
+- Dismissing the sheet (scrim/back) does **nothing** to the pending approval (no accidental
+  approve/deny); it re-opens from `pendingApproval` until resolved.
+
+### D. Reusable `SlideToConfirm` composable
+
+A horizontal track with a draggable thumb; drag past ~90% triggers `onConfirm()` and animates to
+"done"; releasing before that snaps back. Accent-tinted. Used for Elevated *Allow*; independently
+unit-testable at the state-holder level (a pure progress→confirmed transition).
+
+### E. Notification path
+
+Notifications can't host a slide, so:
+- **Standard:** inline **Allow once** (`choice=once`) + **Deny** actions; tapping the body opens the
+  app to the sheet for Session/Always.
+- **Elevated:** **Deny** + **Open** only — no inline allow, forcing the deliberate in-app slide. The
+  mapper must therefore carry enough to know the tier: include `allow_permanent` in the
+  `approval.request` → notification mapping so `NotificationMapper` picks the action set.
+- The `NotificationActionReceiver` sends `respondApproval(sid, ONCE|DENY)` (choice-based, not boolean).
+
+## Data flow
+
+```
+approval.request {command, description, pattern_keys, allow_permanent, session_id}
+  → ServerEvent → ChatUiState.reduce → pendingApproval: ApprovalRequest
+  → ChatScreen shows ApprovalSheet (tier = tierFor(req))
+  → user picks scope (Standard buttons) or slides (Elevated)
+  → ChatViewModel.respondApproval(choice) → ChatRepository.respondApproval → WS approval.respond {session_id, choice}
+Notification (bg): approval.request → NotificationMapper (tier-aware actions) → NotificationActionReceiver → respondApproval(choice)
+```
+
+## Components / files
+
+- `ui/chat/ChatUiState.kt` — expand `ApprovalRequest`; update the `approval.request` reduce to parse the new fields.
+- `ui/chat/ApprovalTier.kt` *(new)* — `ApprovalTier`, `ApprovalChoice`, `tierFor`, `allowedScopes` (pure).
+- `data/repository/ChatRepository.kt` — `respondApproval(sessionId, choice: ApprovalChoice)` (replaces the boolean).
+- `ui/chat/ChatViewModel.kt` — `respondApproval(choice)` (replaces `approve(Boolean)`).
+- `ui/chat/ApprovalSheet.kt` *(new)* — the bottom sheet; replaces `ApprovalDialog` usage in `ChatScreen.kt`.
+- `ui/components/SlideToConfirm.kt` *(new)* — reusable slide-to-confirm.
+- `notifications/NotificationMapper.kt` + `NotificationModels.kt` — tier-aware approval actions (add an `allow once` action; Elevated → Deny/Open only); carry `allowPermanent`.
+- `notifications/NotificationActionReceiver.kt` — send `ApprovalChoice` instead of a boolean.
+
+## Testing
+
+- **Pure unit tests:** `tierFor` / `allowedScopes` (Standard vs Elevated); `ApprovalRequest` parsing from a representative payload (and graceful defaults when fields are missing); `respondApproval` sends `{session_id, choice}` with the right wire value; `NotificationMapper` returns the correct action set per tier; `SlideToConfirm` progress→confirmed transition.
+- **On-device:** drive both tiers via the harness mock emitting a Standard (`allow_permanent=true`) and an Elevated (`allow_permanent=false`) `approval.request`; verify the sheet, the three Standard scopes, the Elevated slide-to-allow + Deny-primary, and that the correct `choice` reaches the WS. Verify the notification action sets per tier.
+
+## Out of scope (v1 — YAGNI)
+
+- Resolve-**all**-pending (`all:true`) — the gateway supports it; deferred until multiple concurrent approvals are common.
+- Any new gateway field (explicit numeric risk level, reversibility hint, free-text deny reason).
+- Client-side severity taxonomy from `pattern_keys` beyond the label — tiering stays on the
+  gateway's `allow_permanent` bit (honest, no invented severity).
+
+## Risks / notes
+
+- **Gateway skew:** this design targets the `approval.respond {choice}` + `command/description/allow_permanent`
+  contract in the current `~/.hermes/hermes-agent` checkout. Verify against the running gateway before
+  promotion (the fix is a no-op improvement if the gateway ever also accepted `approved`, but the
+  `choice` form is the authoritative one).
+- The `always` scope writes a permanent allowlist entry in the gateway's `config.yaml` — intended, and
+  only offered for Standard (`allow_permanent=true`).

--- a/docs/superpowers/specs/2026-07-13-session-project-view-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-13-session-project-view-toggle-design.md
@@ -1,0 +1,194 @@
+# Session ⇆ Project view toggle — design
+
+**Status:** approved design, ready for implementation plan
+**Branch:** `feature/project-view-toggle` → PR into `dev`
+**Scope:** Browse-only, full desktop parity via the gateway's `projects.*` JSON-RPC. NO gateway changes.
+
+## Goal
+
+Give the Android **Chats** screen a segmented toggle between two modes, mirroring the desktop
+client's session/project switch:
+
+- **Sessions** — a flat, most-recent-first list of chats (the "session view" Android lacks today;
+  the current screen is *always* grouped by workspace basename).
+- **Projects** — the gateway's real, server-authoritative project tree (`projects.tree`), with
+  drill-in into a project's sessions (`projects.project_sessions`). Grouping is identical to the
+  desktop's: explicit user projects from `projects.db`, auto git-repo projects, discovered repos,
+  each with repo → branch-lane structure.
+
+Browse-only: no creating/editing/archiving/deleting projects from the phone in v1 (that stays on
+desktop).
+
+## Current state
+
+- `ui/sessions/SessionsScreen.kt` renders a `LazyColumn` grouped **Profile → Workspace** via the pure
+  `SessionGrouping.groupSessions(...)`; "workspace" = basename of the session `cwd`
+  (`domain/Mappers.kt` drops the full path). There is **no** flat session list and **no** toggle.
+- Sessions are loaded cross-profile over REST: `SessionRepository.listAllProfiles()` →
+  `HermesRestApi.profileSessions()` → `GET /api/profiles/sessions?limit=500&order=recent`. The
+  `SessionDto` already parses `cwd` (and `source`, `profile`, `last_active`, …).
+- A live WS gateway connection already exists on this screen: `SessionsViewModel.init` calls
+  `chat.connect()`. The generic request/response entry point is
+  `HermesGatewayClient.call(method, params): JsonElement` (correlates by numeric JSON-RPC `id`;
+  waits on `readyGate`). Existing non-chat precedent: `commands.catalog` in `ChatRepository`.
+- `ProfileManager` (`@Singleton`, `active: StateFlow<String?>`, `switchTo`) is the active-profile
+  source of truth; `SessionsViewModel` already exposes `activeProfile` / `switchProfile`, and a
+  `ProfileSwitcher` chip row sits in the top bar.
+
+## Gateway contract (already exists — consumed read-only)
+
+WS JSON-RPC over `/api/ws` (no REST equivalent exists for either call).
+
+### `projects.tree`
+- **Params:** `preview_limit` (default 3), `session_limit` (default 2000). **No `profile` param.**
+- **Profile scope:** single-profile — reads the `projects.db` + `state.db` of whatever profile the
+  connected gateway process is bound to (`HERMES_HOME`). Not selectable per-call.
+- **Returns:** `{ projects: ProjectNode[], active_id: String?, scoped_session_ids: String[] }`.
+
+`ProjectNode` (camelCase where noted):
+```
+{ id, label, path, color?, icon?, isAuto: Bool, sessionCount: Int,
+  lastActive: Double?, repos: Repo[], previewSessions: SessionRow[] }
+```
+- `id`: explicit projects → `p_<hex>`; auto/discovered → the repo-root **path**.
+- `label` (not `name`); `color`/`icon` null for auto/discovered.
+- On the tree (overview) call, lane `sessions` arrays are **empty** (counts preserved);
+  `previewSessions` holds up to `preview_limit` newest rows.
+
+`Repo`:
+```
+{ id, label, path, sessionCount: Int, groups: Lane[] }
+```
+`Lane` (branch lane):
+```
+{ id, label, path, isMain: Bool, isKanban: Bool, sessions: SessionRow[] }
+```
+
+`SessionRow` (the `_project_tree_row` projection):
+```
+id, parent_session_id, title, preview, started_at, ended_at, last_active,
+source, archived, message_count, tool_call_count, input_tokens, output_tokens,
+model, cwd, git_branch, git_repo_root
+```
+(`_lineage_root_id`, `is_active` also present; `is_active` always false — ignored client-side.)
+
+### `projects.project_sessions`
+- **Params:** `project_id` (**required**; must equal a node `id` from `projects.tree` — `p_<hex>` or
+  the repo-root path), `session_limit` (default 5000). No `profile`, no pagination beyond the limit.
+- **Returns:** `{ project: ProjectNode? }` — a single node, **hydrated** (lane `sessions` fully
+  populated with `SessionRow`s), `previewSessions` empty, discovered tier excluded.
+
+## Design
+
+### A. View mode (pure, persisted)
+```kotlin
+enum class ViewMode { SESSIONS, PROJECTS }
+```
+- Held as `viewMode: StateFlow<ViewMode>` in `SessionsViewModel`, default `SESSIONS`.
+- Persisted device-local (same mechanism as `GroupExpansionStore` / a small DataStore pref) so the
+  choice survives navigation and restart.
+
+### B. Sessions mode (flat recency)
+- Reuse the already-loaded cross-profile list. Render a flat list sorted by `lastActive`
+  descending (newest first), keeping the existing **Pinned** section on top and the existing search
+  filter. No workspace grouping in this mode.
+- The current `groupSessions` Profile→Workspace grouping is **replaced** by these two modes (it is
+  not retained as a third mode — YAGNI). Profile is still surfaced per-row via the existing
+  supporting-text prefix, and the profile switcher stays visible in Sessions mode.
+
+### C. Projects mode (server tree + drill-in)
+- On entering Projects mode (or pull-to-refresh), call `ProjectsRepository.tree()`.
+- **Overview:** a list of project cards — accent-tinted; show `label`, `color`/`icon` (fallback to a
+  default folder icon/accent when null), `sessionCount`, and a relative `lastActive`. Auto/discovered
+  projects render with the neutral default styling (`isAuto = true`, no color).
+- **Drill-in:** tapping a project sets `projectScope = id` and calls
+  `ProjectsRepository.projectSessions(id)`. Render the project's sessions:
+  - If the project has a single lane, show a flat session list.
+  - If it has multiple repos/lanes, show lane sub-headers (repo label + branch label) with sessions
+    under each (reuse the existing collapsible-header composable).
+  - A back row at top (mirrors desktop `ProjectBackRow`) calls `exitProject()` → clears
+    `projectScope` back to the overview.
+- Tapping a session navigates `chat/{id}` (existing path). Because the tree is single-profile
+  (see D), no `prepareOpen`/profile switch is needed before opening from Projects mode — the
+  session belongs to the connected gateway's profile.
+
+### D. Profile scoping (honest limitation)
+`projects.tree` takes no `profile` param and reflects only the connected gateway's bound profile.
+Therefore in **Projects** mode:
+- The **profile switcher is hidden**, and a small caption reads `Projects · <profile>` using the
+  app's current active profile as the best-available label.
+- Switching profiles does not re-scope the project tree. Matching the desktop's per-profile behavior
+  fully would require a gateway change (a `profile` param on `projects.tree`) — explicitly out of
+  scope for v1 and noted as the gateway follow-up.
+
+Sessions mode is unaffected — it stays cross-profile over REST as today.
+
+### E. Toggle UI
+- A Material3 `SingleChoiceSegmentedButtonRow` ("Sessions" | "Projects"), placed in the top-bar
+  `Column` directly under the profile switcher (copy the `ui/activity/FeedTabs.kt` pattern; per-tenant
+  accent). Selecting a segment updates `viewMode`.
+
+### F. Errors & empty states
+- Projects fetch failure (RPC error / not connected): show an inline retry row; do not crash the
+  screen or affect Sessions mode. Reuse the screen's existing error affordance.
+- Empty tree (no projects): friendly empty state ("No projects yet — projects are created on
+  desktop").
+- Drill-in returning `project: null`: treat as empty and offer back.
+
+## Components / files
+
+- `data/network/Dtos.kt` — add `ProjectTreeDto`, `ProjectNodeDto`, `RepoDto`, `LaneDto`; reuse a
+  session-row DTO for `previewSessions` and lane `sessions` (carrying `cwd`/`git_branch`/`git_repo_root`).
+- `data/repository/ProjectsRepository.kt` *(new)* — `suspend fun tree(previewLimit, sessionLimit): ProjectTree`,
+  `suspend fun projectSessions(id, sessionLimit): ProjectNode?`; wraps `client.call(...)`, parses DTO → domain.
+- `di/AppModule.kt` — `@Provides @Singleton` for `ProjectsRepository(client)`.
+- `domain/Models.kt` + `domain/Mappers.kt` — `Project`, `ProjectRepo`, `ProjectLane` domain types;
+  extend `Session` with full `cwd`, `gitBranch`, `gitRepoRoot` (set `cwd` from the already-parsed DTO field).
+- `ui/sessions/SessionsViewModel.kt` — `ViewMode`, `viewMode` StateFlow (persisted), `projectTree`,
+  `projectScope`, `projectsLoading`/`projectsError` state; `setViewMode`, `loadProjectTree`,
+  `enterProject`, `exitProject`.
+- `ui/sessions/SessionsScreen.kt` — segmented toggle; branch body on `viewMode`; hide `ProfileSwitcher`
+  + show caption in Projects mode; wire card taps / drill-in / back / session open.
+- `ui/sessions/ProjectList.kt` *(new)* — project card + project-scope (drill-in) session list composables.
+
+## Testing
+
+**Pure/unit (JVM):**
+- DTO → domain mapping: full node, missing `color`/`icon` → null, `isAuto` projects, nested
+  repos/lanes, `previewSessions` and hydrated lane `sessions`; graceful defaults for absent fields.
+- `ProjectsRepository`: mocked `HermesGatewayClient.call` returns fake tree/project JSON;
+  `coVerify { call("projects.tree", …) }` and `call("projects.project_sessions", match { project_id })`.
+- `SessionsViewModel`: `viewMode` toggle + persistence; `enterProject`/`exitProject` scope reducer;
+  Sessions-mode flat-recency sort (newest first, pinned on top).
+- Follows existing `ChatRepositoryTest`, `SessionGroupingTest`, `SessionsViewModelTest` patterns.
+
+**On-device (emulator vs mock, per-tenant accent):**
+- Toggle flips Sessions ⇆ Projects; choice persists across navigation.
+- Projects overview shows cards (explicit colored + auto neutral); drill into a project → its
+  sessions (single-lane flat; multi-lane with sub-headers); tap a session → opens chat; back returns
+  to overview.
+- Profile switcher hidden + `Projects · <profile>` caption shown in Projects mode; visible again in
+  Sessions mode.
+- Empty state (no projects) and RPC-error retry row render correctly.
+
+## Build / CI
+
+`JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`;
+`:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. Feature branch → PR into
+`dev` (gitleaks gate before push).
+
+## Out of scope (v1 — YAGNI)
+
+- Any project **management** (create/rename/add-folder/set-primary/archive/delete) — desktop only.
+- A `profile` param on `projects.tree` (would let Projects mode follow the active profile) — gateway
+  follow-up.
+- Retaining the old Profile→Workspace basename grouping as a separate third mode.
+- Kanban/board affordances implied by lane `isKanban` — surfaced as a plain lane in v1.
+
+## Risks / notes
+
+- **Gateway version skew:** targets the `projects.tree` / `projects.project_sessions` contract in the
+  current `~/.hermes/hermes-agent` checkout. If a connected gateway predates these RPCs, the call
+  errors → Projects mode shows the error/retry row (Sessions mode unaffected). Verify against the
+  running gateway before promotion.
+- **Single-profile projects** is the one place this intentionally diverges from the desktop; see D.


### PR DESCRIPTION
Promotes the `0.1.50` beta cycle to production (stable `v0.1.50`).

## Included since v0.1.49
- **Touch-native tiered approvals** — bottom-sheet approvals with Standard scopes + Elevated slide-to-confirm; tier-aware notification actions.
- **Sessions ⇆ Projects toggle** on the Chats screen — flat recency Sessions list + a Projects view.
- **Projects across all profiles** — Projects is derived client-side from the cross-profile session list (grouped by git repo / cwd), tenant-badged, since the gateway's `projects.tree` is pinned to the launch profile (follow-up: #95).
- **Fixes:** load Projects on cold launch; exclude subagent/tool/messaging sources from the session list (desktop parity); honest cross-profile caption; RTL back icon; drill-in polish.

## Gates
- 245 unit tests green; assembleBeta green; gitleaks clean on all pushes.
- No open HIGH/CRITICAL Dependabot alerts.
- Verified on-device (emulator against the live gateway): toggle, cross-profile projects, drill-in, open-with-profile-switch.

Tag `v0.1.50` on merge to publish the signed release APK.
