### PR TITLE
feat: QR-scan pairing on the setup screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     implementation(libs.datastore.preferences)
     implementation(libs.security.crypto)
     implementation(libs.markdown.m3)
+    implementation(libs.zxing.embedded)
 
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/app/src/main/java/com/hermes/client/data/network/GatedAuth.kt
+++ b/app/src/main/java/com/hermes/client/data/network/GatedAuth.kt
@@ -69,12 +69,13 @@ class GatedAuth(
             put("username", cfg.username)
             put("password", cfg.password)
         }
-        val req = Request.Builder()
-            .url("${cfg.baseUrl.trimEnd('/')}/auth/password-login")
-            .post(json.encodeToString(JsonObject.serializer(), payload).toRequestBody(JSON_MEDIA))
-            .build()
-        val ok = runCatching { loginClient.newCall(req).execute().use { it.isSuccessful } }
-            .getOrDefault(false)
+        val ok = runCatching {
+            val req = Request.Builder()
+                .url("${cfg.baseUrl.trimEnd('/')}/auth/password-login")
+                .post(json.encodeToString(JsonObject.serializer(), payload).toRequestBody(JSON_MEDIA))
+                .build()
+            loginClient.newCall(req).execute().use { it.isSuccessful }
+        }.getOrDefault(false)
         DebugLog.log("ws", "gated login -> $ok")
         return ok
     }
@@ -108,11 +109,11 @@ class GatedAuth(
             put("username", username)
             put("password", password)
         }
-        val req = Request.Builder()
-            .url("${baseUrl.trimEnd('/')}/auth/password-login")
-            .post(json.encodeToString(JsonObject.serializer(), payload).toRequestBody(JSON_MEDIA))
-            .build()
         return runCatching {
+            val req = Request.Builder()
+                .url("${baseUrl.trimEnd('/')}/auth/password-login")
+                .post(json.encodeToString(JsonObject.serializer(), payload).toRequestBody(JSON_MEDIA))
+                .build()
             OkHttpClient().newCall(req).execute().use { it.isSuccessful }
         }.getOrDefault(false)
     }

--- a/app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt
@@ -1,0 +1,25 @@
+package com.hermes.client.ui.setup
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Credentials carried by a Hermes pairing QR. Primary payload is url + username + password. */
+@Serializable
+data class PairingPayload(
+    val v: Int = 0,
+    val url: String = "",
+    val token: String = "",
+    val username: String = "",
+    val password: String = "",
+)
+
+private val pairingJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Parse a scanned QR string. Returns null (never throws) unless it is a valid v1 Hermes pairing
+ * object with a non-blank url — so a random/non-Hermes QR is rejected cleanly.
+ */
+fun parsePairingPayload(raw: String): PairingPayload? =
+    runCatching { pairingJson.decodeFromString<PairingPayload>(raw) }
+        .getOrNull()
+        ?.takeIf { it.v == 1 && it.url.isNotBlank() }

--- a/app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt
@@ -22,4 +22,4 @@ private val pairingJson = Json { ignoreUnknownKeys = true }
 fun parsePairingPayload(raw: String): PairingPayload? =
     runCatching { pairingJson.decodeFromString<PairingPayload>(raw) }
         .getOrNull()
-        ?.takeIf { it.v == 1 && it.url.isNotBlank() }
+        ?.takeIf { it.v == 1 && (it.url.startsWith("http://") || it.url.startsWith("https://")) }

