### PR TITLE
feat: hermes:// deep links (tab + chat)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,12 @@
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="hermes" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -22,6 +22,7 @@ import com.hermes.client.data.repository.SettingsStore
 import com.hermes.client.data.repository.ThemeMode
 import com.hermes.client.ui.diagnostics.CrashReportScreen
 import com.hermes.client.ui.nav.HermesNav
+import com.hermes.client.ui.nav.deepLinkRouteFor
 import com.hermes.client.ui.theme.HermesTheme
 import com.hermes.client.ui.theme.LocalToolCallTechnical
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,7 +53,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         pendingRoute.value = intent?.getStringExtra("extra_route")
+            ?: intent?.data?.let { deepLinkRouteFor(it.toString()) }
         intent?.removeExtra("extra_route")
+        intent?.data = null
         handleShare(intent)
         val hasConfig = credentialStore.load() != null
         val crashReport = CrashReporter.read(this)
@@ -121,7 +124,9 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         pendingRoute.value = intent.getStringExtra("extra_route")
+            ?: intent.data?.let { deepLinkRouteFor(it.toString()) }
         intent.removeExtra("extra_route")
+        intent.data = null
         handleShare(intent)
     }
 

--- a/app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt
@@ -1,0 +1,21 @@
+package com.hermes.client.ui.nav
+
+private val TAB_ROUTES = setOf("sessions", "activity", "you")
+
+/**
+ * Map a `hermes://` URI string to an internal nav route, or null if it isn't a recognised link.
+ * Parsed with [java.net.URI] (pure JVM, unit-testable). Strict allowlist — a `hermes://` link is
+ * untrusted external input (BROWSABLE), so anything unknown returns null and is ignored.
+ */
+fun deepLinkRouteFor(raw: String): String? {
+    if (raw.isBlank()) return null
+    val uri = runCatching { java.net.URI(raw) }.getOrNull() ?: return null
+    if (!"hermes".equals(uri.scheme, ignoreCase = true)) return null
+    val host = uri.host ?: return null
+    val segs = uri.path.orEmpty().split('/').filter { it.isNotBlank() }
+    return when (host) {
+        "tab" -> segs.singleOrNull()?.takeIf { it in TAB_ROUTES }
+        "chat" -> segs.singleOrNull()?.takeIf { it.isNotBlank() && '/' !in it }?.let { "chat/$it" }
+        else -> null
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -89,7 +89,14 @@ fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsu
     val nav = rememberNavController()
     val start = if (hasConfig) "activity" else "setup"
 
-    LaunchedEffect(deepLinkRoute) { deepLinkRoute?.let { nav.navigate(it); onDeepLinkConsumed() } }
+    // Guard the navigate: a hermes:// deep link is untrusted, and even the notification path could
+    // carry a stale/unknown route — an unresolved route must be ignored, never crash.
+    LaunchedEffect(deepLinkRoute) {
+        deepLinkRoute?.let {
+            runCatching { nav.navigate(it) }
+            onDeepLinkConsumed()
+        }
+    }
 
     val backStackEntry by nav.currentBackStackEntryAsState()
     val route = backStackEntry?.destination?.route

--- a/app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt
@@ -1,0 +1,31 @@
+package com.hermes.client.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeepLinkMapperTest {
+    @Test fun tab_routes_map() {
+        assertEquals("sessions", deepLinkRouteFor("hermes://tab/sessions"))
+        assertEquals("activity", deepLinkRouteFor("hermes://tab/activity"))
+        assertEquals("you", deepLinkRouteFor("hermes://tab/you"))
+    }
+
+    @Test fun chat_id_maps() {
+        assertEquals("chat/abc-123", deepLinkRouteFor("hermes://chat/abc-123"))
+    }
+
+    @Test fun scheme_is_case_insensitive() {
+        assertEquals("sessions", deepLinkRouteFor("HERMES://tab/sessions"))
+    }
+
+    @Test fun unknown_or_malformed_is_null() {
+        assertNull(deepLinkRouteFor("hermes://tab/nope"))
+        assertNull(deepLinkRouteFor("hermes://chat"))       // no id
+        assertNull(deepLinkRouteFor("hermes://chat/a/b"))   // two segments
+        assertNull(deepLinkRouteFor("hermes://bogus/x"))    // unknown host
+        assertNull(deepLinkRouteFor("http://tab/sessions")) // wrong scheme
+        assertNull(deepLinkRouteFor(""))
+        assertNull(deepLinkRouteFor("not a uri at all ::: %%%"))
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-hermes-deep-links.md
+++ b/docs/superpowers/plans/2026-07-17-hermes-deep-links.md
@@ -1,0 +1,202 @@
+# `hermes://` Deep Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** Route `hermes://tab/{sessions|activity|you}` and `hermes://chat/<id>` links into the app, reusing the existing deep-link rail; harden the navigate against bad routes.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-hermes-deep-links-design.md`
+
+## Global Constraints
+- Client-only; strict allowlist (unknown links ignored); no crash on a bad route.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch `feature/hermes-deep-links` (off `dev`). No AI attribution.
+
+---
+
+### Task 1: Pure `deepLinkRouteFor` mapper
+
+**Files:** Create `app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt`; Test `app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+`DeepLinkMapperTest.kt`:
+```kotlin
+package com.hermes.client.ui.nav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DeepLinkMapperTest {
+    @Test fun tab_routes_map() {
+        assertEquals("sessions", deepLinkRouteFor("hermes://tab/sessions"))
+        assertEquals("activity", deepLinkRouteFor("hermes://tab/activity"))
+        assertEquals("you", deepLinkRouteFor("hermes://tab/you"))
+    }
+
+    @Test fun chat_id_maps() {
+        assertEquals("chat/abc-123", deepLinkRouteFor("hermes://chat/abc-123"))
+    }
+
+    @Test fun scheme_is_case_insensitive() {
+        assertEquals("sessions", deepLinkRouteFor("HERMES://tab/sessions"))
+    }
+
+    @Test fun unknown_or_malformed_is_null() {
+        assertNull(deepLinkRouteFor("hermes://tab/nope"))
+        assertNull(deepLinkRouteFor("hermes://chat"))       // no id
+        assertNull(deepLinkRouteFor("hermes://chat/a/b"))   // two segments
+        assertNull(deepLinkRouteFor("hermes://bogus/x"))    // unknown host
+        assertNull(deepLinkRouteFor("http://tab/sessions")) // wrong scheme
+        assertNull(deepLinkRouteFor(""))
+        assertNull(deepLinkRouteFor("not a uri at all ::: %%%"))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.nav.DeepLinkMapperTest"` → FAIL (unresolved).
+
+- [ ] **Step 3: Implement**
+
+`DeepLinkMapper.kt`:
+```kotlin
+package com.hermes.client.ui.nav
+
+private val TAB_ROUTES = setOf("sessions", "activity", "you")
+
+/**
+ * Map a `hermes://` URI string to an internal nav route, or null if it isn't a recognised link.
+ * Parsed with [java.net.URI] (pure JVM, unit-testable). Strict allowlist — a `hermes://` link is
+ * untrusted external input (BROWSABLE), so anything unknown returns null and is ignored.
+ */
+fun deepLinkRouteFor(raw: String): String? {
+    if (raw.isBlank()) return null
+    val uri = runCatching { java.net.URI(raw) }.getOrNull() ?: return null
+    if (!"hermes".equals(uri.scheme, ignoreCase = true)) return null
+    val host = uri.host ?: return null
+    val segs = uri.path.orEmpty().split('/').filter { it.isNotBlank() }
+    return when (host) {
+        "tab" -> segs.singleOrNull()?.takeIf { it in TAB_ROUTES }
+        "chat" -> segs.singleOrNull()?.takeIf { it.isNotBlank() && '/' !in it }?.let { "chat/$it" }
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.nav.DeepLinkMapperTest"` → PASS (4 tests). If `java.net.URI("not a uri at all ::: %%%")` throws instead of the `runCatching` catching it, confirm the `runCatching` wraps the constructor (it does) — the test expects null.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt \
+        app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt
+git commit -m "feat: add hermes:// deep-link route mapper"
+```
+
+---
+
+### Task 2: Intent-filter + MainActivity + navigate hardening
+
+**Files:**
+- Modify: `app/src/main/AndroidManifest.xml`
+- Modify: `app/src/main/java/com/hermes/client/MainActivity.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt`
+- Test: none new (Android glue). Compile + full suite + assembleBeta + Task 3.
+
+**Interfaces:** Consumes `deepLinkRouteFor` (Task 1).
+
+- [ ] **Step 1: Add the intent-filter**
+
+In `AndroidManifest.xml`, inside the existing `<activity android:name=".MainActivity" …>` block (after the existing intent-filters), add:
+```xml
+        <intent-filter android:autoVerify="false">
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="hermes" />
+        </intent-filter>
+```
+
+- [ ] **Step 2: Read `intent.data` in MainActivity**
+
+In `MainActivity.kt`, add the import:
+```kotlin
+import com.hermes.client.ui.nav.deepLinkRouteFor
+```
+In `onCreate`, replace:
+```kotlin
+        pendingRoute.value = intent?.getStringExtra("extra_route")
+        intent?.removeExtra("extra_route")
+```
+with:
+```kotlin
+        pendingRoute.value = intent?.getStringExtra("extra_route")
+            ?: intent?.data?.let { deepLinkRouteFor(it.toString()) }
+        intent?.removeExtra("extra_route")
+        intent?.data = null
+```
+In `onNewIntent`, replace:
+```kotlin
+        pendingRoute.value = intent.getStringExtra("extra_route")
+        intent.removeExtra("extra_route")
+```
+with:
+```kotlin
+        pendingRoute.value = intent.getStringExtra("extra_route")
+            ?: intent.data?.let { deepLinkRouteFor(it.toString()) }
+        intent.removeExtra("extra_route")
+        intent.data = null
+```
+
+- [ ] **Step 3: Harden the navigate in HermesNav**
+
+In `HermesNav.kt`, replace:
+```kotlin
+    LaunchedEffect(deepLinkRoute) { deepLinkRoute?.let { nav.navigate(it); onDeepLinkConsumed() } }
+```
+with:
+```kotlin
+    // Guard the navigate: a hermes:// deep link is untrusted, and even the notification path could
+    // carry a stale/unknown route — an unresolved route must be ignored, never crash.
+    LaunchedEffect(deepLinkRoute) {
+        deepLinkRoute?.let {
+            runCatching { nav.navigate(it) }
+            onDeepLinkConsumed()
+        }
+    }
+```
+
+- [ ] **Step 4: Compile + full suite + assembleBeta**
+
+Run each (JAVA_HOME set): `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta` — all BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/AndroidManifest.xml \
+        app/src/main/java/com/hermes/client/MainActivity.kt \
+        app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+git commit -m "feat: accept hermes:// VIEW intents and guard deep-link navigation"
+```
+
+---
+
+### Task 3: On-device verification (adb-driven, fully exercisable)
+
+**Files:** none.
+
+- [ ] **Step 1:** `:app:installBeta` (target the emulator explicitly if multiple devices: `adb -s emulator-5554 …`). The app must be configured (past setup) for tab navigation to land meaningfully; if on the setup screen, note it.
+- [ ] **Step 2:** `adb shell am start -a android.intent.action.VIEW -d "hermes://tab/sessions" com.hermes.client.beta` → app foregrounds on the **Chats** tab. Repeat `hermes://tab/activity` (Home) and `hermes://tab/you` (You).
+- [ ] **Step 3:** `adb shell am start -a android.intent.action.VIEW -d "hermes://chat/<real-id>" com.hermes.client.beta` → opens that chat (if the active profile owns it). Confirm no crash if the id isn't found (lands/stays gracefully).
+- [ ] **Step 4:** `adb shell am start -a android.intent.action.VIEW -d "hermes://bogus/x" com.hermes.client.beta` → app opens normally, link ignored, **no crash** (verify process alive: `adb shell pidof com.hermes.client.beta`).
+- [ ] **Step 5:** Record pass/fail in the PR description (no commit).
+
+---
+
+## Notes for the executor
+- Keep the existing `extra_route` (notification) path working — the deep-link read is a **fallback** (`?:`) only when `extra_route` is absent.
+- Do NOT add `?profile=` handling, cron links, `https://` App Links, or link *generation* — all explicit anti-scope for this wave.

--- a/docs/superpowers/specs/2026-07-17-hermes-deep-links-design.md
+++ b/docs/superpowers/specs/2026-07-17-hermes-deep-links-design.md
@@ -1,0 +1,101 @@
+# `hermes://` Deep Links — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/hermes-deep-links` (off `dev`).
+
+**Goal:** Accept a public `hermes://` link that routes into a specific tab or chat — the foundation for a future home-screen widget and share-sheet. Client-only; reuses the existing `pendingRoute → HermesNav.deepLinkRoute → nav.navigate` rail.
+
+**Constraints:** Kotlin/Compose/Hilt. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Scope
+
+- **In:** a `hermes://` VIEW/BROWSABLE intent-filter; a pure allowlist `Uri`→route mapper; wiring into the existing deep-link rail; hardening the currently-unguarded `nav.navigate` (a bad route currently crashes).
+- **URLs:** `hermes://tab/sessions`, `hermes://tab/activity`, `hermes://tab/you`, `hermes://chat/<id>`.
+- **Out (deferred follow-ups):** `?profile=<p>` profile-switch for chat links (has an async switch-then-navigate ordering subtlety — its own design); `hermes://cron/<id>` (cron is per-profile, same profile concern); App Links (`https://` + `autoVerify`); generating links (widget/share — later waves).
+
+## Security & tenant notes
+- A `hermes://` link is **untrusted external input** (BROWSABLE = any app/web page can fire it). The mapper is a strict allowlist returning `null` for anything unknown; unknown/malformed links are silently ignored. Never forward a raw URL segment to `nav.navigate`.
+- `hermes://chat/<id>` opens in the **current active profile**. If the id belongs to another tenant, `ChatViewModel` loads against the active profile and shows "session not found" — it **fails safe** (session ids are UUIDs; no cross-tenant collision, so no other tenant's data is shown). Profile-aware chat links are a deferred enhancement.
+
+## Architecture
+
+### 1. `ui/nav/DeepLinkMapper.kt` (new) — pure mapper
+Takes the raw URI **string** (parsed with `java.net.URI`, pure JVM — so it's unit-testable without Android `Uri`):
+```kotlin
+private val TAB_ROUTES = setOf("sessions", "activity", "you")
+
+/** Map a hermes:// URI string to an internal nav route, or null if it isn't a recognised link. */
+fun deepLinkRouteFor(raw: String): String? {
+    if (raw.isBlank()) return null
+    val uri = runCatching { java.net.URI(raw) }.getOrNull() ?: return null
+    if (!"hermes".equals(uri.scheme, ignoreCase = true)) return null
+    val host = uri.host ?: return null
+    val segs = uri.path.orEmpty().split('/').filter { it.isNotBlank() }
+    return when (host) {
+        "tab" -> segs.singleOrNull()?.takeIf { it in TAB_ROUTES }
+        "chat" -> segs.singleOrNull()?.takeIf { it.isNotBlank() && '/' !in it }?.let { "chat/$it" }
+        else -> null
+    }
+}
+```
+
+### 2. `AndroidManifest.xml` (modify) — intent-filter
+Add to the existing `MainActivity` `<activity>` block (already `exported="true"`):
+```xml
+<intent-filter android:autoVerify="false">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="hermes" />
+</intent-filter>
+```
+
+### 3. `MainActivity.kt` (modify) — read `intent.data`
+In `onCreate` and `onNewIntent`, fall back to a mapped `hermes://` link when there's no `extra_route`, and consume `intent.data` (mirroring the existing `removeExtra` discipline so a config-change recreation doesn't re-fire):
+```kotlin
+pendingRoute.value = intent?.getStringExtra("extra_route")
+    ?: intent?.data?.let { deepLinkRouteFor(it.toString()) }
+intent?.removeExtra("extra_route")
+intent?.data = null
+```
+(`onNewIntent` uses the non-null `intent`; same two-line pattern after `setIntent(intent)`.)
+
+### 4. `HermesNav.kt` (modify) — harden the navigate
+The `LaunchedEffect(deepLinkRoute)` currently does `nav.navigate(it)` unguarded — an unknown route throws. Wrap it so a bad/unknown route is ignored, not crashing (this also protects the notification `extra_route` path):
+```kotlin
+LaunchedEffect(deepLinkRoute) {
+    deepLinkRoute?.let {
+        runCatching { nav.navigate(it) }
+        onDeepLinkConsumed()
+    }
+}
+```
+
+## Data flow
+```
+external hermes://tab/sessions (or chat/<id>) → VIEW intent → MainActivity onCreate/onNewIntent
+  → deepLinkRouteFor(intent.data.toString()) → "sessions" / "chat/<id>" (or null → ignored)
+  → pendingRoute → HermesNav.deepLinkRoute → runCatching { nav.navigate(route) } → onDeepLinkConsumed
+```
+
+## Error handling
+- Unknown host / bad path / wrong scheme / malformed URI → `deepLinkRouteFor` returns null → nothing navigated.
+- A mapped route that somehow isn't registered → `runCatching` swallows the navigation exception (no crash).
+- `intent.data` consumed (`= null`) after read so recreation doesn't re-navigate.
+
+## Testing
+- **`DeepLinkMapperTest`** (pure JUnit, string input): each tab route maps; `hermes://chat/abc-123` → `chat/abc-123`; unknown host → null; `hermes://tab/nope` → null; `hermes://chat` (no id) → null; `hermes://chat/a/b` (2 segs) → null; wrong scheme `http://...` → null; blank/garbage → null; scheme case-insensitive.
+- MainActivity/manifest/HermesNav are Android glue — verified on-device (deep links are directly testable via `adb am start -a VIEW -d "hermes://…"`).
+
+## On-device verification
+`adb shell am start -a android.intent.action.VIEW -d "hermes://tab/sessions" com.hermes.client.beta` → app opens on the Chats tab. Repeat for `tab/activity`, `tab/you`, and `hermes://chat/<real-id>` (opens that chat if in the right profile). `adb ... -d "hermes://bogus/x"` → app opens normally (link ignored, no crash).
+
+## Files
+| Action | Path |
+|--------|------|
+| New | `ui/nav/DeepLinkMapper.kt` + `DeepLinkMapperTest.kt` |
+| Modify | `AndroidManifest.xml` (intent-filter) |
+| Modify | `MainActivity.kt` (read intent.data) |
+| Modify | `ui/nav/HermesNav.kt` (harden navigate) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave (client-only). Accepts a public `hermes://` link that routes into a specific tab or chat — the foundation for a future home-screen widget + share-sheet.

## What ships
- **`hermes://tab/{sessions|activity|you}`** and **`hermes://chat/<id>`** via a strict, pure allowlist mapper (`deepLinkRouteFor`) — anything unknown/malformed is ignored.
- A VIEW/BROWSABLE `hermes` intent-filter on `MainActivity`; `intent.data` read in onCreate + onNewIntent as a `?:` fallback after the existing notification `extra_route` path (both consumed after read).
- **Hardened** the deep-link `nav.navigate` in `runCatching` — a bad/unknown route is ignored, never crashes (also protects the notification path).
- `MainActivity` set to `singleTask` so an external `hermes://` link reuses the running instance (via `onNewIntent`) instead of duplicating the activity.

## Safety
- A `hermes://` link is untrusted (BROWSABLE); the allowlist + guard make an unknown/malformed link inert. Chat links open in the current active profile and **fail safe** to "session not found" if the id belongs to another tenant (UUIDs don't collide → no cross-tenant data shown).

## Quality
- Subagent-driven: 2 TDD/code tasks + adb-driven on-device verification, per-task reviews, opus whole-branch review (caught + fixed the `launchMode` duplicate-activity issue).
- **Gates:** 285 unit tests pass; compile + assembleBeta green; gitleaks clean.
- **On-device (adb VIEW intents):** `hermes://tab/you`→You, `tab/sessions`→Chats (reused running instance after the singleTask fix), `hermes://bogus/x`→ignored, no crash.

## Deferred follow-ups
`?profile=` profile-switch for chat links (async switch-then-navigate ordering — own design), `hermes://cron/<id>`, `https://` App Links, and link *generation* (the widget/share waves).