### PR TITLE
feat: home-screen quick-launch widget (Glance)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
     implementation(libs.security.crypto)
     implementation(libs.markdown.m3)
     implementation(libs.zxing.embedded)
+    implementation(libs.glance.appwidget)
 
     debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,16 @@
         <receiver
             android:name=".notifications.NotificationActionReceiver"
             android:exported="false" />
+        <receiver
+            android:name=".widget.HermesWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/hermes_widget_info" />
+        </receiver>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -50,6 +50,7 @@ class MainActivity : ComponentActivity() {
      * already running still navigates; consumed by `HermesNav`'s `deepLinkRoute` param.
      */
     private var pendingRoute = mutableStateOf<String?>(null)
+    private val newChatInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -156,18 +157,23 @@ class MainActivity : ComponentActivity() {
     /** Create a fresh chat and navigate to it (widget "New chat" / hermes://new). No-op if unconfigured. */
     private fun openNewChat() {
         if (credentialStore.load() == null) return
+        if (!newChatInFlight.compareAndSet(false, true)) return // a create is already running — ignore repeat taps
         lifecycleScope.launch {
-            chat.connect() // idempotent; a cold start has no socket yet
-            runCatching {
-                profileManager.refresh() // load active profile so the session isn't orphaned to default
-                chat.createSession(profileManager.active.value)
-            }.onSuccess { id -> pendingRoute.value = "chat/$id" }
-                .onFailure { e ->
-                    if (e is kotlinx.coroutines.CancellationException) throw e
-                    android.widget.Toast.makeText(
-                        this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT,
-                    ).show()
-                }
+            try {
+                chat.connect() // idempotent; a cold start has no socket yet
+                runCatching {
+                    profileManager.refresh() // load active profile so the session isn't orphaned to default
+                    chat.createSession(profileManager.active.value)
+                }.onSuccess { id -> pendingRoute.value = "chat/$id" }
+                    .onFailure { e ->
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        android.widget.Toast.makeText(
+                            this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                    }
+            } finally {
+                newChatInFlight.set(false)
+            }
         }
     }
 

--- a/app/src/main/java/com/hermes/client/MainActivity.kt
+++ b/app/src/main/java/com/hermes/client/MainActivity.kt
@@ -23,6 +23,7 @@ import com.hermes.client.data.repository.ThemeMode
 import com.hermes.client.ui.diagnostics.CrashReportScreen
 import com.hermes.client.ui.nav.HermesNav
 import com.hermes.client.ui.nav.deepLinkRouteFor
+import com.hermes.client.ui.nav.isNewChatLink
 import com.hermes.client.ui.theme.HermesTheme
 import com.hermes.client.ui.theme.LocalToolCallTechnical
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,10 +53,16 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        pendingRoute.value = intent?.getStringExtra("extra_route")
-            ?: intent?.data?.let { deepLinkRouteFor(it.toString()) }
-        intent?.removeExtra("extra_route")
-        intent?.data = null
+        val dlData = intent?.data
+        if (dlData != null && isNewChatLink(dlData.toString())) {
+            openNewChat()
+            intent?.data = null
+        } else {
+            pendingRoute.value = intent?.getStringExtra("extra_route")
+                ?: dlData?.let { deepLinkRouteFor(it.toString()) }
+            intent?.removeExtra("extra_route")
+            intent?.data = null
+        }
         handleShare(intent)
         val hasConfig = credentialStore.load() != null
         val crashReport = CrashReporter.read(this)
@@ -123,10 +130,16 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        pendingRoute.value = intent.getStringExtra("extra_route")
-            ?: intent.data?.let { deepLinkRouteFor(it.toString()) }
-        intent.removeExtra("extra_route")
-        intent.data = null
+        val dlData = intent.data
+        if (dlData != null && isNewChatLink(dlData.toString())) {
+            openNewChat()
+            intent.data = null
+        } else {
+            pendingRoute.value = intent.getStringExtra("extra_route")
+                ?: dlData?.let { deepLinkRouteFor(it.toString()) }
+            intent.removeExtra("extra_route")
+            intent.data = null
+        }
         handleShare(intent)
     }
 
@@ -138,6 +151,24 @@ class MainActivity : ComponentActivity() {
             putExtra(Intent.EXTRA_TEXT, report)
         }
         startActivity(Intent.createChooser(intent, "Share crash report"))
+    }
+
+    /** Create a fresh chat and navigate to it (widget "New chat" / hermes://new). No-op if unconfigured. */
+    private fun openNewChat() {
+        if (credentialStore.load() == null) return
+        lifecycleScope.launch {
+            chat.connect() // idempotent; a cold start has no socket yet
+            runCatching {
+                profileManager.refresh() // load active profile so the session isn't orphaned to default
+                chat.createSession(profileManager.active.value)
+            }.onSuccess { id -> pendingRoute.value = "chat/$id" }
+                .onFailure { e ->
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    android.widget.Toast.makeText(
+                        this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+        }
     }
 
     /**

--- a/app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt
@@ -19,3 +19,11 @@ fun deepLinkRouteFor(raw: String): String? {
         else -> null
     }
 }
+
+/** True for a `hermes://new` link (widget "New chat"). Not a nav route — the caller runs createSession. */
+fun isNewChatLink(raw: String): Boolean {
+    val uri = runCatching { java.net.URI(raw) }.getOrNull() ?: return false
+    if (!"hermes".equals(uri.scheme, ignoreCase = true) || uri.host != "new") return false
+    val segs = uri.path.orEmpty().split('/').filter { it.isNotBlank() }
+    return segs.isEmpty()
+}

--- a/app/src/main/java/com/hermes/client/widget/HermesWidget.kt
+++ b/app/src/main/java/com/hermes/client/widget/HermesWidget.kt
@@ -1,0 +1,57 @@
+package com.hermes.client.widget
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+
+class HermesWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent { Content(context) }
+    }
+
+    @Composable
+    private fun Content(context: Context) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize()
+                .background(ColorProvider(Color(0xFF3B3BAF)))
+                .padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Item(context, "New chat", "hermes://new")
+            Item(context, "Chats", "hermes://tab/sessions")
+            Item(context, "Home", "hermes://tab/activity")
+        }
+    }
+
+    @Composable
+    private fun Item(context: Context, label: String, uri: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).setPackage(context.packageName)
+        Text(
+            text = label,
+            modifier = GlanceModifier.fillMaxWidth()
+                .padding(vertical = 6.dp)
+                .clickable(actionStartActivity(intent)),
+            style = TextStyle(color = ColorProvider(Color.White), fontSize = 16.sp, textAlign = TextAlign.Center),
+        )
+    }
+}

