### PR TITLE
feat: act on results from the notification shade (inline reply + approve-for-session)

### DIFF
--- a/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/ChatRepository.kt
@@ -132,9 +132,10 @@ class ChatRepository(private val client: HermesGatewayClient) {
         })
     }
 
-    suspend fun respondClarify(sessionId: String, answer: String) {
+    suspend fun respondClarify(sessionId: String, requestId: String, answer: String) {
         client.call("clarify.respond", buildJsonObject {
             put("session_id", sessionId)
+            put("request_id", requestId)
             put("answer", answer)
         })
     }

--- a/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+++ b/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.RemoteInput
 import com.hermes.client.MainActivity
 import com.hermes.client.R
 
@@ -49,7 +50,16 @@ class HermesNotifier(private val context: Context) {
             .setGroup(spec.groupKey)
             .setContentIntent(openIntent(spec.route, spec.id))
         spec.actions.forEach { a ->
-            b.addAction(0, a.label, actionIntent(a, spec.id))
+            if (a.reply) {
+                val remoteInput = RemoteInput.Builder(Notif.KEY_REPLY_TEXT).setLabel("Reply…").build()
+                val action = NotificationCompat.Action.Builder(0, a.label, replyIntent(a, spec.id))
+                    .addRemoteInput(remoteInput)
+                    .setAllowGeneratedReplies(false)
+                    .build()
+                b.addAction(action)
+            } else {
+                b.addAction(0, a.label, actionIntent(a, spec.id))
+            }
         }
         if (mgr.areNotificationsEnabled()) {
             mgr.notify(spec.id, b.build())
@@ -73,6 +83,22 @@ class HermesNotifier(private val context: Context) {
             putExtra("notif_id", notifId)
         }
         return PendingIntent.getBroadcast(context, (a.action + a.sessionId).hashCode(), intent, pendingFlags())
+    }
+
+    private fun replyIntent(a: NotifAction, notifId: Int): PendingIntent {
+        val intent = Intent(context, NotificationActionReceiver::class.java).apply {
+            action = a.action
+            putExtra("session_id", a.sessionId)
+            putExtra("notif_id", notifId)
+        }
+        // Direct-reply requires FLAG_MUTABLE so the system can attach the RemoteInput results.
+        // The intent is explicit (our own receiver), so it can't be redirected — mutability is safe.
+        return PendingIntent.getBroadcast(
+            context,
+            (a.action + a.sessionId).hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
     }
 
     private fun pendingFlags() = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE

--- a/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+++ b/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
@@ -90,6 +90,7 @@ class HermesNotifier(private val context: Context) {
             action = a.action
             putExtra("session_id", a.sessionId)
             putExtra("notif_id", notifId)
+            putExtra("request_id", a.requestId.orEmpty())
         }
         // Direct-reply requires FLAG_MUTABLE so the system can attach the RemoteInput results.
         // The intent is explicit (our own receiver), so it can't be redirected — mutability is safe.

--- a/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+++ b/app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
@@ -95,7 +95,9 @@ class HermesNotifier(private val context: Context) {
         // The intent is explicit (our own receiver), so it can't be redirected — mutability is safe.
         return PendingIntent.getBroadcast(
             context,
-            (a.action + a.sessionId).hashCode(),
+            // Distinct namespace from actionIntent()'s button request code so a reply (MUTABLE) and a
+            // button (IMMUTABLE) can never share PendingIntent identity (would crash on Android 12+).
+            ("reply:" + a.action + a.sessionId).hashCode(),
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
         )

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -31,8 +31,9 @@ fun receiverActionFor(action: String?): ReceiverAction = when (action) {
 
 /**
  * Handles a notification action headlessly: Allow-once/Session/Deny → `approval.respond`; an inline
- * Reply → `prompt.submit`. Runs a single RPC on a background scope; only clears the notification
- * once the RPC succeeds, so a failed action isn't silently lost.
+ * Reply → `clarify.respond` (answers the pending clarify request, doesn't start a new turn). Runs a
+ * single RPC on a background scope; only clears the notification once the RPC succeeds, so a failed
+ * action isn't silently lost.
  */
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
@@ -57,7 +58,10 @@ class NotificationActionReceiver : BroadcastReceiver() {
                     withTimeout(8_000) {
                         when (ra) {
                             is ReceiverAction.Approval -> chat.respondApproval(sid, ra.choice)
-                            ReceiverAction.Reply -> chat.submit(sid, replyText!!)
+                            ReceiverAction.Reply -> {
+                                val requestId = intent.getStringExtra("request_id").orEmpty()
+                                chat.respondClarify(sid, requestId, replyText!!)
+                            }
                             ReceiverAction.Unknown -> Unit // unreachable (returned above)
                         }
                     }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt
@@ -3,6 +3,7 @@ package com.hermes.client.notifications
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.core.app.RemoteInput
 import com.hermes.client.data.diagnostics.DebugLog
 import com.hermes.client.data.repository.ChatRepository
 import com.hermes.client.ui.chat.ApprovalChoice
@@ -13,7 +14,26 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 
-/** Handles the Allow once/Deny actions on an approval notification by sending the approval RPC. */
+/** What a received notification-action intent should do. Pure/testable, no Android deps. */
+sealed interface ReceiverAction {
+    data class Approval(val choice: ApprovalChoice) : ReceiverAction
+    data object Reply : ReceiverAction
+    data object Unknown : ReceiverAction
+}
+
+fun receiverActionFor(action: String?): ReceiverAction = when (action) {
+    Notif.ACTION_ALLOW_ONCE -> ReceiverAction.Approval(ApprovalChoice.ONCE)
+    Notif.ACTION_ALLOW_SESSION -> ReceiverAction.Approval(ApprovalChoice.SESSION)
+    Notif.ACTION_DENY -> ReceiverAction.Approval(ApprovalChoice.DENY)
+    Notif.ACTION_REPLY -> ReceiverAction.Reply
+    else -> ReceiverAction.Unknown
+}
+
+/**
+ * Handles a notification action headlessly: Allow-once/Session/Deny → `approval.respond`; an inline
+ * Reply → `prompt.submit`. Runs a single RPC on a background scope; only clears the notification
+ * once the RPC succeeds, so a failed action isn't silently lost.
+ */
 @AndroidEntryPoint
 class NotificationActionReceiver : BroadcastReceiver() {
     @Inject lateinit var chat: ChatRepository
@@ -22,22 +42,30 @@ class NotificationActionReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         val sid = intent.getStringExtra("session_id") ?: return
         val notifId = intent.getIntExtra("notif_id", -1)
-        val choice = when (intent.action) {
-            Notif.ACTION_ALLOW_ONCE -> ApprovalChoice.ONCE
-            else -> ApprovalChoice.DENY
-        }
+        val ra = receiverActionFor(intent.action)
+        val replyText = RemoteInput.getResultsFromIntent(intent)
+            ?.getCharSequence(Notif.KEY_REPLY_TEXT)?.toString()?.trim()
+
+        // Nothing actionable, or a blank reply → leave the notification up (retryable) and stop.
+        if (ra is ReceiverAction.Unknown) return
+        if (ra is ReceiverAction.Reply && replyText.isNullOrBlank()) return
+
         val pending = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                runCatching { withTimeout(8_000) { chat.respondApproval(sid, choice) } }
-                    .onSuccess {
-                        // Only clear the notification once the RPC actually succeeded — on
-                        // failure, leave it so the action isn't silently lost.
-                        if (notifId != -1) notifier.cancel(notifId)
+                runCatching {
+                    withTimeout(8_000) {
+                        when (ra) {
+                            is ReceiverAction.Approval -> chat.respondApproval(sid, ra.choice)
+                            ReceiverAction.Reply -> chat.submit(sid, replyText!!)
+                            ReceiverAction.Unknown -> Unit // unreachable (returned above)
+                        }
                     }
-                    .onFailure { e ->
-                        DebugLog.log("notif", "approval response failed session=$sid choice=$choice: ${e.message}")
-                    }
+                }.onSuccess {
+                    if (notifId != -1) notifier.cancel(notifId)
+                }.onFailure { e ->
+                    DebugLog.log("notif", "action failed session=$sid action=${intent.action}: ${e.message}")
+                }
             } finally {
                 pending.finish()
             }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -35,6 +35,7 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
                 actions = if (elevated) listOf(NotifAction("Deny", Notif.ACTION_DENY, sid))
                           else listOf(
                               NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid),
+                              NotifAction("Session", Notif.ACTION_ALLOW_SESSION, sid),
                               NotifAction("Deny", Notif.ACTION_DENY, sid),
                           ),
                 groupKey = "approval",
@@ -44,7 +45,9 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
         Notif.EVENT_CLARIFY -> if (!prefs.approvals) null else NotificationSpec(
             id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Needs your input",
             body = event.str("question") ?: "The agent has a question.",
-            route = "chat/$sid", actions = emptyList(), groupKey = "approval",
+            route = "chat/$sid",
+            actions = listOf(NotifAction("Reply", Notif.ACTION_REPLY, sid, reply = true)),
+            groupKey = "approval",
         )
         // Run finished: `message.complete` is the end-of-turn event on /api/ws (the app also uses it
         // to stop the "generating" spinner). Only notify when backgrounded; the per-session id above

--- a/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt
@@ -46,7 +46,7 @@ fun toNotificationSpec(event: ServerEvent, prefs: NotificationPrefs, appInForegr
             id = id, channelId = Notif.CHANNEL_APPROVALS, title = "Needs your input",
             body = event.str("question") ?: "The agent has a question.",
             route = "chat/$sid",
-            actions = listOf(NotifAction("Reply", Notif.ACTION_REPLY, sid, reply = true)),
+            actions = listOf(NotifAction("Reply", Notif.ACTION_REPLY, sid, reply = true, requestId = event.str("request_id"))),
             groupKey = "approval",
         )
         // Run finished: `message.complete` is the end-of-turn event on /api/ws (the app also uses it

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -7,8 +7,16 @@ data class NotificationPrefs(
     val runFinished: Boolean = true,
 )
 
-/** An inline notification action (Allow once/Deny) carrying the target session. */
-data class NotifAction(val label: String, val action: String, val sessionId: String)
+/**
+ * An inline notification action carrying the target session. [reply] = true marks a direct-reply
+ * action (Android RemoteInput text field) rather than a plain button.
+ */
+data class NotifAction(
+    val label: String,
+    val action: String,
+    val sessionId: String,
+    val reply: Boolean = false,
+)
 
 /** A platform-independent description of a notification, so mapping stays unit-testable. */
 data class NotificationSpec(
@@ -41,5 +49,10 @@ object Notif {
     const val EVENT_ERROR = "error"
 
     const val ACTION_ALLOW_ONCE = "allow_once"
+    const val ACTION_ALLOW_SESSION = "allow_session"
     const val ACTION_DENY = "deny"
+    const val ACTION_REPLY = "reply"
+
+    // RemoteInput result key for the inline reply on a clarify ("Needs your input") notification.
+    const val KEY_REPLY_TEXT = "reply_text"
 }

--- a/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
+++ b/app/src/main/java/com/hermes/client/notifications/NotificationModels.kt
@@ -16,6 +16,7 @@ data class NotifAction(
     val action: String,
     val sessionId: String,
     val reply: Boolean = false,
+    val requestId: String? = null,
 )
 
 /** A platform-independent description of a notification, so mapping stays unit-testable. */

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -15,7 +15,7 @@ data class ApprovalRequest(
     val patternKeys: List<String>,
     val allowPermanent: Boolean,
 )
-data class ClarifyRequest(val question: String, val options: List<String>)
+data class ClarifyRequest(val question: String, val options: List<String>, val requestId: String = "")
 
 data class ChatUiState(
     val messages: List<ChatMessage> = emptyList(),
@@ -101,7 +101,9 @@ fun ChatUiState.reduce(event: ServerEvent): ChatUiState {
             ),
         )
         "clarify.request" -> state.copy(
-            pendingClarify = ClarifyRequest(event.str("question") ?: "", emptyList()),
+            pendingClarify = ClarifyRequest(
+                event.str("question") ?: "", emptyList(), event.str("request_id") ?: "",
+            ),
         )
         "error" -> state.copy(
             messages = state.messages + ChatMessage(

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -254,8 +254,9 @@ class ChatViewModel @Inject constructor(
     }
 
     fun clarify(answer: String) {
+        val requestId = _state.value.pendingClarify?.requestId ?: ""
         _state.value = _state.value.copy(pendingClarify = null)
-        viewModelScope.launch { runCatching { chat.respondClarify(sessionId, answer) } }
+        viewModelScope.launch { runCatching { chat.respondClarify(sessionId, requestId, answer) } }
     }
 
     /** Appends a non-fatal error as a system message and stops the generating spinner. */

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -23,19 +23,34 @@ class NotificationMapperTest {
         assertEquals(Notif.CHANNEL_APPROVALS, spec.channelId)
         assertEquals("chat/s1", spec.route)
         assertTrue(spec.body.contains("Delete file?"))
-        assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
+        assertEquals(
+            listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_ALLOW_SESSION, Notif.ACTION_DENY),
+            spec.actions.map { it.action },
+        )
+        assertTrue(spec.actions.none { it.reply })
         assertTrue(spec.actions.all { it.sessionId == "s1" })
     }
 
-    @Test fun standard_approval_offers_allow_once_and_deny() {
+    @Test fun standard_approval_offers_allow_once_session_and_deny() {
         val e = ServerEvent("approval.request", "s1", buildJsonObject {
             put("session_id", "s1"); put("command", "git push -f"); put("allow_permanent", true)
         })
         val spec = toNotificationSpec(e, on, appInForeground = false)!!
-        assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), spec.actions.map { it.action })
+        assertEquals(
+            listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_ALLOW_SESSION, Notif.ACTION_DENY),
+            spec.actions.map { it.action },
+        )
     }
 
     @Test fun elevated_approval_offers_deny_only() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(listOf(Notif.ACTION_DENY), spec.actions.map { it.action })
+    }
+
+    @Test fun elevated_approval_has_no_session_action() {
         val e = ServerEvent("approval.request", "s1", buildJsonObject {
             put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
         })
@@ -65,7 +80,12 @@ class NotificationMapperTest {
         assertEquals("Needs your input", spec.title)
         assertEquals("Which repo?", spec.body)
         assertEquals("chat/c1", spec.route)
-        assertTrue(spec.actions.isEmpty())
+        assertEquals(1, spec.actions.size)
+        val reply = spec.actions.single()
+        assertEquals(Notif.ACTION_REPLY, reply.action)
+        assertEquals("Reply", reply.label)
+        assertTrue(reply.reply)
+        assertEquals("c1", reply.sessionId)
     }
 
     @Test fun clarify_off_when_approvals_off() {

--- a/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
@@ -75,7 +75,7 @@ class NotificationMapperTest {
     }
 
     @Test fun clarify_notifies_with_question_regardless_of_foreground() {
-        val e = event(Notif.EVENT_CLARIFY, "c1", "question" to "Which repo?")
+        val e = event(Notif.EVENT_CLARIFY, "c1", "question" to "Which repo?", "request_id" to "req-9")
         val spec = toNotificationSpec(e, on, appInForeground = true)!!
         assertEquals("Needs your input", spec.title)
         assertEquals("Which repo?", spec.body)
@@ -86,6 +86,7 @@ class NotificationMapperTest {
         assertEquals("Reply", reply.label)
         assertTrue(reply.reply)
         assertEquals("c1", reply.sessionId)
+        assertEquals("req-9", reply.requestId)
     }
 
     @Test fun clarify_off_when_approvals_off() {

--- a/app/src/test/java/com/hermes/client/notifications/ReceiverActionTest.kt
+++ b/app/src/test/java/com/hermes/client/notifications/ReceiverActionTest.kt
@@ -1,0 +1,28 @@
+package com.hermes.client.notifications
+
+import com.hermes.client.ui.chat.ApprovalChoice
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReceiverActionTest {
+    @Test fun allow_once_maps_to_approval_once() {
+        assertEquals(ReceiverAction.Approval(ApprovalChoice.ONCE), receiverActionFor(Notif.ACTION_ALLOW_ONCE))
+    }
+
+    @Test fun allow_session_maps_to_approval_session() {
+        assertEquals(ReceiverAction.Approval(ApprovalChoice.SESSION), receiverActionFor(Notif.ACTION_ALLOW_SESSION))
+    }
+
+    @Test fun deny_maps_to_approval_deny() {
+        assertEquals(ReceiverAction.Approval(ApprovalChoice.DENY), receiverActionFor(Notif.ACTION_DENY))
+    }
+
+    @Test fun reply_maps_to_reply() {
+        assertEquals(ReceiverAction.Reply, receiverActionFor(Notif.ACTION_REPLY))
+    }
+
+    @Test fun null_and_unknown_map_to_unknown() {
+        assertEquals(ReceiverAction.Unknown, receiverActionFor(null))
+        assertEquals(ReceiverAction.Unknown, receiverActionFor("something_else"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
@@ -103,6 +103,13 @@ class ChatReducerTest {
         assertEquals("rm -rf?", s.pendingApproval?.command)
     }
 
+    @Test fun clarify_request_captures_request_id() {
+        var s = ChatUiState.empty()
+        s = s.reduce(ev("clarify.request") { put("question", "Which repo?"); put("request_id", "req-9") })
+        assertEquals("Which repo?", s.pendingClarify?.question)
+        assertEquals("req-9", s.pendingClarify?.requestId)
+    }
+
     @Test fun thinking_delta_accumulates() {
         var s = ChatUiState.empty()
         s = s.reduce(ev("message.start") { put("message_id", "a1") })

--- a/docs/superpowers/plans/2026-07-16-act-on-result-inline-reply.md
+++ b/docs/superpowers/plans/2026-07-16-act-on-result-inline-reply.md
@@ -1,0 +1,431 @@
+# Act-on-Result: Inline Reply + Broader Approval — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two client-only notification actions — an inline **Reply** to "Needs your input" (`clarify.request`) notifications via Android `RemoteInput` → headless `prompt.submit`, and an **Approve for session** action on standard-tier approval notifications via the existing `approval.respond`.
+
+**Architecture:** All changes live in the existing notification pipeline (`NotificationModels` → `NotificationMapper` → `HermesNotifier` → `NotificationActionReceiver`). The event→spec mapping and the action→intent decision are pure and unit-tested; the `RemoteInput`/`PendingIntent` glue is Android, verified on-device.
+
+**Tech Stack:** Kotlin, AndroidX Core (`NotificationCompat`, `RemoteInput`), Hilt, Coroutines.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-act-on-result-inline-reply-design.md`
+
+## Global Constraints
+
+- Client-only: reuse `ChatRepository.submit(sessionId, text)` (→ `prompt.submit`) and `ChatRepository.respondApproval(sessionId, choice)` (→ `approval.respond`, wire `"session"` already accepted). No gateway edits.
+- Android caps visible notification actions at 3: standard-tier approval is `[Allow once, Session, Deny]`. **No "Always" on the notification.** **Elevated-tier approval unchanged (Deny-only).**
+- Reply is scoped to `clarify.request` only (not `message.complete`).
+- The reply PendingIntent must be `FLAG_MUTABLE` (direct-reply requirement) and **explicit** (targets `NotificationActionReceiver`); button PendingIntents stay `FLAG_IMMUTABLE`.
+- Tests: pure JUnit (`NotificationMapperTest`, new `ReceiverActionTest`). No Compose/instrumentation tests.
+- No AI/assistant attribution in commits or files.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch: `feature/act-on-result-inline-reply` (off `dev`; spec committed at `a1947b8`). All commits land here.
+
+---
+
+### Task 1: Model constants + mapper actions
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationModels.kt`
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt`
+- Test: `app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt`
+
+**Interfaces:**
+- Produces: `NotifAction(label, action, sessionId, reply: Boolean = false)`; constants `Notif.ACTION_REPLY = "reply"`, `Notif.ACTION_ALLOW_SESSION = "allow_session"`, `Notif.KEY_REPLY_TEXT = "reply_text"`. Mapper: `clarify.request` → one reply action; standard-tier `approval.request` → `[Allow once, Session, Deny]`.
+
+- [ ] **Step 1: Update the failing tests**
+
+In `NotificationMapperTest.kt`, make these edits (they will fail until the model/mapper change lands):
+
+Replace the assertion in `approval_makes_high_priority_spec_with_actions` (the `assertEquals(listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_DENY), ...)` line) with:
+```kotlin
+        assertEquals(
+            listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_ALLOW_SESSION, Notif.ACTION_DENY),
+            spec.actions.map { it.action },
+        )
+        assertTrue(spec.actions.none { it.reply })
+```
+
+Replace the whole `standard_approval_offers_allow_once_and_deny` test with:
+```kotlin
+    @Test fun standard_approval_offers_allow_once_session_and_deny() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "git push -f"); put("allow_permanent", true)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(
+            listOf(Notif.ACTION_ALLOW_ONCE, Notif.ACTION_ALLOW_SESSION, Notif.ACTION_DENY),
+            spec.actions.map { it.action },
+        )
+    }
+```
+
+Replace the body of `clarify_notifies_with_question_regardless_of_foreground` (the `assertTrue(spec.actions.isEmpty())` line) with:
+```kotlin
+        assertEquals(1, spec.actions.size)
+        val reply = spec.actions.single()
+        assertEquals(Notif.ACTION_REPLY, reply.action)
+        assertEquals("Reply", reply.label)
+        assertTrue(reply.reply)
+        assertEquals("c1", reply.sessionId)
+```
+
+Add a new test:
+```kotlin
+    @Test fun elevated_approval_has_no_session_action() {
+        val e = ServerEvent("approval.request", "s1", buildJsonObject {
+            put("session_id", "s1"); put("command", "rm -rf /"); put("allow_permanent", false)
+        })
+        val spec = toNotificationSpec(e, on, appInForeground = false)!!
+        assertEquals(listOf(Notif.ACTION_DENY), spec.actions.map { it.action })
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.notifications.NotificationMapperTest"`
+Expected: FAIL — `Notif.ACTION_ALLOW_SESSION`/`ACTION_REPLY` unresolved and/or the action-list assertions mismatch.
+
+- [ ] **Step 3: Update the model**
+
+In `NotificationModels.kt`, change the `NotifAction` data class and add three constants to the `Notif` object.
+
+Replace:
+```kotlin
+/** An inline notification action (Allow once/Deny) carrying the target session. */
+data class NotifAction(val label: String, val action: String, val sessionId: String)
+```
+with:
+```kotlin
+/**
+ * An inline notification action carrying the target session. [reply] = true marks a direct-reply
+ * action (Android RemoteInput text field) rather than a plain button.
+ */
+data class NotifAction(
+    val label: String,
+    val action: String,
+    val sessionId: String,
+    val reply: Boolean = false,
+)
+```
+
+In the `Notif` object, replace:
+```kotlin
+    const val ACTION_ALLOW_ONCE = "allow_once"
+    const val ACTION_DENY = "deny"
+```
+with:
+```kotlin
+    const val ACTION_ALLOW_ONCE = "allow_once"
+    const val ACTION_ALLOW_SESSION = "allow_session"
+    const val ACTION_DENY = "deny"
+    const val ACTION_REPLY = "reply"
+
+    // RemoteInput result key for the inline reply on a clarify ("Needs your input") notification.
+    const val KEY_REPLY_TEXT = "reply_text"
+```
+
+- [ ] **Step 4: Update the mapper**
+
+In `NotificationMapper.kt`, in the `Notif.EVENT_APPROVAL` branch, replace the `actions = ...` expression with (elevated unchanged; standard now includes Session):
+```kotlin
+                actions = if (elevated) listOf(NotifAction("Deny", Notif.ACTION_DENY, sid))
+                          else listOf(
+                              NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid),
+                              NotifAction("Session", Notif.ACTION_ALLOW_SESSION, sid),
+                              NotifAction("Deny", Notif.ACTION_DENY, sid),
+                          ),
+```
+
+In the `Notif.EVENT_CLARIFY` branch, replace `actions = emptyList()` with a single reply action:
+```kotlin
+            route = "chat/$sid",
+            actions = listOf(NotifAction("Reply", Notif.ACTION_REPLY, sid, reply = true)),
+            groupKey = "approval",
+```
+(Keep the rest of the CLARIFY branch — title "Needs your input", body, channel — unchanged.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.notifications.NotificationMapperTest"`
+Expected: PASS (all existing + updated + new cases green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/NotificationModels.kt \
+        app/src/main/java/com/hermes/client/notifications/NotificationMapper.kt \
+        app/src/test/java/com/hermes/client/notifications/NotificationMapperTest.kt
+git commit -m "feat: add reply + approve-for-session notification actions to the mapper"
+```
+
+---
+
+### Task 2: Receiver action helper + headless handling
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt`
+- Test: `app/src/test/java/com/hermes/client/notifications/ReceiverActionTest.kt`
+
+**Interfaces:**
+- Consumes: `Notif.ACTION_*` constants (Task 1); `ChatRepository.submit(sessionId, text)` and `ChatRepository.respondApproval(sessionId, choice)`; `ApprovalChoice` (`ui.chat`, values `ONCE`/`SESSION`/`DENY`).
+- Produces: `sealed interface ReceiverAction { Approval(choice); Reply; Unknown }` and `fun receiverActionFor(action: String?): ReceiverAction`.
+
+- [ ] **Step 1: Write the failing test**
+
+`app/src/test/java/com/hermes/client/notifications/ReceiverActionTest.kt`:
+```kotlin
+package com.hermes.client.notifications
+
+import com.hermes.client.ui.chat.ApprovalChoice
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReceiverActionTest {
+    @Test fun allow_once_maps_to_approval_once() {
+        assertEquals(ReceiverAction.Approval(ApprovalChoice.ONCE), receiverActionFor(Notif.ACTION_ALLOW_ONCE))
+    }
+
+    @Test fun allow_session_maps_to_approval_session() {
+        assertEquals(ReceiverAction.Approval(ApprovalChoice.SESSION), receiverActionFor(Notif.ACTION_ALLOW_SESSION))
+    }
+
+    @Test fun deny_maps_to_approval_deny() {
+        assertEquals(ReceiverAction.Approval(ApprovalChoice.DENY), receiverActionFor(Notif.ACTION_DENY))
+    }
+
+    @Test fun reply_maps_to_reply() {
+        assertEquals(ReceiverAction.Reply, receiverActionFor(Notif.ACTION_REPLY))
+    }
+
+    @Test fun null_and_unknown_map_to_unknown() {
+        assertEquals(ReceiverAction.Unknown, receiverActionFor(null))
+        assertEquals(ReceiverAction.Unknown, receiverActionFor("something_else"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.notifications.ReceiverActionTest"`
+Expected: FAIL — `ReceiverAction`/`receiverActionFor` unresolved.
+
+- [ ] **Step 3: Implement the helper + wire onReceive**
+
+Rewrite `NotificationActionReceiver.kt` to add the sealed type + pure helper and route Reply/Session headlessly:
+```kotlin
+package com.hermes.client.notifications
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.RemoteInput
+import com.hermes.client.data.diagnostics.DebugLog
+import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.ui.chat.ApprovalChoice
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
+
+/** What a received notification-action intent should do. Pure/testable, no Android deps. */
+sealed interface ReceiverAction {
+    data class Approval(val choice: ApprovalChoice) : ReceiverAction
+    data object Reply : ReceiverAction
+    data object Unknown : ReceiverAction
+}
+
+fun receiverActionFor(action: String?): ReceiverAction = when (action) {
+    Notif.ACTION_ALLOW_ONCE -> ReceiverAction.Approval(ApprovalChoice.ONCE)
+    Notif.ACTION_ALLOW_SESSION -> ReceiverAction.Approval(ApprovalChoice.SESSION)
+    Notif.ACTION_DENY -> ReceiverAction.Approval(ApprovalChoice.DENY)
+    Notif.ACTION_REPLY -> ReceiverAction.Reply
+    else -> ReceiverAction.Unknown
+}
+
+/**
+ * Handles a notification action headlessly: Allow-once/Session/Deny → `approval.respond`; an inline
+ * Reply → `prompt.submit`. Runs a single RPC on a background scope; only clears the notification
+ * once the RPC succeeds, so a failed action isn't silently lost.
+ */
+@AndroidEntryPoint
+class NotificationActionReceiver : BroadcastReceiver() {
+    @Inject lateinit var chat: ChatRepository
+    @Inject lateinit var notifier: HermesNotifier
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val sid = intent.getStringExtra("session_id") ?: return
+        val notifId = intent.getIntExtra("notif_id", -1)
+        val ra = receiverActionFor(intent.action)
+        val replyText = RemoteInput.getResultsFromIntent(intent)
+            ?.getCharSequence(Notif.KEY_REPLY_TEXT)?.toString()?.trim()
+
+        // Nothing actionable, or a blank reply → leave the notification up (retryable) and stop.
+        if (ra is ReceiverAction.Unknown) return
+        if (ra is ReceiverAction.Reply && replyText.isNullOrBlank()) return
+
+        val pending = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                runCatching {
+                    withTimeout(8_000) {
+                        when (ra) {
+                            is ReceiverAction.Approval -> chat.respondApproval(sid, ra.choice)
+                            ReceiverAction.Reply -> chat.submit(sid, replyText!!)
+                            ReceiverAction.Unknown -> Unit // unreachable (returned above)
+                        }
+                    }
+                }.onSuccess {
+                    if (notifId != -1) notifier.cancel(notifId)
+                }.onFailure { e ->
+                    DebugLog.log("notif", "action failed session=$sid action=${intent.action}: ${e.message}")
+                }
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.notifications.ReceiverActionTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Compile the app**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. (Confirms `chat.submit`/`chat.respondApproval` signatures and `ApprovalChoice.SESSION` resolve.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/NotificationActionReceiver.kt \
+        app/src/test/java/com/hermes/client/notifications/ReceiverActionTest.kt
+git commit -m "feat: handle reply + approve-for-session notification actions headlessly"
+```
+
+---
+
+### Task 3: Notifier builds the RemoteInput reply action
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt`
+- Test: none new (Android glue; covered by compile + assembleBeta + on-device Task 4).
+
+**Interfaces:**
+- Consumes: `NotifAction.reply` + `Notif.KEY_REPLY_TEXT` (Task 1). Reply actions are posted for specs whose `NotifAction.reply == true`.
+
+- [ ] **Step 1: Add the RemoteInput import**
+
+In `HermesNotifier.kt`, add to the imports:
+```kotlin
+import androidx.core.app.RemoteInput
+```
+
+- [ ] **Step 2: Branch the action build in `post()`**
+
+Replace the action loop in `post(spec)`:
+```kotlin
+        spec.actions.forEach { a ->
+            b.addAction(0, a.label, actionIntent(a, spec.id))
+        }
+```
+with:
+```kotlin
+        spec.actions.forEach { a ->
+            if (a.reply) {
+                val remoteInput = RemoteInput.Builder(Notif.KEY_REPLY_TEXT).setLabel("Reply…").build()
+                val action = NotificationCompat.Action.Builder(0, a.label, replyIntent(a, spec.id))
+                    .addRemoteInput(remoteInput)
+                    .setAllowGeneratedReplies(false)
+                    .build()
+                b.addAction(action)
+            } else {
+                b.addAction(0, a.label, actionIntent(a, spec.id))
+            }
+        }
+```
+
+- [ ] **Step 3: Add the mutable reply PendingIntent builder**
+
+Add this private method next to `actionIntent(...)` in `HermesNotifier`:
+```kotlin
+    private fun replyIntent(a: NotifAction, notifId: Int): PendingIntent {
+        val intent = Intent(context, NotificationActionReceiver::class.java).apply {
+            action = a.action
+            putExtra("session_id", a.sessionId)
+            putExtra("notif_id", notifId)
+        }
+        // Direct-reply requires FLAG_MUTABLE so the system can attach the RemoteInput results.
+        // The intent is explicit (our own receiver), so it can't be redirected — mutability is safe.
+        return PendingIntent.getBroadcast(
+            context,
+            (a.action + a.sessionId).hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+    }
+```
+(Leave `actionIntent`/`pendingFlags` as-is: buttons keep `FLAG_IMMUTABLE`.)
+
+- [ ] **Step 4: Compile**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Run the full unit-test suite**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL, 0 failures (includes the Task 1 + Task 2 suites).
+
+- [ ] **Step 6: Assemble the beta variant**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleBeta`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/notifications/HermesNotifier.kt
+git commit -m "feat: post inline-reply notification action with RemoteInput"
+```
+
+---
+
+### Task 4: On-device verification (best-effort)
+
+**Files:** none (manual verification on the emulator or a connected device with notifications enabled + a reachable gateway).
+
+There is no automated Compose/instrumentation test (per Global Constraints); this manual pass is the acceptance gate for the `RemoteInput`/PendingIntent glue. Notifications must be enabled in the app and the foreground service running (so the WS is connected for the headless RPC).
+
+- [ ] **Step 1: Install the beta build**
+
+Run:
+```bash
+JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:installBeta
+```
+Expected: `Installed on 1 device`.
+
+- [ ] **Step 2: Verify the approve-for-session action**
+
+Trigger (or wait for) a **standard-tier** tool approval so an "Approval needed" notification posts. Confirm it shows three actions: **Allow once · Session · Deny**. Tap **Session** → the tool proceeds and the notification clears; a subsequent same-type tool call in that session is auto-allowed (session scope). Confirm an **elevated**-tier approval still shows **Deny** only.
+
+- [ ] **Step 3: Verify the inline reply action**
+
+When a **"Needs your input"** (`clarify.request`) notification appears, confirm it shows a **Reply** action that expands to an inline text field. Type an answer and send → confirm the text reaches the session as a new user turn (open the chat to verify) and the notification clears. Send a **blank** reply → confirm nothing is sent and the notification remains.
+
+- [ ] **Step 4: Note the caveat**
+
+A `clarify.request` requires an agent to actually ask a clarifying question, which cannot be forced on demand. If none occurs during the session, record that the reply path was verified by the pure tests + code review and the action's *appearance* (if any clarify notification is available), and note the live send was not exercised. Record the outcome in the PR description.
+
+---
+
+## Notes for the executor
+
+- `ChatRepository.submit(sessionId, text)` is the existing headless `prompt.submit` call; `respondApproval(sessionId, choice)` is the existing `approval.respond` call. Both are already injected into the receiver as `chat`. Do not add new RPCs.
+- The reply and button actions for the same session never collide on request code because their `a.action` strings differ (`reply` vs `allow_once`/`deny`/`allow_session`).
+- Do NOT add "Always" to the notification (would be a 4th action, past Android's 3-action display budget) or a reply action to `message.complete` — both are explicit anti-scope.

--- a/docs/superpowers/specs/2026-07-16-act-on-result-inline-reply-design.md
+++ b/docs/superpowers/specs/2026-07-16-act-on-result-inline-reply-design.md
@@ -10,6 +10,19 @@
 
 ---
 
+## Correction (post-implementation review)
+
+The final review found the original mechanism below was **wrong**: a `clarify.request` is a *blocking* agent park on the gateway that is answered only by **`clarify.respond` with the event's `request_id`**. `prompt.submit` (originally specified) hits the gateway's busy handler while the turn is `running` — it **abandons the parked question and posts a disconnected new turn**. The review also found the *existing* in-app clarify path (`ChatRepository.respondClarify`) already omits `request_id` and fails with gateway error 4009 — a pre-existing bug.
+
+**Corrected mechanism (client-only; the `clarify.request` event carries `request_id`, added by the gateway's `_block`):** thread `request_id` end-to-end so the inline reply answers via `clarify.respond`, which also repairs the in-app bug:
+- `ClarifyRequest` gains `requestId`; the `clarify.request` reducer captures `event.str("request_id")`.
+- `ChatRepository.respondClarify(sessionId, requestId, answer)` sends `request_id`; `ChatViewModel.clarify` passes `pendingClarify.requestId`.
+- `NotifAction` gains `requestId`; the mapper's clarify action carries it; `HermesNotifier` puts it as a `request_id` intent extra; `NotificationActionReceiver` reads it and calls `chat.respondClarify(sid, requestId, text)` (not `submit`).
+
+The **Approve-for-session** half of this spec is unaffected and correct. Where the sections below say `prompt.submit`/`chat.submit` for the reply, read `clarify.respond`/`respondClarify(sid, requestId, text)`.
+
+---
+
 ## Scope (locked)
 
 - **Reply** action on `clarify.request` ("Needs your input") notifications — today they carry no actions, only tap-to-open. Android `RemoteInput` → headless `prompt.submit`.

--- a/docs/superpowers/specs/2026-07-16-act-on-result-inline-reply-design.md
+++ b/docs/superpowers/specs/2026-07-16-act-on-result-inline-reply-design.md
@@ -1,0 +1,157 @@
+# Act-on-Result: Inline Reply + Broader Approval — Design
+
+**Wave:** Quick-wins wave 3 (from `docs/ideas/2026-07-16-competitive-refresh.md`, "act-on-result"). **Branch:** `feature/act-on-result-inline-reply` (off `dev`).
+
+**Goal:** Let the user act on an agent's result from the notification shade without opening the app — answer a "Needs your input" prompt inline, and approve a tool call *for the session* (not just once). Fully client-only; reuses the existing headless `NotificationActionReceiver` → RPC pattern.
+
+**Positioning:** Most act-on-result actions already ship — approval notifications carry Allow-once/Deny (headless via `approval.respond`), and the activity feed has run-now / retry / open / view-full-chat. This wave adds the two missing high-value **notification** actions.
+
+**Constraints:** Kotlin / Compose / Hilt / Material3, per-tenant accent. **Client-only** — no gateway changes; reuses `prompt.submit` and `approval.respond`. Standing repo constraints (no AI attribution; gitleaks before every push; tenant isolation; `main` only via approved PR).
+
+---
+
+## Scope (locked)
+
+- **Reply** action on `clarify.request` ("Needs your input") notifications — today they carry no actions, only tap-to-open. Android `RemoteInput` → headless `prompt.submit`.
+- **Approve for session** action on **standard-tier** `approval.request` notifications — today only Allow-once/Deny. Reuses `approval.respond` with `choice = "session"`.
+- **Out:** "Always" on the notification (Android caps visible actions at 3; `[Allow once, Session, Deny]` is the budget — a permanent grant stays a deliberate in-app choice); reply on `message.complete` (run-finished isn't awaiting input); true "rerun this run" (needs a gateway RPC); cron-completion notifications (gateway doesn't emit them).
+
+---
+
+## Architecture
+
+Four touch points, all in the existing notification pipeline. The event→spec mapping and the action→intent decision are pure and unit-tested; the `RemoteInput`/`PendingIntent`/receiver glue is Android, verified on-device.
+
+### 1. Model — `notifications/NotificationModels.kt`
+
+- `NotifAction` gains a reply flag:
+  ```kotlin
+  data class NotifAction(
+      val label: String,
+      val action: String,
+      val sessionId: String,
+      val reply: Boolean = false, // true → an inline RemoteInput reply action, not a button
+  )
+  ```
+- New constants in the `Notif` object:
+  ```kotlin
+  const val ACTION_REPLY = "reply"
+  const val ACTION_ALLOW_SESSION = "allow_session"
+  const val KEY_REPLY_TEXT = "reply_text" // RemoteInput result key
+  ```
+
+### 2. Event→spec mapping — `notifications/NotificationMapper.kt`
+
+- `clarify.request` → add a single reply action (keep the existing `chat/$sid` tap route + title "Needs your input"):
+  ```kotlin
+  actions = listOf(NotifAction("Reply", Notif.ACTION_REPLY, sid, reply = true))
+  ```
+- `approval.request` **standard tier** → insert "Approve for session" between Allow-once and Deny:
+  ```kotlin
+  listOf(
+      NotifAction("Allow once", Notif.ACTION_ALLOW_ONCE, sid),
+      NotifAction("Session", Notif.ACTION_ALLOW_SESSION, sid),
+      NotifAction("Deny", Notif.ACTION_DENY, sid),
+  )
+  ```
+  **Elevated tier is unchanged** (Deny-only) — the tiered-approvals safety design stays intact.
+
+### 3. Notifier — `notifications/HermesNotifier.kt`
+
+In `post(spec)`, branch the per-action build:
+- `action.reply == false` → the existing plain `addAction(0, label, actionIntent(a, id))` with a `FLAG_IMMUTABLE` broadcast PendingIntent (unchanged).
+- `action.reply == true` → build a `NotificationCompat.Action` carrying a `RemoteInput`:
+  ```kotlin
+  val remoteInput = RemoteInput.Builder(Notif.KEY_REPLY_TEXT).setLabel("Reply…").build()
+  val piFlags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+  val replyAction = NotificationCompat.Action.Builder(0, a.label, replyPendingIntent(a, spec.id, piFlags))
+      .addRemoteInput(remoteInput)
+      .setAllowGeneratedReplies(false)
+      .build()
+  b.addAction(replyAction)
+  ```
+  The reply PendingIntent targets the **explicit** `NotificationActionReceiver` component (same as `actionIntent`), so `FLAG_MUTABLE` is safe — an explicit intent can't be redirected; mutability only lets the system attach the `RemoteInput` results. (Existing button actions keep `FLAG_IMMUTABLE`.)
+
+### 4. Receiver — `notifications/NotificationActionReceiver.kt`
+
+A pure decision helper makes the dispatch unit-testable:
+```kotlin
+sealed interface ReceiverAction {
+    data class Approval(val choice: ApprovalChoice) : ReceiverAction
+    data object Reply : ReceiverAction
+    data object Unknown : ReceiverAction
+}
+
+fun receiverActionFor(action: String?): ReceiverAction = when (action) {
+    Notif.ACTION_ALLOW_ONCE -> ReceiverAction.Approval(ApprovalChoice.ONCE)
+    Notif.ACTION_ALLOW_SESSION -> ReceiverAction.Approval(ApprovalChoice.SESSION)
+    Notif.ACTION_DENY -> ReceiverAction.Approval(ApprovalChoice.DENY)
+    Notif.ACTION_REPLY -> ReceiverAction.Reply
+    else -> ReceiverAction.Unknown
+}
+```
+`onReceive` (headless via `goAsync()` + `CoroutineScope(Dispatchers.IO)` + `withTimeout(8_000)`, mirroring the shipped approval handler):
+- `Approval(choice)` → `chat.respondApproval(sid, choice)` (covers Allow-once, **Session**, Deny), cancel notif on success.
+- `Reply` → `RemoteInput.getResultsFromIntent(intent)?.getCharSequence(Notif.KEY_REPLY_TEXT)`; trim; if non-blank → `chat.submit(sid, text.toString())` (the existing `prompt.submit`), cancel notif on success; blank → do nothing (leave the notification).
+- `Unknown` → ignore.
+
+`chat.submit(sessionId, text)` and `chat.respondApproval(sessionId, choice)` are existing headless `suspend` funcs on `ChatRepository` over the gateway WebSocket. They require the socket to be connected — the same precondition the shipped approval action already relies on (the foreground `GatewayConnectionService` keeps it alive when notifications are enabled).
+
+---
+
+## Data flow
+
+```
+clarify.request event ─ NotificationMapper ─→ spec.actions = [Reply(reply=true)]
+approval.request event ─ NotificationMapper ─→ spec.actions = [Allow once, Session, Deny]  (standard tier)
+                                   │
+                          HermesNotifier.post
+              reply? → NotificationCompat.Action + RemoteInput + FLAG_MUTABLE PendingIntent
+              button? → addAction + FLAG_IMMUTABLE PendingIntent
+                                   │  (user taps / types in the shade)
+                          NotificationActionReceiver.onReceive  (headless, goAsync + withTimeout)
+                    receiverActionFor(action)
+              Reply → chat.submit(sid, RemoteInput text) ── prompt.submit
+              Approval(SESSION/ONCE/DENY) → chat.respondApproval(sid, choice) ── approval.respond
+                                   │ on success → notifier cancels the notification
+```
+
+## Error handling
+
+- Blank/absent reply text → no send, notification left in place (user can retry).
+- RPC failure / timeout (`withTimeout(8_000)`) → notification is **not** cancelled (so the action can be retried), mirroring the shipped approval handler's success-gated cancel.
+- Socket not connected → the RPC call fails within the timeout; notification stays. (No new failure mode vs. the existing approval action.)
+- Unknown action string → ignored.
+
+## Testing
+
+**Pure `NotificationMapperTest` additions** (JUnit, existing pure test for `toNotificationSpec`):
+- `clarify.request` → exactly one action, `reply == true`, `label == "Reply"`, `action == ACTION_REPLY`, correct `sessionId`; tap route still `chat/$sid`.
+- standard-tier `approval.request` → actions `[Allow once, Session, Deny]` with `ACTION_ALLOW_SESSION` present and `reply == false` on all three.
+- elevated-tier `approval.request` → unchanged (Deny-only), no Session action.
+
+**Pure `receiverActionFor` tests** (new small test):
+- each action constant → the correct `ReceiverAction` (incl. `ACTION_ALLOW_SESSION → Approval(SESSION)`, `ACTION_REPLY → Reply`); `null`/unknown → `Unknown`.
+
+`RemoteInput` extraction, PendingIntent flags, and the receiver's coroutine glue are Android — no unit tests (repo style); covered by on-device verification.
+
+## On-device verification (best-effort)
+
+- **Approve-for-session:** trigger a standard-tier tool approval; confirm the notification shows `[Allow once, Session, Deny]`; tap **Session** → the tool proceeds and subsequent same-type calls in that session are auto-allowed (session scope), notification clears.
+- **Inline reply:** when a `clarify.request` ("Needs your input") notification appears, confirm a **Reply** action with an inline text field; type and send → the text reaches the session (a new user turn) and the notification clears.
+- **Caveat:** a `clarify.request` requires an agent to actually ask a clarifying question, which can't be forced on demand — so the reply path is verified opportunistically; the pure tests + review are the primary correctness gate. If no clarify arises during the session, note it and rely on the tests.
+
+## Files
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `notifications/NotificationModels.kt` | `NotifAction.reply` flag + `ACTION_REPLY`/`ACTION_ALLOW_SESSION`/`KEY_REPLY_TEXT` |
+| Modify | `notifications/NotificationMapper.kt` | reply action on clarify; Session action on standard approval |
+| Modify | `notifications/HermesNotifier.kt` | build RemoteInput reply action (MUTABLE explicit PI) vs. plain button |
+| Modify | `notifications/NotificationActionReceiver.kt` | `receiverActionFor` helper + Reply→`submit` / Session→`respondApproval` headless handling |
+| Modify/Create test | `test/…/notifications/NotificationMapperTest.kt` | mapper action assertions |
+| Create test | `test/…/notifications/ReceiverActionTest.kt` | `receiverActionFor` mapping |
+
+## Build & gates
+
+`JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before every push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave 3 (from `docs/ideas/2026-07-16-competitive-refresh.md`, "act-on-result"). Adds the two missing high-value **notification** actions so a user can act on an agent's result without opening the app. Client-only — reuses existing headless RPCs.

## What ships
- **Inline Reply to "Needs your input"** — a `clarify.request` notification now carries an Android `RemoteInput` **Reply** action. Typing in the shade answers the parked question via **`clarify.respond`** (with the event's `request_id`), handled headless by `NotificationActionReceiver`.
- **Approve for session** — standard-tier approval notifications now offer `[Allow once, Session, Deny]` (was Allow-once/Deny), reusing `approval.respond` with `choice = "session"`. Elevated tier unchanged (Deny-only); no "Always" (Android's 3-action budget).

## Also fixes a pre-existing bug
The in-app clarify answer (`ChatRepository.respondClarify`) previously sent no `request_id`, so the gateway rejected it with error 4009 — the app's clarify-answer path was already broken. This PR threads `request_id` end-to-end, repairing both the notification reply **and** the in-app path.

## Quality
- Executed subagent-driven: 3 TDD tasks + on-device smoke, per-task reviews, opus whole-branch review.
- The whole-branch review caught a **design error in the original spec** (it specified `prompt.submit`, which *interrupts* a blocking clarify and posts a disconnected turn). Reworked to `clarify.respond` + `request_id` (spec corrected), re-reviewed by opus → RESOLVED / READY TO MERGE.
- Earlier fix: distinct request-code namespace so the MUTABLE reply and IMMUTABLE button PendingIntents can never collide (Android 12+ crash class).
- **Gates:** 264 unit tests pass (0 fail/err); `compileDebugKotlin` + `assembleBeta` green; gitleaks clean.
- Security: the reply PendingIntent is `FLAG_MUTABLE` but **explicit** (targets our own non-exported receiver) — cannot be redirected.

## On-device (best-effort)
Beta installs + launches clean (no crash from the notification changes). The live Reply/Session actions couldn't be exercised because a real `clarify.request` / manual approval can't be forced on demand (and would drive real turns on the production gateway); correctness rests on the pure tests (mapper + reducer + receiverActionFor) + review, per the plan.

## Deferred follow-ups (non-blocking)
- Direct-reply spinner isn't cleared on a blank/failed reply (Android glue).
- Minor test/dedup cleanups noted in review.