### PR TITLE
feat: read assistant responses aloud (TTS)

### DIFF
--- a/app/src/main/java/com/hermes/client/data/tts/TextToSpeechController.kt
+++ b/app/src/main/java/com/hermes/client/data/tts/TextToSpeechController.kt
@@ -1,0 +1,52 @@
+package com.hermes.client.data.tts
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Speaks text aloud; [speaking] is true while an utterance is playing. */
+interface TextToSpeechController {
+    val speaking: StateFlow<Boolean>
+    fun speak(text: String)
+    fun stop()
+}
+
+private const val UTTERANCE_ID = "hermes-read-aloud"
+
+/** Android [TextToSpeech]-backed controller. Init is async; a speak before ready is queued. */
+class AndroidTtsManager(context: Context) : TextToSpeechController {
+    private val _speaking = MutableStateFlow(false)
+    override val speaking: StateFlow<Boolean> = _speaking.asStateFlow()
+
+    private var ready = false
+    private var pending: String? = null
+
+    private val engine: TextToSpeech = TextToSpeech(context.applicationContext) { status ->
+        ready = status == TextToSpeech.SUCCESS
+        if (ready) {
+            engine.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+                override fun onStart(utteranceId: String?) { _speaking.value = true }
+                override fun onDone(utteranceId: String?) { _speaking.value = false }
+                @Deprecated("legacy") override fun onError(utteranceId: String?) { _speaking.value = false }
+                override fun onError(utteranceId: String?, errorCode: Int) { _speaking.value = false }
+                override fun onStop(utteranceId: String?, interrupted: Boolean) { _speaking.value = false }
+            })
+            pending?.let { speak(it); pending = null }
+        }
+    }
+
+    override fun speak(text: String) {
+        if (text.isBlank()) return
+        if (!ready) { pending = text; return }
+        engine.speak(text, TextToSpeech.QUEUE_FLUSH, null, UTTERANCE_ID)
+    }
+
+    override fun stop() {
+        pending = null
+        engine.stop()
+        _speaking.value = false
+    }
+}

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -212,4 +212,11 @@ object AppModule {
     @Singleton
     fun provideEnvRepository(rest: HermesRestApi): com.hermes.client.data.repository.EnvRepository =
         com.hermes.client.data.repository.EnvRepository(rest)
+
+    @Provides
+    @Singleton
+    fun provideTextToSpeechController(
+        @ApplicationContext context: Context,
+    ): com.hermes.client.data.tts.TextToSpeechController =
+        com.hermes.client.data.tts.AndroidTtsManager(context)
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -81,6 +81,9 @@ fun ChatMessageList(
     isGenerating: Boolean = false,
     onEditResend: (String) -> Unit = {},
     onRegenerate: () -> Unit = {},
+    isSpeaking: Boolean = false,
+    onReadAloud: (String) -> Unit = {},
+    onStopReading: () -> Unit = {},
     highlightIndex: Int? = null,
 ) {
     val lastIndex = state.messages.lastIndex
@@ -165,7 +168,16 @@ fun ChatMessageList(
             key = { index, msg -> "$index:${msg.id}" },
         ) { index, msg ->
             val canRegenerate = msg.id == lastAssistantId && !isGenerating
-            MessageBubble(msg, canRegenerate, onEditResend, onRegenerate, highlighted = index == highlightIndex)
+            MessageBubble(
+                msg,
+                canRegenerate,
+                onEditResend,
+                onRegenerate,
+                isSpeaking,
+                onReadAloud,
+                onStopReading,
+                highlighted = index == highlightIndex,
+            )
         }
     }
 }
@@ -180,11 +192,14 @@ private fun MessageBubble(
     canRegenerate: Boolean,
     onEditResend: (String) -> Unit,
     onRegenerate: () -> Unit,
+    isSpeaking: Boolean,
+    onReadAloud: (String) -> Unit,
+    onStopReading: () -> Unit,
     highlighted: Boolean = false,
 ) {
     when (msg.role) {
         Role.USER -> UserBubble(msg, onEditResend, highlighted = highlighted)
-        else -> AssistantTurn(msg, canRegenerate, onRegenerate, highlighted = highlighted)
+        else -> AssistantTurn(msg, canRegenerate, onRegenerate, isSpeaking, onReadAloud, onStopReading, highlighted = highlighted)
     }
 }
 