--- a/app/src/main/java/com/hermes/client/widget/HermesWidgetReceiver.kt
+++ b/app/src/main/java/com/hermes/client/widget/HermesWidgetReceiver.kt
@@ -1,0 +1,8 @@
+package com.hermes.client.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class HermesWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = HermesWidget()
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="widget_description">Quick actions for Hermes</string>
+</resources>

--- a/app/src/main/res/xml/hermes_widget_info.xml
+++ b/app/src/main/res/xml/hermes_widget_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/glance_default_loading_layout" />

--- a/app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt
@@ -1,7 +1,9 @@
 package com.hermes.client.ui.nav
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DeepLinkMapperTest {
@@ -27,5 +29,18 @@ class DeepLinkMapperTest {
         assertNull(deepLinkRouteFor("http://tab/sessions")) // wrong scheme
         assertNull(deepLinkRouteFor(""))
         assertNull(deepLinkRouteFor("not a uri at all ::: %%%"))
+    }
+
+    @Test fun new_chat_link_recognised() {
+        assertTrue(isNewChatLink("hermes://new"))
+        assertTrue(isNewChatLink("HERMES://new"))
+    }
+
+    @Test fun non_new_links_are_false() {
+        assertFalse(isNewChatLink("hermes://new/x"))
+        assertFalse(isNewChatLink("hermes://tab/sessions"))
+        assertFalse(isNewChatLink("http://new"))
+        assertFalse(isNewChatLink(""))
+        assertFalse(isNewChatLink("garbage ::: %%"))
     }
 }