--- a/app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
@@ -1,5 +1,6 @@
 package com.hermes.client.ui.setup
 
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,10 +20,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 
 @Composable
 fun SetupScreen(vm: SetupViewModel = hiltViewModel(), onSaved: () -> Unit) {
     val state by vm.state.collectAsStateWithLifecycle()
+    val scanLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
+        // Null contents = the user cancelled or denied the camera; manual entry stays usable.
+        result.contents?.let { vm.applyPairing(it) }
+    }
     LaunchedEffect(state.saved) { if (state.saved) onSaved() }
     Column(
         // safeDrawingPadding keeps content clear of the status bar (clock/notifications)
@@ -31,6 +38,20 @@ fun SetupScreen(vm: SetupViewModel = hiltViewModel(), onSaved: () -> Unit) {
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Text("Connect to Hermes", style = MaterialTheme.typography.headlineSmall)
+        OutlinedButton(
+            onClick = {
+                scanLauncher.launch(
+                    ScanOptions().apply {
+                        setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                        setPrompt("Scan the Hermes pairing QR")
+                        setBeepEnabled(false)
+                        setOrientationLocked(false)
+                    },
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Scan QR") }
+        state.scanError?.let { Text(it, color = MaterialTheme.colorScheme.error) }
         OutlinedTextField(
             value = state.url,
             onValueChange = vm::onUrlChange,

--- a/app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt
@@ -22,6 +22,7 @@ data class SetupUiState(
     val password: String = "",
     val testResult: String? = null,
     val saved: Boolean = false,
+    val scanError: String? = null,
 )
 
 @HiltViewModel
@@ -58,5 +59,23 @@ class SetupViewModel @Inject constructor(
         store.save(GatewayConfig(s.url, s.token, s.username.trim(), s.password))
         gatedAuth.cookieJar.clear()
         _state.value = _state.value.copy(saved = true)
+    }
+
+    /** Apply a scanned pairing QR: prefill the fields and auto-run the existing probe. */
+    fun applyPairing(raw: String) {
+        val p = parsePairingPayload(raw)
+        if (p == null) {
+            _state.value = _state.value.copy(scanError = "Not a Hermes pairing code")
+            return
+        }
+        _state.value = _state.value.copy(
+            url = p.url, token = p.token, username = p.username, password = p.password,
+            scanError = null, testResult = null,
+        )
+        test()
+    }
+
+    fun clearScanError() {
+        if (_state.value.scanError != null) _state.value = _state.value.copy(scanError = null)
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt
@@ -39,4 +39,9 @@ class PairingPayloadTest {
         assertNull(parsePairingPayload("""{"v":1,"url":""}"""))
         assertNull(parsePairingPayload("""{"v":1}"""))
     }
+
+    @Test fun rejects_non_url() {
+        assertNull(parsePairingPayload("""{"v":1,"url":"hello"}"""))
+        assertNull(parsePairingPayload("""{"v":1,"url":"ftp://h"}"""))
+    }
 }

--- a/app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt
@@ -1,0 +1,42 @@
+package com.hermes.client.ui.setup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PairingPayloadTest {
+    @Test fun parses_gated_payload() {
+        val p = parsePairingPayload("""{"v":1,"url":"https://h.ts.net","username":"a","password":"p"}""")!!
+        assertEquals("https://h.ts.net", p.url)
+        assertEquals("a", p.username)
+        assertEquals("p", p.password)
+        assertEquals("", p.token)
+    }
+
+    @Test fun parses_token_payload() {
+        val p = parsePairingPayload("""{"v":1,"url":"http://127.0.0.1:9119","token":"tok"}""")!!
+        assertEquals("tok", p.token)
+        assertEquals("", p.username)
+    }
+
+    @Test fun ignores_unknown_keys() {
+        val p = parsePairingPayload("""{"v":1,"url":"http://h","extra":"x"}""")!!
+        assertEquals("http://h", p.url)
+    }
+
+    @Test fun rejects_malformed_json() {
+        assertNull(parsePairingPayload("not json"))
+        assertNull(parsePairingPayload("{bad"))
+        assertNull(parsePairingPayload("\"https://h\"")) // a bare string, not an object
+    }
+
+    @Test fun rejects_wrong_or_missing_version() {
+        assertNull(parsePairingPayload("""{"v":2,"url":"http://h"}"""))
+        assertNull(parsePairingPayload("""{"url":"http://h"}""")) // v defaults to 0
+    }
+
+    @Test fun rejects_blank_url() {
+        assertNull(parsePairingPayload("""{"v":1,"url":""}"""))
+        assertNull(parsePairingPayload("""{"v":1}"""))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/setup/SetupViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/setup/SetupViewModelTest.kt
@@ -1,0 +1,59 @@
+package com.hermes.client.ui.setup
+
+import com.hermes.client.data.auth.CredentialStore
+import com.hermes.client.data.network.GatedAuth
+import com.hermes.client.data.network.HermesRestApi
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SetupViewModelTest {
+    private val store = mockk<CredentialStore>(relaxed = true)
+    private val rest = mockk<HermesRestApi>(relaxed = true)
+    private val gatedAuth = mockk<GatedAuth>(relaxed = true)
+
+    @Before fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        every { store.load() } returns null
+    }
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun vm() = SetupViewModel(store, rest, gatedAuth)
+
+    @Test fun applyPairing_populates_fields_from_valid_payload() {
+        val vm = vm()
+        vm.applyPairing("""{"v":1,"url":"https://h.ts.net","username":"a","password":"p"}""")
+        val s = vm.state.value
+        assertEquals("https://h.ts.net", s.url)
+        assertEquals("a", s.username)
+        assertEquals("p", s.password)
+        assertNull(s.scanError)
+    }
+
+    @Test fun applyPairing_sets_scanError_and_leaves_fields_blank_on_garbage() {
+        val vm = vm()
+        vm.applyPairing("not a hermes code")
+        val s = vm.state.value
+        assertEquals("Not a Hermes pairing code", s.scanError)
+        assertEquals("", s.url)
+        assertEquals("", s.password)
+    }
+
+    @Test fun clearScanError_clears_it() {
+        val vm = vm()
+        vm.applyPairing("garbage")
+        vm.clearScanError()
+        assertNull(vm.state.value.scanError)
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-qr-scan-pairing.md
+++ b/docs/superpowers/plans/2026-07-17-qr-scan-pairing.md
@@ -1,0 +1,398 @@
+# QR-Scan Pairing in Setup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Scan QR" path to the setup screen: scan a QR encoding the gateway URL + credentials, prefill the existing fields, auto-run the existing Test, then Save. Fully client-only.
+
+**Architecture:** A pure JSON payload parser (`parsePairingPayload`), a `SetupViewModel.applyPairing` entry point that reuses the existing `test()`/`save()`, and a ZXing scan launcher on `SetupScreen`. Parser + ViewModel logic are pure/unit-tested; the camera/ZXing launch is Android glue verified on-device.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, Hilt, kotlinx.serialization (existing), ZXing embedded (new).
+
+**Spec:** `docs/superpowers/specs/2026-07-17-qr-scan-pairing-design.md`
+
+## Global Constraints
+
+- Client-only: no gateway changes. Scanned payload maps onto `GatewayConfig(baseUrl, token, username, password)` via the existing `store.save`.
+- Primary payload is **URL + username + password** (the loopback token is useless off-device); `token` optional.
+- Scanner = **ZXing embedded** (`com.journeyapps:zxing-android-embedded`) — offline, GMS-free. Needs the `CAMERA` permission (ZXing's `CaptureActivity` handles the runtime request itself; a denied permission yields a null scan result → manual entry still works).
+- Setup is pre-connection → **no tenant accent**; use default Material styling for the Scan button.
+- Tests: pure JUnit (`PairingPayloadTest`, `SetupViewModelTest`). No Compose/instrumentation tests.
+- No AI/assistant attribution in commits or files.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch: `feature/qr-scan-pairing` (off `dev`; spec committed). All commits land here.
+
+---
+
+### Task 1: Pairing payload parser (pure)
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt`
+
+**Interfaces:**
+- Produces: `@Serializable data class PairingPayload(v, url, token, username, password)` and `fun parsePairingPayload(raw: String): PairingPayload?` (null unless valid v1 with non-blank url; never throws).
+
+- [ ] **Step 1: Write the failing test**
+
+`app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt`:
+```kotlin
+package com.hermes.client.ui.setup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PairingPayloadTest {
+    @Test fun parses_gated_payload() {
+        val p = parsePairingPayload("""{"v":1,"url":"https://h.ts.net","username":"a","password":"p"}""")!!
+        assertEquals("https://h.ts.net", p.url)
+        assertEquals("a", p.username)
+        assertEquals("p", p.password)
+        assertEquals("", p.token)
+    }
+
+    @Test fun parses_token_payload() {
+        val p = parsePairingPayload("""{"v":1,"url":"http://127.0.0.1:9119","token":"tok"}""")!!
+        assertEquals("tok", p.token)
+        assertEquals("", p.username)
+    }
+
+    @Test fun ignores_unknown_keys() {
+        val p = parsePairingPayload("""{"v":1,"url":"http://h","extra":"x"}""")!!
+        assertEquals("http://h", p.url)
+    }
+
+    @Test fun rejects_malformed_json() {
+        assertNull(parsePairingPayload("not json"))
+        assertNull(parsePairingPayload("{bad"))
+        assertNull(parsePairingPayload("\"https://h\"")) // a bare string, not an object
+    }
+
+    @Test fun rejects_wrong_or_missing_version() {
+        assertNull(parsePairingPayload("""{"v":2,"url":"http://h"}"""))
+        assertNull(parsePairingPayload("""{"url":"http://h"}""")) // v defaults to 0
+    }
+
+    @Test fun rejects_blank_url() {
+        assertNull(parsePairingPayload("""{"v":1,"url":""}"""))
+        assertNull(parsePairingPayload("""{"v":1}"""))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.setup.PairingPayloadTest"`
+Expected: FAIL — `PairingPayload`/`parsePairingPayload` unresolved.
+
+- [ ] **Step 3: Write the implementation**
+
+`app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt`:
+```kotlin
+package com.hermes.client.ui.setup
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Credentials carried by a Hermes pairing QR. Primary payload is url + username + password. */
+@Serializable
+data class PairingPayload(
+    val v: Int = 0,
+    val url: String = "",
+    val token: String = "",
+    val username: String = "",
+    val password: String = "",
+)
+
+private val pairingJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Parse a scanned QR string. Returns null (never throws) unless it is a valid v1 Hermes pairing
+ * object with a non-blank url — so a random/non-Hermes QR is rejected cleanly.
+ */
+fun parsePairingPayload(raw: String): PairingPayload? =
+    runCatching { pairingJson.decodeFromString<PairingPayload>(raw) }
+        .getOrNull()
+        ?.takeIf { it.v == 1 && it.url.isNotBlank() }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.setup.PairingPayloadTest"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt \
+        app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt
+git commit -m "feat: add pairing-QR payload parser"
+```
+
+---
+
+### Task 2: SetupViewModel.applyPairing
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/setup/SetupViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: `parsePairingPayload` (Task 1); existing `test()`, `SetupUiState`, injected `store`/`rest`/`gatedAuth`.
+- Produces: `SetupUiState.scanError: String?`; `fun applyPairing(raw: String)`; `fun clearScanError()`.
+
+- [ ] **Step 1: Write the failing test**
+
+`app/src/test/java/com/hermes/client/ui/setup/SetupViewModelTest.kt`:
+```kotlin
+package com.hermes.client.ui.setup
+
+import com.hermes.client.data.auth.CredentialStore
+import com.hermes.client.data.network.GatedAuth
+import com.hermes.client.data.network.HermesRestApi
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SetupViewModelTest {
+    private val store = mockk<CredentialStore>(relaxed = true)
+    private val rest = mockk<HermesRestApi>(relaxed = true)
+    private val gatedAuth = mockk<GatedAuth>(relaxed = true)
+
+    @Before fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        every { store.load() } returns null
+    }
+
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private fun vm() = SetupViewModel(store, rest, gatedAuth)
+
+    @Test fun applyPairing_populates_fields_from_valid_payload() {
+        val vm = vm()
+        vm.applyPairing("""{"v":1,"url":"https://h.ts.net","username":"a","password":"p"}""")
+        val s = vm.state.value
+        assertEquals("https://h.ts.net", s.url)
+        assertEquals("a", s.username)
+        assertEquals("p", s.password)
+        assertNull(s.scanError)
+    }
+
+    @Test fun applyPairing_sets_scanError_and_leaves_fields_blank_on_garbage() {
+        val vm = vm()
+        vm.applyPairing("not a hermes code")
+        val s = vm.state.value
+        assertEquals("Not a Hermes pairing code", s.scanError)
+        assertEquals("", s.url)
+        assertEquals("", s.password)
+    }
+
+    @Test fun clearScanError_clears_it() {
+        val vm = vm()
+        vm.applyPairing("garbage")
+        vm.clearScanError()
+        assertNull(vm.state.value.scanError)
+    }
+}
+```
+(Assertions are on the synchronous state changes; the `test()` probe `applyPairing` triggers runs in `viewModelScope` and is not asserted here — its behavior is unchanged and already exercised by the existing Test button.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.setup.SetupViewModelTest"`
+Expected: FAIL — `scanError`/`applyPairing`/`clearScanError` unresolved.
+
+- [ ] **Step 3: Modify the ViewModel**
+
+In `SetupViewModel.kt`, add `scanError` to the state:
+```kotlin
+data class SetupUiState(
+    val url: String = "",
+    val token: String = "",
+    val username: String = "",
+    val password: String = "",
+    val testResult: String? = null,
+    val saved: Boolean = false,
+    val scanError: String? = null,
+)
+```
+And add these two functions to the `SetupViewModel` class (e.g. after `save()`):
+```kotlin
+    /** Apply a scanned pairing QR: prefill the fields and auto-run the existing probe. */
+    fun applyPairing(raw: String) {
+        val p = parsePairingPayload(raw)
+        if (p == null) {
+            _state.value = _state.value.copy(scanError = "Not a Hermes pairing code")
+            return
+        }
+        _state.value = _state.value.copy(
+            url = p.url, token = p.token, username = p.username, password = p.password,
+            scanError = null, testResult = null,
+        )
+        test()
+    }
+
+    fun clearScanError() {
+        if (_state.value.scanError != null) _state.value = _state.value.copy(scanError = null)
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.setup.SetupViewModelTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt \
+        app/src/test/java/com/hermes/client/ui/setup/SetupViewModelTest.kt
+git commit -m "feat: SetupViewModel.applyPairing populates fields from a scanned QR"
+```
+
+---
+
+### Task 3: ZXing dependency + CAMERA permission + Scan-QR button
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`
+- Modify: `app/build.gradle.kts`
+- Modify: `app/src/main/AndroidManifest.xml`
+- Modify: `app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt`
+- Test: none new (Android glue). Verified by compile + full suite + assembleBeta + Task 4.
+
+**Interfaces:**
+- Consumes: `SetupViewModel.applyPairing` + `SetupUiState.scanError` (Task 2).
+
+- [ ] **Step 1: Add the ZXing version + library alias**
+
+In `gradle/libs.versions.toml`, add under `[versions]` (e.g. after the existing entries):
+```toml
+zxingEmbedded = "4.3.0"
+```
+and under `[libraries]`:
+```toml
+zxing-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxingEmbedded" }
+```
+
+- [ ] **Step 2: Add the dependency**
+
+In `app/build.gradle.kts`, in the `dependencies { }` block (next to the other `implementation(libs.*)` lines, e.g. after `implementation(libs.markdown.m3)`):
+```kotlin
+    implementation(libs.zxing.embedded)
+```
+
+- [ ] **Step 3: Add the CAMERA permission**
+
+In `app/src/main/AndroidManifest.xml`, add after the `ACCESS_NETWORK_STATE` line:
+```xml
+    <uses-permission android:name="android.permission.CAMERA" />
+```
+
+- [ ] **Step 4: Add the Scan-QR button + launcher to SetupScreen**
+
+In `app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt`, add imports:
+```kotlin
+import androidx.activity.compose.rememberLauncherForActivityResult
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
+```
+Inside `SetupScreen`, after `val state by vm.state.collectAsStateWithLifecycle()`, register the scan launcher:
+```kotlin
+    val scanLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
+        // Null contents = the user cancelled or denied the camera; manual entry stays usable.
+        result.contents?.let { vm.applyPairing(it) }
+    }
+```
+Add the button + error text directly under the `Text("Connect to Hermes", …)` title (making scan the primary path), before the URL field:
+```kotlin
+        OutlinedButton(
+            onClick = {
+                scanLauncher.launch(
+                    ScanOptions().apply {
+                        setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                        setPrompt("Scan the Hermes pairing QR")
+                        setBeepEnabled(false)
+                        setOrientationLocked(false)
+                    },
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Scan QR") }
+        state.scanError?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+```
+(The existing URL/username/password/token fields, Test/Save row, and `testResult` remain unchanged below.)
+
+- [ ] **Step 5: Compile**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL. (Resolves the ZXing dependency + `ScanContract`/`ScanOptions`.)
+
+- [ ] **Step 6: Run the full unit-test suite**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:testDebugUnitTest`
+Expected: BUILD SUCCESSFUL, 0 failures (includes Tasks 1–2 suites).
+
+- [ ] **Step 7: Assemble the beta variant**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleBeta`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add gradle/libs.versions.toml app/build.gradle.kts app/src/main/AndroidManifest.xml \
+        app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt
+git commit -m "feat: add Scan-QR pairing button to setup (ZXing + CAMERA)"
+```
+
+---
+
+### Task 4: On-device verification
+
+**Files:** none (manual, on the emulator or a connected device).
+
+No automated Compose/camera test (per Global Constraints); this manual pass is the acceptance gate for the scanner glue.
+
+- [ ] **Step 1: Prepare a test QR**
+
+Encode this JSON as a QR with any offline QR tool (replace with a reachable gateway + real credentials):
+```json
+{"v":1,"url":"http://10.0.2.2:9119","username":"andrew","password":"<password>"}
+```
+(For an emulator, `10.0.2.2` reaches the host; or use a `token` payload against a loopback-reachable gateway.)
+
+- [ ] **Step 2: Install the beta build**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:installBeta`
+Expected: `Installed on 1 device`.
+
+- [ ] **Step 3: Verify the happy path**
+
+Launch the app to the setup screen → tap **Scan QR** → grant camera → scan the QR. Confirm: the URL/username/password fields **prefill**, the auto-Test shows "Connected", and **Save & continue** connects into the app.
+
+- [ ] **Step 4: Verify the error + denial paths**
+
+Scan a random non-Hermes QR → confirm **"Not a Hermes pairing code"** appears and the fields are untouched. Re-open Scan QR and **deny** the camera permission (or cancel) → confirm no crash and the manual URL/username/password entry still works.
+
+- [ ] **Step 5: Record the outcome**
+
+No commit. Note pass/fail per step in the PR description.
+
+---
+
+## Notes for the executor
+
+- ZXing embedded's `CaptureActivity` is declared in the library manifest (merged automatically) and requests the CAMERA permission itself — no manual activity declaration and no separate Compose permission launcher are needed. A cancelled/denied scan returns `result.contents == null`, handled as a no-op.
+- Do NOT add dashboard QR generation, mDNS discovery, Tailscale discovery, or a `hermes://` scheme — all explicit anti-scope.
+- The scanned password persists only through the existing `CredentialStore`/`EncryptedCredentialStore`; do not log the payload.

--- a/docs/superpowers/specs/2026-07-17-qr-scan-pairing-design.md
+++ b/docs/superpowers/specs/2026-07-17-qr-scan-pairing-design.md
@@ -1,0 +1,122 @@
+# QR-Scan Pairing in Setup — Design
+
+**Wave:** Quick-wins (from `docs/ideas/2026-07-16-competitive-refresh.md`, self-hosted onboarding). **Branch:** `feature/qr-scan-pairing` (off `dev`).
+
+**Goal:** Add a "Scan QR" path to the setup screen so a user pairs by scanning a QR that encodes the gateway URL + credentials, instead of hand-typing a long `ts.net` URL + password. Fully client-only.
+
+**Positioning:** The self-hosted onboarding today is a manual paste of `http://100.x.x.x:9119` + username/password (or a loopback token). Scanning kills the error-prone paste. The QR is produced out-of-band for now (a dashboard QR *generator* is a separate fork/SPA follow-up, explicitly out of scope here).
+
+**Constraints:** Kotlin / Compose / Material3 / Hilt, per-tenant accent. **Client-only** — no gateway changes. Standing repo constraints (no AI attribution; gitleaks before every push; tenant isolation; `main` only via approved PR).
+
+**Key auth fact (from the gateway audit):** the loopback session token is **useless off-device** — any non-loopback bind forces the auth gate on, so a phone authenticates with **username + password** (`POST /auth/password-login`, already implemented via `GatedAuth.probeLogin`). A pairing QR's primary payload is therefore **URL + username + password**; `token` is optional (loopback/adb cases only).
+
+---
+
+## Scope (locked)
+
+- **In:** an in-app QR *scanner* on the setup screen; a versioned JSON payload; prefill + auto-Test + explicit Save; CAMERA permission; a new scanner dependency.
+- **Out:** dashboard QR *generation* (fork/SPA follow-up); mDNS/LAN auto-discovery (needs gateway `zeroconf` + non-loopback bind); Tailscale auto-discovery; a `hermes://` deep-link scheme (separate roadmap item).
+
+---
+
+## Architecture
+
+Three units: a pure payload parser, a ViewModel entry point, and the setup-screen UI (scanner + permission glue). The parser and the ViewModel apply-logic are pure/unit-tested; the camera/ZXing launch is Android glue verified on-device.
+
+### 1. Scanner library — ZXing embedded
+
+`com.journeyapps:zxing-android-embedded` (pulls `com.google.zxing:core`). Chosen because it is **offline and Google-Play-Services-free** (the app is currently GMS-free; a self-hosted/privacy audience may run no-GMS ROMs), small, and integrates via a one-shot `ScanContract`/`ScanOptions` ActivityResult. Requires the `CAMERA` permission.
+
+*Alternatives considered:* CameraX + ML Kit barcode (in-Compose scanner, but more code + a larger bundled model); GMS `play-services-code-scanner` (no CAMERA permission, but requires Play Services — rejected to keep no-GMS support).
+
+### 2. Payload — versioned JSON — `ui/setup/PairingPayload.kt` (new)
+
+```kotlin
+@Serializable
+data class PairingPayload(
+    val v: Int = 0,
+    val url: String = "",
+    val token: String = "",
+    val username: String = "",
+    val password: String = "",
+)
+
+/** Parse a scanned QR string; null if it isn't a valid v1 Hermes pairing code. */
+fun parsePairingPayload(raw: String): PairingPayload?
+```
+Rules: parse `raw` as JSON with a lenient `Json { ignoreUnknownKeys = true }`; return null when it isn't an object, `v != 1`, or `url` is blank; otherwise the payload. Never throws — malformed input → null. Example valid payload:
+```json
+{ "v": 1, "url": "https://andrews-macbook.tailc63a9b.ts.net", "username": "andrew", "password": "…" }
+```
+
+### 3. ViewModel — `ui/setup/SetupViewModel.kt` (modify)
+
+Add a `scanError: String?` field to `SetupUiState` and an entry point:
+```kotlin
+fun applyPairing(raw: String) {
+    val p = parsePairingPayload(raw)
+    if (p == null) {
+        _state.value = _state.value.copy(scanError = "Not a Hermes pairing code")
+        return
+    }
+    _state.value = _state.value.copy(
+        url = p.url, token = p.token, username = p.username, password = p.password,
+        scanError = null, testResult = null,
+    )
+    test() // reuse the existing probe; sets testResult to "Connected"/"Unreachable"
+}
+```
+`test()` and `save()` are unchanged. The scan populates the same fields the user could type, so the existing verify/persist path is reused end to end. (A `clearScanError()` may be added to dismiss the error on edit.)
+
+### 4. UI — `ui/setup/SetupScreen.kt` (modify)
+
+- A **"Scan QR"** button (per-tenant accent styling) above/beside the fields.
+- A CAMERA permission launcher (`rememberLauncherForActivityResult(RequestPermission)`); on grant → launch the scanner; on denial → keep manual entry + a short inline rationale (no hard block).
+- A ZXing scan launcher (`rememberLauncherForActivityResult(ScanContract())` with `ScanOptions().setDesiredBarcodeFormats(QR_CODE).setBeepEnabled(false)`); on a non-null result → `vm.applyPairing(result.contents)`.
+- Surface `scanError` inline near the button; the prefilled fields + `testResult` show the outcome. The user reviews, then taps the existing **Save & continue**.
+
+### 5. Files
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `gradle/libs.versions.toml` | ZXing embedded version + library alias |
+| Modify | `app/build.gradle.kts` | `implementation(libs.zxing.embedded)` |
+| Modify | `app/src/main/AndroidManifest.xml` | `<uses-permission android:name="android.permission.CAMERA" />` |
+| Create | `app/src/main/java/com/hermes/client/ui/setup/PairingPayload.kt` | payload model + pure `parsePairingPayload` |
+| Modify | `app/src/main/java/com/hermes/client/ui/setup/SetupViewModel.kt` | `scanError` state + `applyPairing` |
+| Modify | `app/src/main/java/com/hermes/client/ui/setup/SetupScreen.kt` | Scan-QR button, CAMERA permission, ZXing launcher |
+| Create | `app/src/test/java/com/hermes/client/ui/setup/PairingPayloadTest.kt` | pure parser tests |
+| Create | `app/src/test/java/com/hermes/client/ui/setup/SetupViewModelTest.kt` | `applyPairing` populate + scanError |
+
+## Data flow
+
+```
+[Scan QR] → CAMERA permission → ZXing ScanContract → result.contents (raw string)
+     → vm.applyPairing(raw) → parsePairingPayload(raw)
+          null → scanError = "Not a Hermes pairing code"
+          ok   → populate url/token/username/password → test() → testResult
+     → user reviews prefilled fields → [Save & continue] → store.save(GatewayConfig(...))
+```
+
+## Error handling
+
+- Malformed / non-Hermes / wrong-version / no-url QR → `scanError` message; fields untouched.
+- Scan cancelled (`result.contents == null`) → no-op.
+- CAMERA permission denied → manual entry remains fully usable; inline rationale; no crash.
+- Unreachable after auto-Test → the existing `testResult = "Unreachable"` (user can fix the fields or re-scan).
+
+## Testing
+
+**Pure `PairingPayloadTest`:** valid gated payload (url+username+password); valid token payload (url+token); malformed JSON → null; missing/`v != 1` → null; blank `url` → null; unknown extra keys ignored.
+
+**`SetupViewModelTest`:** `applyPairing(validJson)` populates url/username/password and clears `scanError`, and triggers the probe (mock `rest.statusFor`/`gatedAuth.probeLogin` → asserts `testResult`); `applyPairing(garbage)` sets `scanError` and leaves fields blank.
+
+The CAMERA permission flow and the ZXing capture Activity are Android — no unit tests (repo style); verified on-device.
+
+## On-device verification
+
+Generate a QR encoding a valid `{v:1,url,username,password}` payload (any offline QR tool), open setup, tap **Scan QR**, grant camera, scan → confirm the fields prefill, the auto-Test runs, and **Save & continue** connects. Also: scan a random non-Hermes QR → "Not a Hermes pairing code"; deny the camera permission → manual entry still works.
+
+## Build & gates
+
+`JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before every push; PR into `dev`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ junit = "4.13.2"
 androidxTestCore = "1.7.0"
 androidxTestJunit = "1.3.0"
 androidxTestRunner = "1.7.0"
+zxingEmbedded = "4.3.0"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -66,6 +67,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+zxing-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxingEmbedded" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Quick-wins wave (from `docs/ideas/2026-07-16-competitive-refresh.md`, self-hosted onboarding). Adds a "Scan QR" path to setup so a user pairs by scanning a QR that encodes the gateway URL + credentials, instead of hand-typing a long `ts.net` URL + password. Fully client-only — no gateway changes.

## What ships
- **Scan QR button** on the setup screen (offline **ZXing** scanner, GMS-free; new `CAMERA` permission). Scan → prefill the existing URL/username/password fields → auto-run the existing **Test** → user reviews → existing **Save & continue**. Cancel/deny → no-op, manual entry still works.
- **Versioned JSON payload** `{v:1, url, username, password, token?}` with a pure `parsePairingPayload` that rejects non-Hermes / malformed / wrong-version / non-http(s) codes → "Not a Hermes pairing code".
- Reuses `GatewayConfig` / `save()` / `test()` unchanged; the scanned password persists only via the existing `EncryptedCredentialStore` and is never logged.

**Auth note:** the QR carries **URL + username + password** — the loopback session token is useless off-device (any non-loopback bind forces the auth gate on), so the phone authenticates via `/auth/password-login`.

## Quality
- Executed subagent-driven: 3 TDD tasks + on-device verification, per-task reviews, opus whole-branch review.
- The whole-branch review caught (and this PR fixes) an **Important crash**: a malformed-but-non-blank URL — scanned *or manually typed* — reached `GatedAuth.probeLogin`, which built `HttpUrl` outside its `runCatching` → uncaught `IllegalArgumentException` → crash. Fixed at the root (build the `Request` inside `runCatching` in both `probeLogin` and `login`) **and** by tightening the parser to require an http/https URL. Re-reviewed → RESOLVED.
- **Gates:** 274 unit tests pass (0 fail/err); `compileDebugKotlin` + `assembleBeta` green (ZXing resolved, lintVital ok); gitleaks clean.
- **On-device (best-effort):** Scan QR button renders; tapping requests CAMERA; ZXing `CaptureActivity` launches a live preview — no crash. The decode→prefill itself couldn't be exercised (the emulator's virtual camera can't present a real QR); covered by ZXing's decode + the unit-tested parser/`applyPairing`.

## Deferred follow-ups (separate, non-blocking)
- **Dashboard QR *generation*** ("Pair phone" QR on the gateway SPA) — needs a fork change; the `qrcode` lib is already bundled there.
- **mDNS/LAN auto-discovery** (gateway `zeroconf` + non-loopback bind) and **Tailscale** auto-discovery.
- A `hermes://` deep-link scheme (separate roadmap item).