@@ -228,7 +243,15 @@ private fun UserBubble(msg: ChatMessage, onEditResend: (String) -> Unit, highlig
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun AssistantTurn(msg: ChatMessage, canRegenerate: Boolean, onRegenerate: () -> Unit, highlighted: Boolean = false) {
+private fun AssistantTurn(
+    msg: ChatMessage,
+    canRegenerate: Boolean,
+    onRegenerate: () -> Unit,
+    isSpeaking: Boolean,
+    onReadAloud: (String) -> Unit,
+    onStopReading: () -> Unit,
+    highlighted: Boolean = false,
+) {
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
     var menuOpen by remember { mutableStateOf(false) }
@@ -283,6 +306,15 @@ private fun AssistantTurn(msg: ChatMessage, canRegenerate: Boolean, onRegenerate
                 DropdownMenuItem(
                     text = { Text("Regenerate") },
                     onClick = { onRegenerate(); menuOpen = false },
+                )
+            }
+            if (msg.text.isNotBlank() && !msg.isError) {
+                DropdownMenuItem(
+                    text = { Text(if (isSpeaking) "Stop" else "Read aloud") },
+                    onClick = {
+                        if (isSpeaking) onStopReading() else onReadAloud(msg.text)
+                        menuOpen = false
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt
@@ -255,6 +255,7 @@ private fun AssistantTurn(
     val clipboard = LocalClipboardManager.current
     val context = LocalContext.current
     var menuOpen by remember { mutableStateOf(false) }
+    val speakable = remember(msg.text) { speechText(msg.text).isNotBlank() }
     val accent = LocalProfileAccent.current.accent
     val hlShape = RoundedCornerShape(12.dp)
     Box {
@@ -308,7 +309,7 @@ private fun AssistantTurn(
                     onClick = { onRegenerate(); menuOpen = false },
                 )
             }
-            if (msg.text.isNotBlank() && !msg.isError) {
+            if (speakable && !msg.isError) {
                 DropdownMenuItem(
                     text = { Text(if (isSpeaking) "Stop" else "Read aloud") },
                     onClick = {

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -102,6 +102,8 @@ fun ChatScreen(
     val activeProfile by vm.activeProfile.collectAsStateWithLifecycle()
     val commands by vm.commands.collectAsStateWithLifecycle()
     val pathItems by vm.pathItems.collectAsStateWithLifecycle()
+    val speaking by vm.speaking.collectAsStateWithLifecycle()
+    androidx.compose.runtime.DisposableEffect(Unit) { onDispose { vm.stopReading() } }
     var draft by remember { mutableStateOf("") }
     var searchOpen by rememberSaveable { mutableStateOf(false) }
     var query by rememberSaveable { mutableStateOf("") }
@@ -480,6 +482,9 @@ fun ChatScreen(
                         isGenerating = state.isGenerating,
                         onEditResend = { text -> draft = text; focusRequester.requestFocus() },
                         onRegenerate = { vm.regenerate() },
+                        isSpeaking = speaking,
+                        onReadAloud = { vm.readAloud(it) },
+                        onStopReading = { vm.stopReading() },
                         modifier = Modifier.weight(1f),
                     )
                 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -33,6 +33,7 @@ class ChatViewModel @Inject constructor(
     private val profileManager: ProfileManager,
     private val favoritesStore: com.hermes.client.data.repository.ModelFavoritesStore,
     private val pendingShareStore: com.hermes.client.share.PendingShareStore,
+    private val tts: com.hermes.client.data.tts.TextToSpeechController,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ChatUiState.empty())
@@ -65,6 +66,15 @@ class ChatViewModel @Inject constructor(
 
     val favorites: kotlinx.coroutines.flow.StateFlow<Set<String>> =
         favoritesStore.favorites.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    /** True while a response is being read aloud. */
+    val speaking: kotlinx.coroutines.flow.StateFlow<Boolean> = tts.speaking
+
+    /** Read [text] aloud (markdown stripped for cleaner speech). */
+    fun readAloud(text: String) = tts.speak(speechText(text))
+
+    /** Stop any current read-aloud. */
+    fun stopReading() = tts.stop()
 
     data class ModelSheetUi(
         val query: String = "",

--- a/app/src/main/java/com/hermes/client/ui/chat/SpeechText.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/SpeechText.kt
@@ -1,0 +1,27 @@
+package com.hermes.client.ui.chat
+
+/**
+ * Strip common markdown so TextToSpeech reads content, not syntax. Best-effort and intentionally
+ * simple — fenced code is dropped, inline code/emphasis/heading markers removed, links reduced to
+ * their text. Not a full markdown parser.
+ */
+fun speechText(raw: String): String {
+    if (raw.isBlank()) return ""
+    var s = raw
+    // Fenced code blocks: drop entirely (```lang ... ```).
+    s = Regex("```[\\s\\S]*?```").replace(s, " ")
+    // Links [text](url) -> text.
+    s = Regex("\\[([^\\]]+)]\\([^)]*\\)").replace(s) { it.groupValues[1] }
+    // Inline code `code` -> code.
+    s = Regex("`([^`]*)`").replace(s) { it.groupValues[1] }
+    // Heading markers at line start.
+    s = Regex("(?m)^\\s{0,3}#{1,6}\\s*").replace(s, "")
+    // Emphasis markers ** * __ _ (leave apostrophes/words intact).
+    s = s.replace("**", "").replace("__", "")
+    s = Regex("(?<![A-Za-z0-9])[*_](?=\\S)").replace(s, "")
+    s = Regex("(?<=\\S)[*_](?![A-Za-z0-9])").replace(s, "")
+    // Collapse whitespace runs and trim.
+    s = Regex("[ \\t]+").replace(s, " ")
+    s = Regex("\\n{2,}").replace(s, "\n").trim()
+    return s
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -40,6 +40,7 @@ class ChatViewModelTest {
     private val profileManager = mockk<com.hermes.client.data.repository.ProfileManager>(relaxed = true)
     private val favoritesStore = mockk<ModelFavoritesStore>(relaxed = true)
     private val pendingShareStore = com.hermes.client.share.PendingShareStore()
+    private val tts = mockk<com.hermes.client.data.tts.TextToSpeechController>(relaxed = true)
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -54,9 +55,10 @@ class ChatViewModelTest {
         coEvery { modelRepo.providers() } returns emptyList()
         coEvery { profileRepo.list() } returns emptyList()
         every { favoritesStore.favorites } returns MutableStateFlow(emptySet())
+        every { tts.speaking } returns MutableStateFlow(false)
     }
 
-    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore)
+    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore, tts)
 
     @Test fun streamed_delta_appears_in_state() = runTest {
         val vm = buildVm()
@@ -252,5 +254,17 @@ class ChatViewModelTest {
         advanceUntilIdle()
 
         coVerify { profileRepo.setActive("personal") }
+    }
+
+    @Test fun readAloud_speaks_markdown_stripped_text() {
+        val vm = buildVm()
+        vm.readAloud("**hi** `there`")
+        io.mockk.verify { tts.speak("hi there") }
+    }
+
+    @Test fun stopReading_stops_tts() {
+        val vm = buildVm()
+        vm.stopReading()
+        io.mockk.verify { tts.stop() }
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/chat/SpeechTextTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/SpeechTextTest.kt
@@ -1,0 +1,32 @@
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechTextTest {
+    @Test fun strips_emphasis_and_headings() {
+        assertEquals("Hello world", speechText("**Hello** _world_"))
+        assertEquals("Title", speechText("# Title"))
+    }
+
+    @Test fun link_becomes_its_text() {
+        assertEquals("click here", speechText("[click here](https://example.com)"))
+    }
+
+    @Test fun inline_code_backticks_stripped() {
+        assertEquals("run ls now", speechText("run `ls` now"))
+    }
+
+    @Test fun fenced_code_block_removed() {
+        val out = speechText("before\n```kotlin\nval x = 1\n```\nafter")
+        assertTrue(out.contains("before"))
+        assertTrue(out.contains("after"))
+        assertTrue(!out.contains("val x = 1"))
+    }
+
+    @Test fun plain_text_unchanged_and_empty_is_empty() {
+        assertEquals("just words", speechText("just words"))
+        assertEquals("", speechText(""))
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-tts-read-aloud.md
+++ b/docs/superpowers/plans/2026-07-17-tts-read-aloud.md
@@ -1,0 +1,352 @@
+# TTS Read-Aloud Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Read an assistant response aloud via native `TextToSpeech`, from the assistant-bubble action menu. Client-only.
+
+**Architecture:** A pure `speechText` markdown-stripper, a `TextToSpeechController` interface (Android impl wraps `TextToSpeech`, exposes `speaking: StateFlow<Boolean>`), `ChatViewModel` delegation, and a "Read aloud"/"Stop" dropdown item threaded through the message list.
+
+**Tech Stack:** Kotlin, Compose, Material3, Hilt, `android.speech.tts.TextToSpeech`.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-tts-read-aloud-design.md`
+
+## Global Constraints
+- Client-only; assistant turns only; no AI attribution.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch: `feature/tts-read-aloud` (off `dev`). All commits land here.
+
+---
+
+### Task 1: `speechText` pure helper
+
+**Files:** Create `app/src/main/java/com/hermes/client/ui/chat/SpeechText.kt`; Test `app/src/test/java/com/hermes/client/ui/chat/SpeechTextTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+`SpeechTextTest.kt`:
+```kotlin
+package com.hermes.client.ui.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechTextTest {
+    @Test fun strips_emphasis_and_headings() {
+        assertEquals("Hello world", speechText("**Hello** _world_"))
+        assertEquals("Title", speechText("# Title"))
+    }
+
+    @Test fun link_becomes_its_text() {
+        assertEquals("click here", speechText("[click here](https://example.com)"))
+    }
+
+    @Test fun inline_code_backticks_stripped() {
+        assertEquals("run ls now", speechText("run `ls` now"))
+    }
+
+    @Test fun fenced_code_block_removed() {
+        val out = speechText("before\n```kotlin\nval x = 1\n```\nafter")
+        assertTrue(out.contains("before"))
+        assertTrue(out.contains("after"))
+        assertTrue(!out.contains("val x = 1"))
+    }
+
+    @Test fun plain_text_unchanged_and_empty_is_empty() {
+        assertEquals("just words", speechText("just words"))
+        assertEquals("", speechText(""))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.SpeechTextTest"` → FAIL (unresolved).
+
+- [ ] **Step 3: Implement**
+
+`SpeechText.kt`:
+```kotlin
+package com.hermes.client.ui.chat
+
+/**
+ * Strip common markdown so TextToSpeech reads content, not syntax. Best-effort and intentionally
+ * simple — fenced code is dropped, inline code/emphasis/heading markers removed, links reduced to
+ * their text. Not a full markdown parser.
+ */
+fun speechText(raw: String): String {
+    if (raw.isBlank()) return ""
+    var s = raw
+    // Fenced code blocks: drop entirely (```lang ... ```).
+    s = Regex("```[\\s\\S]*?```").replace(s, " ")
+    // Links [text](url) -> text.
+    s = Regex("\\[([^\\]]+)]\\([^)]*\\)").replace(s) { it.groupValues[1] }
+    // Inline code `code` -> code.
+    s = Regex("`([^`]*)`").replace(s) { it.groupValues[1] }
+    // Heading markers at line start.
+    s = Regex("(?m)^\\s{0,3}#{1,6}\\s*").replace(s, "")
+    // Emphasis markers ** * __ _ (leave apostrophes/words intact).
+    s = s.replace("**", "").replace("__", "")
+    s = Regex("(?<![A-Za-z0-9])[*_](?=\\S)").replace(s, "")
+    s = Regex("(?<=\\S)[*_](?![A-Za-z0-9])").replace(s, "")
+    // Collapse whitespace runs and trim.
+    s = Regex("[ \\t]+").replace(s, " ")
+    s = Regex("\\n{2,}").replace(s, "\n").trim()
+    return s
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.SpeechTextTest"` → PASS (5 tests). If a regex edge case fails, adjust the regex minimally to satisfy the asserted behavior (the tests are the contract).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/SpeechText.kt \
+        app/src/test/java/com/hermes/client/ui/chat/SpeechTextTest.kt
+git commit -m "feat: add speechText markdown stripper for TTS"
+```
+
+---
+
+### Task 2: TextToSpeechController + Android impl + DI + ChatViewModel wiring
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/data/tts/TextToSpeechController.kt`
+- Modify: `app/src/main/java/com/hermes/client/di/AppModule.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt` (extend)
+
+**Interfaces:**
+- Consumes: `speechText` (Task 1).
+- Produces: `interface TextToSpeechController { val speaking: StateFlow<Boolean>; fun speak(text: String); fun stop() }`; `class AndroidTtsManager(context: Context) : TextToSpeechController`; `ChatViewModel.speaking`/`readAloud(text)`/`stopReading()`.
+
+- [ ] **Step 1: Write the failing test (extend ChatViewModelTest)**
+
+Add a mock field near the other mocks in `ChatViewModelTest.kt`:
+```kotlin
+    private val tts = mockk<com.hermes.client.data.tts.TextToSpeechController>(relaxed = true)
+```
+Update `buildVm()` to pass it (new last arg):
+```kotlin
+    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore, tts)
+```
+Add tests:
+```kotlin
+    @Test fun readAloud_speaks_markdown_stripped_text() {
+        val vm = buildVm()
+        vm.readAloud("**hi** `there`")
+        io.mockk.verify { tts.speak("hi there") }
+    }
+
+    @Test fun stopReading_stops_tts() {
+        val vm = buildVm()
+        vm.stopReading()
+        io.mockk.verify { tts.stop() }
+    }
+```
+(If `every { tts.speaking } returns MutableStateFlow(false)` is needed for the VM to read `tts.speaking` at construction, add it to the test setup alongside the other `every { … }` stubs. `relaxed = true` returns a default for `speaking`, but if the VM assigns `val speaking = tts.speaking` a relaxed mock returns a relaxed StateFlow — acceptable; add an explicit stub only if a test asserts on `vm.speaking`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ChatViewModelTest"` → FAIL (unresolved `TextToSpeechController`/`readAloud`/`stopReading` + arity mismatch).
+
+- [ ] **Step 3: Create the controller + Android impl**
+
+`app/src/main/java/com/hermes/client/data/tts/TextToSpeechController.kt`:
+```kotlin
+package com.hermes.client.data.tts
+
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** Speaks text aloud; [speaking] is true while an utterance is playing. */
+interface TextToSpeechController {
+    val speaking: StateFlow<Boolean>
+    fun speak(text: String)
+    fun stop()
+}
+
+private const val UTTERANCE_ID = "hermes-read-aloud"
+
+/** Android [TextToSpeech]-backed controller. Init is async; a speak before ready is queued. */
+class AndroidTtsManager(context: Context) : TextToSpeechController {
+    private val _speaking = MutableStateFlow(false)
+    override val speaking: StateFlow<Boolean> = _speaking.asStateFlow()
+
+    private var ready = false
+    private var pending: String? = null
+
+    private val engine = TextToSpeech(context.applicationContext) { status ->
+        ready = status == TextToSpeech.SUCCESS
+        if (ready) {
+            engine.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+                override fun onStart(utteranceId: String?) { _speaking.value = true }
+                override fun onDone(utteranceId: String?) { _speaking.value = false }
+                @Deprecated("legacy") override fun onError(utteranceId: String?) { _speaking.value = false }
+                override fun onError(utteranceId: String?, errorCode: Int) { _speaking.value = false }
+                override fun onStop(utteranceId: String?, interrupted: Boolean) { _speaking.value = false }
+            })
+            pending?.let { speak(it); pending = null }
+        }
+    }
+
+    override fun speak(text: String) {
+        if (text.isBlank()) return
+        if (!ready) { pending = text; return }
+        engine.speak(text, TextToSpeech.QUEUE_FLUSH, null, UTTERANCE_ID)
+    }
+
+    override fun stop() {
+        pending = null
+        engine.stop()
+        _speaking.value = false
+    }
+}
+```
+
+- [ ] **Step 4: Provide it via Hilt**
+
+In `app/src/main/java/com/hermes/client/di/AppModule.kt`, add a provider (mirror the existing `@Provides @Singleton` + `@ApplicationContext context: Context` style):
+```kotlin
+    @Provides
+    @Singleton
+    fun provideTextToSpeechController(
+        @ApplicationContext context: Context,
+    ): com.hermes.client.data.tts.TextToSpeechController =
+        com.hermes.client.data.tts.AndroidTtsManager(context)
+```
+
+- [ ] **Step 5: Wire ChatViewModel**
+
+In `ChatViewModel.kt`, add the constructor param (new last param) and the three members. Add to the `@Inject constructor(...)`:
+```kotlin
+    private val tts: com.hermes.client.data.tts.TextToSpeechController,
+```
+Add inside the class body:
+```kotlin
+    /** True while a response is being read aloud. */
+    val speaking: kotlinx.coroutines.flow.StateFlow<Boolean> = tts.speaking
+
+    /** Read [text] aloud (markdown stripped for cleaner speech). */
+    fun readAloud(text: String) = tts.speak(speechText(text))
+
+    /** Stop any current read-aloud. */
+    fun stopReading() = tts.stop()
+```
+
+- [ ] **Step 6: Run tests + compile**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ChatViewModelTest"` → PASS.
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/data/tts/TextToSpeechController.kt \
+        app/src/main/java/com/hermes/client/di/AppModule.kt \
+        app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt \
+        app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+git commit -m "feat: TextToSpeechController + ChatViewModel read-aloud"
+```
+
+---
+
+### Task 3: Dropdown item + threading + stop-on-leave
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+- Test: none new (Compose glue). Verified by compile + full suite + assembleBeta + Task 4.
+
+**Interfaces:** Consumes `ChatViewModel.speaking`/`readAloud`/`stopReading` (Task 2).
+
+- [ ] **Step 1: Thread params through the message list**
+
+In `ChatComponents.kt`, add three params to `ChatMessageList` (after `onRegenerate`):
+```kotlin
+    isSpeaking: Boolean = false,
+    onReadAloud: (String) -> Unit = {},
+    onStopReading: () -> Unit = {},
+```
+Pass them into `MessageBubble` where it is called inside `ChatMessageList` (alongside the existing args), and add matching params to `MessageBubble`:
+```kotlin
+private fun MessageBubble(
+    msg: ChatMessage,
+    canRegenerate: Boolean,
+    onEditResend: (String) -> Unit,
+    onRegenerate: () -> Unit,
+    isSpeaking: Boolean,
+    onReadAloud: (String) -> Unit,
+    onStopReading: () -> Unit,
+    highlighted: Boolean = false,
+)
+```
+and forward `isSpeaking`/`onReadAloud`/`onStopReading` to `AssistantTurn` (add the same three params to `AssistantTurn`'s signature). (`MessageBubble` dispatches `USER -> UserBubble`, `else -> AssistantTurn(...)` — add the args only to the `AssistantTurn` call.)
+
+- [ ] **Step 2: Add the dropdown item in `AssistantTurn`**
+
+In `AssistantTurn`'s `DropdownMenu`, after the `Copy` item (and the `canRegenerate` item), add:
+```kotlin
+            if (msg.text.isNotBlank() && !msg.isError) {
+                DropdownMenuItem(
+                    text = { Text(if (isSpeaking) "Stop" else "Read aloud") },
+                    onClick = {
+                        if (isSpeaking) onStopReading() else onReadAloud(msg.text)
+                        menuOpen = false
+                    },
+                )
+            }
+```
+
+- [ ] **Step 3: Wire ChatScreen**
+
+In `ChatScreen.kt`, collect speaking near the other `collectAsStateWithLifecycle` calls:
+```kotlin
+    val speaking by vm.speaking.collectAsStateWithLifecycle()
+```
+At the `ChatMessageList(...)` call (~line 475), add:
+```kotlin
+                        isSpeaking = speaking,
+                        onReadAloud = { vm.readAloud(it) },
+                        onStopReading = { vm.stopReading() },
+```
+Add a `DisposableEffect` in `ChatScreen` so audio stops when the screen leaves composition:
+```kotlin
+    androidx.compose.runtime.DisposableEffect(Unit) { onDispose { vm.stopReading() } }
+```
+
+- [ ] **Step 4: Compile + full suite + assembleBeta**
+
+Run each (JAVA_HOME set): `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta`. All BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatComponents.kt \
+        app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat: Read aloud/Stop item on assistant bubbles"
+```
+
+---
+
+### Task 4: On-device verification
+
+**Files:** none (manual).
+
+- [ ] **Step 1:** `:app:installBeta`.
+- [ ] **Step 2:** Open a chat with an assistant reply → long-press the assistant turn → tap **Read aloud** → confirm audio plays and the item flips to **Stop**.
+- [ ] **Step 3:** Tap **Stop** → audio stops. Start again, then navigate back → audio stops (stop-on-leave).
+- [ ] **Step 4:** Read a code-heavy reply → confirm backticks/markdown aren't read as literal syntax.
+- [ ] **Step 5:** Record pass/fail in the PR description (no commit). If the emulator has no TTS engine/audio, note it and rely on the unit tests + review.
+
+---
+
+## Notes for the executor
+- `AndroidTtsManager` never `shutdown()`s the engine (a process-lifetime singleton); acceptable for v1. Do not add a language/voice picker or auto-read (anti-scope).
+- If `UtteranceProgressListener`'s abstract members differ by API level, implement all required overrides so it compiles against the project's compileSdk.

--- a/docs/superpowers/specs/2026-07-17-tts-read-aloud-design.md
+++ b/docs/superpowers/specs/2026-07-17-tts-read-aloud-design.md
@@ -1,0 +1,76 @@
+# TTS Read-Aloud — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/tts-read-aloud` (off `dev`).
+
+**Goal:** Let the user have an assistant response read aloud via native Android `TextToSpeech`, from the existing per-bubble action menu. Fully client-only; no gateway involvement.
+
+**Constraints:** Kotlin / Compose / Material3 / Hilt. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Scope
+
+- **In:** a "Read aloud" / "Stop" item on the assistant-bubble dropdown; a lifecycle-safe TTS wrapper; markdown-stripped speech text; stop when leaving the chat.
+- **Out:** voice/language pickers, per-message playback UI/scrubber, auto-read-on-arrival, reading user/system messages (assistant turns only).
+
+## Architecture
+
+### 1. `ui/chat/SpeechText.kt` (new) — pure helper
+`fun speechText(raw: String): String` — strip common markdown so TTS doesn't read syntax aloud: fenced code blocks removed, inline code backticks stripped, `**`/`*`/`_` emphasis markers removed, heading `#` markers removed, link `[text](url)` → `text`, collapse blank runs. Pure, unit-tested.
+
+### 2. `data/tts/TextToSpeechController.kt` (new) — interface + Android impl
+```kotlin
+interface TextToSpeechController {
+    val speaking: StateFlow<Boolean>
+    fun speak(text: String)   // QUEUE_FLUSH (replaces any current utterance)
+    fun stop()
+}
+```
+`AndroidTtsManager(context)` (Hilt `@Singleton`): wraps `android.speech.tts.TextToSpeech`. Lazy async init via `OnInitListener` — a `speak` before init completes is queued and spoken on ready (or dropped if init failed). An `UtteranceProgressListener` drives `speaking` (`true` on start, `false` on done/error/stop). `speak` uses a fixed utterance id + `QUEUE_FLUSH`. Provided via a Hilt module using `@ApplicationContext`.
+
+### 3. `ui/chat/ChatViewModel.kt` (modify)
+Inject `TextToSpeechController`; expose:
+```kotlin
+val speaking: StateFlow<Boolean> = tts.speaking
+fun readAloud(text: String) = tts.speak(speechText(text))
+fun stopReading() = tts.stop()
+```
+
+### 4. UI — `ui/chat/ChatComponents.kt` + `ChatScreen.kt` (modify)
+Thread `isSpeaking: Boolean`, `onReadAloud: (String) -> Unit`, `onStopReading: () -> Unit` through `ChatMessageList` → `MessageBubble` → `AssistantTurn` (mirroring the existing `onRegenerate` threading). In `AssistantTurn`'s `DropdownMenu`, add an item:
+- `isSpeaking` → **"Stop"** → `onStopReading()`; else → **"Read aloud"** → `onReadAloud(msg.text)` (only when `msg.text.isNotBlank()` and `!msg.isError`).
+
+In `ChatScreen`: collect `vm.speaking`; pass `isSpeaking`, `onReadAloud = { vm.readAloud(it) }`, `onStopReading = { vm.stopReading() }` into `ChatMessageList` (call site ~line 475). Add a `DisposableEffect` (or reuse the existing leave path) calling `vm.stopReading()` when the chat screen leaves composition, so audio doesn't continue after navigating away.
+
+## Data flow
+```
+long-press assistant bubble → "Read aloud" → onReadAloud(msg.text)
+  → vm.readAloud → tts.speak(speechText(text)) → TextToSpeech (QUEUE_FLUSH)
+  → UtteranceProgressListener → speaking=true → menu item shows "Stop"
+"Stop" / leave chat → vm.stopReading() → tts.stop() → speaking=false
+```
+
+## Error handling
+- TTS init failure → `speak` is a no-op (nothing read; no crash); `speaking` stays false.
+- Blank/`isError` message → no "Read aloud" item shown.
+- `speechText` on empty → "" → nothing spoken.
+
+## Testing
+- **`SpeechTextTest`** (pure): code fence removed; inline backticks stripped; `**bold**`/`# heading`/`[t](u)` → clean text; plain text unchanged; empty → empty.
+- **`ChatViewModelTest`** (mock `TextToSpeechController`): `readAloud("**hi**")` calls `tts.speak` with the markdown-stripped text; `stopReading()` calls `tts.stop()`; `speaking` reflects the controller's flow.
+- The `AndroidTtsManager`/`TextToSpeech` glue is Android — verified on-device.
+
+## On-device verification
+Open a chat with an assistant reply → long-press → **Read aloud** → confirm audio plays and the item flips to **Stop**; tap **Stop** → audio stops. Start reading, then navigate back → confirm audio stops. Read a code-heavy reply → confirm code syntax isn't read as literal backticks/markdown.
+
+## Files
+| Action | Path |
+|--------|------|
+| New | `ui/chat/SpeechText.kt` + test |
+| New | `data/tts/TextToSpeechController.kt` (interface + `AndroidTtsManager`) |
+| Modify | `di/AppModule.kt` (provide the controller) |
+| Modify | `ui/chat/ChatViewModel.kt` |
+| Modify | `ui/chat/ChatComponents.kt` (menu + threading) |
+| Modify | `ui/chat/ChatScreen.kt` (wire + stop-on-leave) |
+| New test | `SpeechTextTest.kt`; extend `ChatViewModelTest` |
+
+## Build & gates
+`JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave (client-only). Adds a **Read aloud** action to the assistant-bubble menu using native Android `TextToSpeech`.

## What ships
- **"Read aloud" / "Stop"** on the assistant-bubble long-press menu (assistant turns only; hidden when the message has no speakable text, e.g. code-only).
- `TextToSpeechController` interface + `AndroidTtsManager` (Hilt singleton) wrapping `TextToSpeech` — async init queues a pre-ready speak, `QUEUE_FLUSH`, init-failure is a safe no-op, `speaking: StateFlow<Boolean>` drives the Stop toggle.
- Pure `speechText` strips markdown (code fences, backticks, emphasis, headings, links) so syntax isn't read aloud.
- Audio stops when leaving the chat (`DisposableEffect`).

## Quality
- Subagent-driven: 3 TDD tasks + on-device smoke, per-task reviews, opus whole-branch review → READY TO MERGE (applied one optional polish: hide the item when there's no speakable text).
- **Gates:** 281 unit tests pass; compile + assembleBeta green; gitleaks clean.
- **On-device (best-effort):** beta installs + launches clean (no crash from the TTS wiring); a TTS engine is present. Audio playback wasn't exercised (needs a connected session with an assistant reply); covered by `SpeechTextTest` + `ChatViewModelTest` (mock controller) + review.