--- a/docs/superpowers/plans/2026-07-17-home-widget.md
+++ b/docs/superpowers/plans/2026-07-17-home-widget.md
@@ -1,0 +1,299 @@
+# Home-Screen Quick-Launch Widget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** A Glance widget with New chat / Chats / Home buttons; New chat via a new `hermes://new` verb reusing the share rail.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-home-widget-design.md`
+
+## Global Constraints
+- Client-only; static widget theme (no per-tenant accent in Glance); no AI attribution.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch `feature/home-widget` (off `dev`).
+
+---
+
+### Task 1: `isNewChatLink` predicate
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt`; Test `app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt` (extend)
+
+- [ ] **Step 1: Add failing tests** to `DeepLinkMapperTest.kt`:
+```kotlin
+    @Test fun new_chat_link_recognised() {
+        assertTrue(isNewChatLink("hermes://new"))
+        assertTrue(isNewChatLink("HERMES://new"))
+    }
+
+    @Test fun non_new_links_are_false() {
+        assertFalse(isNewChatLink("hermes://new/x"))
+        assertFalse(isNewChatLink("hermes://tab/sessions"))
+        assertFalse(isNewChatLink("http://new"))
+        assertFalse(isNewChatLink(""))
+        assertFalse(isNewChatLink("garbage ::: %%"))
+    }
+```
+(Add `import org.junit.Assert.assertTrue` / `assertFalse` if not already present.)
+
+- [ ] **Step 2:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.nav.DeepLinkMapperTest"` → FAIL (unresolved `isNewChatLink`).
+
+- [ ] **Step 3: Implement** — append to `DeepLinkMapper.kt`:
+```kotlin
+/** True for a `hermes://new` link (widget "New chat"). Not a nav route — the caller runs createSession. */
+fun isNewChatLink(raw: String): Boolean {
+    val uri = runCatching { java.net.URI(raw) }.getOrNull() ?: return false
+    return "hermes".equals(uri.scheme, ignoreCase = true) && uri.host == "new"
+}
+```
+
+- [ ] **Step 4:** Run the test → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/nav/DeepLinkMapper.kt \
+        app/src/test/java/com/hermes/client/ui/nav/DeepLinkMapperTest.kt
+git commit -m "feat: recognise hermes://new deep link"
+```
+
+---
+
+### Task 2: `openNewChat` + `hermes://new` handling in MainActivity
+
+**Files:** Modify `app/src/main/java/com/hermes/client/MainActivity.kt`
+
+**Interfaces:** Consumes `isNewChatLink` (Task 1); reuses existing `chat`, `profileManager`, `credentialStore`, `pendingRoute`, `lifecycleScope`.
+
+- [ ] **Step 1: Add the import**
+```kotlin
+import com.hermes.client.ui.nav.isNewChatLink
+```
+(`deepLinkRouteFor` is already imported from the deep-links wave.)
+
+- [ ] **Step 2: Add `openNewChat()`** as a private method (near `handleShare`):
+```kotlin
+    /** Create a fresh chat and navigate to it (widget "New chat" / hermes://new). No-op if unconfigured. */
+    private fun openNewChat() {
+        if (credentialStore.load() == null) return
+        lifecycleScope.launch {
+            chat.connect() // idempotent; a cold start has no socket yet
+            runCatching {
+                profileManager.refresh() // load active profile so the session isn't orphaned to default
+                chat.createSession(profileManager.active.value)
+            }.onSuccess { id -> pendingRoute.value = "chat/$id" }
+                .onFailure { e ->
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    android.widget.Toast.makeText(
+                        this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT,
+                    ).show()
+                }
+        }
+    }
+```
+
+- [ ] **Step 3: Branch on `hermes://new` in onCreate.** Replace the existing deep-link read block in `onCreate`:
+```kotlin
+        pendingRoute.value = intent?.getStringExtra("extra_route")
+            ?: intent?.data?.let { deepLinkRouteFor(it.toString()) }
+        intent?.removeExtra("extra_route")
+        intent?.data = null
+```
+with:
+```kotlin
+        val dlData = intent?.data
+        if (dlData != null && isNewChatLink(dlData.toString())) {
+            openNewChat()
+            intent?.data = null
+        } else {
+            pendingRoute.value = intent?.getStringExtra("extra_route")
+                ?: dlData?.let { deepLinkRouteFor(it.toString()) }
+            intent?.removeExtra("extra_route")
+            intent?.data = null
+        }
+```
+
+- [ ] **Step 4: Same branch in onNewIntent.** Replace the equivalent block:
+```kotlin
+        pendingRoute.value = intent.getStringExtra("extra_route")
+            ?: intent.data?.let { deepLinkRouteFor(it.toString()) }
+        intent.removeExtra("extra_route")
+        intent.data = null
+```
+with:
+```kotlin
+        val dlData = intent.data
+        if (dlData != null && isNewChatLink(dlData.toString())) {
+            openNewChat()
+            intent.data = null
+        } else {
+            pendingRoute.value = intent.getStringExtra("extra_route")
+                ?: dlData?.let { deepLinkRouteFor(it.toString()) }
+            intent.removeExtra("extra_route")
+            intent.data = null
+        }
+```
+
+- [ ] **Step 5: Compile** — `JAVA_HOME=… ./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/MainActivity.kt
+git commit -m "feat: handle hermes://new to start a new chat"
+```
+
+---
+
+### Task 3: Glance widget + dependency + manifest
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`, `app/build.gradle.kts`
+- New: `app/src/main/java/com/hermes/client/widget/HermesWidget.kt`, `HermesWidgetReceiver.kt`
+- New: `app/src/main/res/xml/hermes_widget_info.xml`
+- Modify: `app/src/main/res/values/strings.xml` (create if absent), `app/src/main/AndroidManifest.xml`
+- Test: none new (Android glue). Compile + full suite + assembleBeta + Task 4.
+
+- [ ] **Step 1: Add the Glance dependency**
+
+`gradle/libs.versions.toml`: under `[versions]` add `glance = "1.1.1"`; under `[libraries]` add:
+```toml
+glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
+```
+`app/build.gradle.kts` (in `dependencies {}`): `implementation(libs.glance.appwidget)`.
+
+- [ ] **Step 2: Create the widget**
+
+`app/src/main/java/com/hermes/client/widget/HermesWidget.kt`:
+```kotlin
+package com.hermes.client.widget
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.action.clickable
+import androidx.glance.GlanceModifier
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+import androidx.glance.text.TextAlign
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+
+class HermesWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent { Content(context) }
+    }
+
+    @Composable
+    private fun Content(context: Context) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize()
+                .background(ColorProvider(Color(0xFF3B3BAF)))
+                .padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Item(context, "New chat", "hermes://new")
+            Item(context, "Chats", "hermes://tab/sessions")
+            Item(context, "Home", "hermes://tab/activity")
+        }
+    }
+
+    @Composable
+    private fun Item(context: Context, label: String, uri: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).setPackage(context.packageName)
+        Text(
+            text = label,
+            modifier = GlanceModifier.fillMaxWidth()
+                .padding(vertical = 6.dp)
+                .clickable(actionStartActivity(intent)),
+            style = TextStyle(color = ColorProvider(Color.White), fontSize = 16.sp, textAlign = TextAlign.Center),
+        )
+    }
+}
+
+class HermesWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = HermesWidget()
+}
+```
+NOTE: the exact Glance imports/API for the resolved `glance-appwidget` version take precedence — if `padding`, `clickable`, `background`, `ColorProvider`, or `actionStartActivity` signatures differ, adjust imports/calls so it compiles. `GlanceModifier.clickable` is `androidx.glance.action.clickable`; `padding(vertical = 6.dp)` uses `androidx.compose.ui.unit.dp`. Keep the three buttons + their `hermes://` URIs and the explicit `setPackage` — that is the contract. (Put `HermesWidgetReceiver` in its own file `HermesWidgetReceiver.kt` if the reviewer prefers; either is fine.)
+
+- [ ] **Step 3: Provider XML**
+
+`app/src/main/res/xml/hermes_widget_info.xml`:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/glance_default_loading_layout" />
+```
+
+- [ ] **Step 4: String resource**
+
+Ensure `app/src/main/res/values/strings.xml` exists; add:
+```xml
+    <string name="widget_description">Quick actions for Hermes</string>
+```
+(If `strings.xml` doesn't exist, create it with a `<resources>` root containing this string.)
+
+- [ ] **Step 5: Manifest receiver**
+
+In `AndroidManifest.xml`, inside `<application>` (near the existing `NotificationActionReceiver`), add:
+```xml
+        <receiver
+            android:name=".widget.HermesWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/hermes_widget_info" />
+        </receiver>
+```
+
+- [ ] **Step 6: Compile + full suite + assembleBeta**
+
+Run each (JAVA_HOME set): `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta` — all BUILD SUCCESSFUL. **If the Glance dependency version fails to resolve or an API signature differs, adjust the version and imports minimally until it builds; the widget's three buttons + hermes:// targets are the contract.**
+
+- [ ] **Step 7: Commit**
+```bash
+git add gradle/libs.versions.toml app/build.gradle.kts \
+        app/src/main/java/com/hermes/client/widget/ \
+        app/src/main/res/xml/hermes_widget_info.xml \
+        app/src/main/res/values/strings.xml \
+        app/src/main/AndroidManifest.xml
+git commit -m "feat: add home-screen quick-launch widget (Glance)"
+```
+
+---
+
+### Task 4: On-device verification (best-effort)
+
+- [ ] **Step 1:** `:app:installBeta` (target `emulator-5554` if multiple devices).
+- [ ] **Step 2:** `adb -s emulator-5554 shell am start -a android.intent.action.VIEW -d "hermes://new" com.hermes.client.beta` → if configured, a new chat opens; if not configured, no crash (verify `pidof`).
+- [ ] **Step 3:** `adb -s emulator-5554 shell dumpsys appwidget | grep -i hermes` → the `HermesWidgetReceiver` provider is registered.
+- [ ] **Step 4:** (Best-effort) confirm the widget appears in the launcher's widget picker; placing + tapping on the emulator is optional — the `hermes://` launch targets are already verified from the deep-links wave.
+- [ ] **Step 5:** Record pass/fail in the PR description.
+
+---
+
+## Notes for the executor
+- Do NOT add a "needs you" dynamic glance, per-tenant accent, or a "scan" button — explicit anti-scope.
+- The widget's launch intents are explicit (`setPackage(self)`), so they can only open this app.
+- If Glance `1.1.1` doesn't resolve, use the newest `androidx.glance:glance-appwidget` 1.x that builds against AGP 9.1 / Compose BOM 2025.12.

--- a/docs/superpowers/specs/2026-07-17-home-widget-design.md
+++ b/docs/superpowers/specs/2026-07-17-home-widget-design.md
@@ -1,0 +1,134 @@
+# Home-Screen Quick-Launch Widget — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/home-widget` (off `dev`).
+
+**Goal:** A home-screen widget with quick-launch buttons — **New chat**, **Chats**, **Home** — using Jetpack Glance. Reuses the `hermes://` deep links (just shipped) for launch, plus one new `hermes://new` verb for new-chat. Client-only.
+
+**Constraints:** Kotlin/Compose/Glance/Hilt. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Scope
+- **In:** a Glance `GlanceAppWidget` + receiver + provider XML + manifest receiver; the `androidx.glance:glance-appwidget` dependency; a `hermes://new` verb + `MainActivity.openNewChat()` reusing the existing share rail.
+- **Out (deferred):** a dynamic "needs you" glance (no persisted attention count exists — all live socket/network; would need a persisted counter first); per-tenant accent in the widget (not available in Glance — use a static theme); a "scan" button (setup-time action, not a daily quick-launch); resizable rich content.
+
+## Architecture
+
+### 1. `hermes://new` verb — `ui/nav/DeepLinkMapper.kt` (modify)
+`hermes://new` is **not** a static nav route (new-chat is an async `createSession` RPC), so it isn't handled by `deepLinkRouteFor`. Add a pure predicate:
+```kotlin
+fun isNewChatLink(raw: String): Boolean {
+    val uri = runCatching { java.net.URI(raw) }.getOrNull() ?: return false
+    return "hermes".equals(uri.scheme, ignoreCase = true) && uri.host == "new"
+}
+```
+
+### 2. `MainActivity.kt` (modify) — handle `hermes://new`
+Extract the new-chat rail from `handleShare` into a reusable helper (identical `connect → refresh → createSession → pendingRoute` sequence, minus the share payload):
+```kotlin
+/** Create a fresh chat and navigate to it (widget "New chat" / hermes://new). No-op if unconfigured. */
+private fun openNewChat() {
+    if (credentialStore.load() == null) return
+    lifecycleScope.launch {
+        chat.connect() // idempotent; a cold start has no socket yet
+        runCatching {
+            profileManager.refresh() // load active profile so the session isn't orphaned to default
+            chat.createSession(profileManager.active.value)
+        }.onSuccess { id -> pendingRoute.value = "chat/$id" }
+            .onFailure { e ->
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                android.widget.Toast.makeText(this@MainActivity, "Couldn't start a chat", android.widget.Toast.LENGTH_SHORT).show()
+            }
+    }
+}
+```
+In `onCreate` and `onNewIntent`, branch on the incoming `hermes://new` link before the existing route handling:
+```kotlin
+val data = intent?.data
+if (data != null && isNewChatLink(data.toString())) {
+    openNewChat()
+    intent?.data = null
+} else {
+    pendingRoute.value = intent?.getStringExtra("extra_route")
+        ?: data?.let { deepLinkRouteFor(it.toString()) }
+    intent?.removeExtra("extra_route")
+    intent?.data = null
+}
+```
+(`onNewIntent` uses the non-null `intent`; same branch.)
+
+### 3. Widget — `widget/HermesWidget.kt` + `widget/HermesWidgetReceiver.kt` (new)
+A `GlanceAppWidget` rendering three buttons; each starts an **explicit** VIEW intent (`setPackage(context.packageName)`) into the already-`singleTask` MainActivity:
+```kotlin
+class HermesWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent { Content(context) }
+    }
+
+    @Composable
+    private fun Content(context: Context) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize().background(ColorProvider(Color(0xFF3B3BAF))).padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Item(context, "New chat", "hermes://new")
+            Item(context, "Chats", "hermes://tab/sessions")
+            Item(context, "Home", "hermes://tab/activity")
+        }
+    }
+
+    @Composable
+    private fun Item(context: Context, label: String, uri: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri)).setPackage(context.packageName)
+        Text(
+            label,
+            modifier = GlanceModifier.fillMaxWidth().padding(vertical = 6.dp).clickable(actionStartActivity(intent)),
+            style = TextStyle(color = ColorProvider(Color.White), fontSize = 16.sp, textAlign = TextAlign.Center),
+        )
+    }
+}
+
+class HermesWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = HermesWidget()
+}
+```
+(Static color — per-tenant accent is a Compose-runtime local unavailable in Glance. Exact Glance API/imports may need minor adjustment to the resolved `glance-appwidget` version; behavior is the contract.)
+
+### 4. Resources + manifest
+- `res/xml/hermes_widget_info.xml` — `<appwidget-provider>` (minWidth/Height, `resizeMode`, `widgetCategory="home_screen"`, `initialLayout="@layout/glance_default_loading_layout"` which `glance-appwidget` provides, a `description` string).
+- `res/values/strings.xml` — add `<string name="widget_description">Quick actions for Hermes</string>`.
+- `AndroidManifest.xml` — a `<receiver android:name=".widget.HermesWidgetReceiver" android:exported="true">` with an `APPWIDGET_UPDATE` intent-filter + `android.appwidget.provider` meta-data (mirror the existing `NotificationActionReceiver` receiver block).
+
+### 5. Dependency
+`gradle/libs.versions.toml`: `glance = "1.1.1"` + `glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }`. `app/build.gradle.kts`: `implementation(libs.glance.appwidget)`. (If 1.1.1 doesn't resolve against the current AGP/Compose, bump to the latest 1.x that does.)
+
+## Data flow
+```
+widget button tap → actionStartActivity(VIEW hermes://…, pkg=self) → MainActivity (singleTask, onNewIntent/onCreate)
+  hermes://new  → isNewChatLink → openNewChat() → connect→refresh→createSession → pendingRoute="chat/$id" → nav
+  hermes://tab/sessions | tab/activity → deepLinkRouteFor → pendingRoute → nav
+```
+
+## Error handling
+- `openNewChat` when unconfigured → no-op (returns early). On a createSession failure → toast, no crash (mirrors share).
+- Widget buttons target an explicit intent (setPackage self) — can't be hijacked.
+- Deep-link routes reuse the already-hardened `runCatching { nav.navigate }`.
+
+## Testing
+- **`DeepLinkMapperTest`** (extend, pure): `isNewChatLink("hermes://new")` → true; `hermes://new/x`, `hermes://tab/sessions`, `http://new`, blank/garbage → false.
+- Glance widget, receiver, `openNewChat`, and MainActivity intent glue are Android — verified on-device (best-effort).
+
+## On-device verification
+- `adb shell am start -a android.intent.action.VIEW -d "hermes://new" com.hermes.client.beta` → opens a new chat (if configured) / no crash if not.
+- Confirm the widget is registered: `adb shell dumpsys appwidget | grep -i hermes` (provider present), and it appears in the launcher's widget picker. Placing + tapping on the emulator is best-effort; the deep-link targets are already verified from wave 2.
+
+## Files
+| Action | Path |
+|--------|------|
+| Modify | `ui/nav/DeepLinkMapper.kt` (`isNewChatLink`) + `DeepLinkMapperTest.kt` |
+| Modify | `MainActivity.kt` (`openNewChat` + hermes://new branch) |
+| New | `widget/HermesWidget.kt`, `widget/HermesWidgetReceiver.kt` |
+| New | `res/xml/hermes_widget_info.xml`; add `widget_description` to `res/values/strings.xml` |
+| Modify | `AndroidManifest.xml` (receiver) |
+| Modify | `gradle/libs.versions.toml`, `app/build.gradle.kts` (glance dep) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ androidxTestCore = "1.7.0"
 androidxTestJunit = "1.3.0"
 androidxTestRunner = "1.7.0"
 zxingEmbedded = "4.3.0"
+glance = "1.1.1"
 
 [libraries]
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
@@ -68,6 +69,7 @@ androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "android
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
 zxing-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxingEmbedded" }
+glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Quick-wins wave (client-only). A Jetpack Glance home-screen widget with **New chat / Chats / Home** quick-launch buttons, built on the `hermes://` deep links.

## What ships
- A `GlanceAppWidget` (`HermesWidget`) + receiver; three buttons firing **explicit** `Intent(ACTION_VIEW, hermes://…).setPackage(self)` — Chats (`tab/sessions`) and Home (`tab/activity`) via existing deep links, and **New chat** via a new `hermes://new` verb.
- `hermes://new` → `MainActivity.openNewChat()` reusing the share rail (`connect → refresh → createSession → open the chat`), with an **in-flight guard** so rapid taps don't create duplicate sessions.
- Static widget theme (per-tenant accent isn't available in Glance).

## Quality
- Subagent-driven: 3 TDD/code tasks + on-device verification, per-task reviews, opus whole-branch review → READY TO MERGE (applied the in-flight guard it flagged).
- **Gates:** 287 unit tests pass; compile + assembleBeta green (Glance 1.1.1, lintVital ok); gitleaks clean.
- **On-device:** the widget provider is registered (appears in the launcher picker); `hermes://new` foregrounds the app with no crash (no-ops gracefully while unconfigured).

## Accepted trade-off
`hermes://new` is reachable from any external `hermes://` link (BROWSABLE), not just the widget — bounded harm: it only creates an **empty** session, and only when the app is configured (a user would see and can delete it). Gating it to widget-only isn't cleanly possible; accepted for this client-only quick win.

## Deferred follow-ups
A dynamic "needs you" glance (needs a persisted attention count — all live socket/network today), per-tenant accent theming, and a "scan" button.