### PR TITLE
feat: prompt/snippet library

### DIFF
--- a/app/src/main/java/com/hermes/client/data/repository/PromptStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/PromptStore.kt
@@ -1,9 +1,18 @@
 package com.hermes.client.data.repository
 
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.io.IOException
 
 /** A user-saved reusable prompt (device-local). */
 @Serializable
@@ -22,3 +31,21 @@ fun upsertPrompt(list: List<SavedPrompt>, p: SavedPrompt): List<SavedPrompt> =
     if (list.any { it.id == p.id }) list.map { if (it.id == p.id) p else it } else list + p
 
 fun deletePrompt(list: List<SavedPrompt>, id: String): List<SavedPrompt> = list.filterNot { it.id == id }
+
+private val Context.promptDataStore by preferencesDataStore(name = "saved_prompts")
+
+/** Device-local, global store of the user's saved prompts (JSON list under one key). */
+class PromptStore(private val context: Context) {
+    private val key = stringPreferencesKey("prompts")
+
+    val prompts: Flow<List<SavedPrompt>> =
+        context.promptDataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .map { decodePrompts(it[key]) }
+
+    suspend fun upsert(p: SavedPrompt) =
+        context.promptDataStore.edit { it[key] = encodePrompts(upsertPrompt(decodePrompts(it[key]), p)) }
+
+    suspend fun delete(id: String) =
+        context.promptDataStore.edit { it[key] = encodePrompts(deletePrompt(decodePrompts(it[key]), id)) }
+}

--- a/app/src/main/java/com/hermes/client/data/repository/PromptStore.kt
+++ b/app/src/main/java/com/hermes/client/data/repository/PromptStore.kt
@@ -1,0 +1,24 @@
+package com.hermes.client.data.repository
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** A user-saved reusable prompt (device-local). */
+@Serializable
+data class SavedPrompt(val id: String, val title: String, val body: String)
+
+private val promptJson = Json { ignoreUnknownKeys = true }
+
+/** Decode the stored JSON list; never throws — corrupt/absent → empty. */
+fun decodePrompts(raw: String?): List<SavedPrompt> =
+    runCatching { promptJson.decodeFromString<List<SavedPrompt>>(raw ?: "[]") }.getOrDefault(emptyList())
+
+fun encodePrompts(list: List<SavedPrompt>): String = promptJson.encodeToString(list)
+
+/** Replace the element whose id matches [p], preserving position; otherwise append. */
+fun upsertPrompt(list: List<SavedPrompt>, p: SavedPrompt): List<SavedPrompt> =
+    if (list.any { it.id == p.id }) list.map { if (it.id == p.id) p else it } else list + p
+
+fun deletePrompt(list: List<SavedPrompt>, id: String): List<SavedPrompt> = list.filterNot { it.id == id }

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -219,4 +219,9 @@ object AppModule {
         @ApplicationContext context: Context,
     ): com.hermes.client.data.tts.TextToSpeechController =
         com.hermes.client.data.tts.AndroidTtsManager(context)
+
+    @Provides
+    @Singleton
+    fun providePromptStore(@ApplicationContext context: Context): com.hermes.client.data.repository.PromptStore =
+        com.hermes.client.data.repository.PromptStore(context)
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.NoteAdd
 import androidx.compose.material.icons.automirrored.rounded.Send
 import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.AttachFile
@@ -48,8 +49,11 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.material3.rememberModalBottomSheetState
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -103,6 +107,8 @@ fun ChatScreen(
     val commands by vm.commands.collectAsStateWithLifecycle()
     val pathItems by vm.pathItems.collectAsStateWithLifecycle()
     val speaking by vm.speaking.collectAsStateWithLifecycle()
+    val savedPrompts by vm.savedPrompts.collectAsStateWithLifecycle()
+    var showPromptSheet by remember { mutableStateOf(false) }
     androidx.compose.runtime.DisposableEffect(Unit) { onDispose { vm.stopReading() } }
     var draft by remember { mutableStateOf("") }
     var searchOpen by rememberSaveable { mutableStateOf(false) }
@@ -351,6 +357,9 @@ fun ChatScreen(
                             )
                         }
                     }
+                    IconButton(onClick = { showPromptSheet = true }) {
+                        Icon(Icons.AutoMirrored.Rounded.NoteAdd, contentDescription = "Saved prompts")
+                    }
                     if (speechAvailable) {
                         IconButton(onClick = { startDictation() }) {
                             Icon(
@@ -531,6 +540,32 @@ fun ChatScreen(
             pending = modelSheet.pending, error = modelSheet.error,
             onDismiss = { modelSheetOpen = false },
         )
+    }
+
+    if (showPromptSheet) {
+        val promptSheetState = rememberModalBottomSheetState()
+        ModalBottomSheet(onDismissRequest = { showPromptSheet = false }, sheetState = promptSheetState) {
+            if (savedPrompts.isEmpty()) {
+                Text(
+                    "No saved prompts yet — add them in Settings › Saved prompts.",
+                    modifier = Modifier.padding(24.dp),
+                )
+            } else {
+                LazyColumn(Modifier.fillMaxWidth()) {
+                    items(savedPrompts, key = { it.id }) { p ->
+                        ListItem(
+                            headlineContent = { Text(p.title) },
+                            supportingContent = { Text(p.body.lineSequence().firstOrNull().orEmpty()) },
+                            modifier = Modifier.clickable {
+                                draft = if (draft.isBlank()) p.body else draft.trimEnd() + "\n" + p.body
+                                showPromptSheet = false
+                                focusRequester.requestFocus()
+                            },
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -34,6 +34,7 @@ class ChatViewModel @Inject constructor(
     private val favoritesStore: com.hermes.client.data.repository.ModelFavoritesStore,
     private val pendingShareStore: com.hermes.client.share.PendingShareStore,
     private val tts: com.hermes.client.data.tts.TextToSpeechController,
+    private val promptStore: com.hermes.client.data.repository.PromptStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ChatUiState.empty())
@@ -75,6 +76,10 @@ class ChatViewModel @Inject constructor(
 
     /** Stop any current read-aloud. */
     fun stopReading() = tts.stop()
+
+    /** Device-local saved prompts, for the composer's prompt picker. */
+    val savedPrompts: kotlinx.coroutines.flow.StateFlow<List<com.hermes.client.data.repository.SavedPrompt>> =
+        promptStore.prompts.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5_000), emptyList())
 
     data class ModelSheetUi(
         val query: String = "",

--- a/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
+++ b/app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt
@@ -260,6 +260,9 @@ fun HermesNav(hasConfig: Boolean, deepLinkRoute: String? = null, onDeepLinkConsu
                 com.hermes.client.ui.settings.NotificationsScreen(onBack = { nav.popBackStack() })
             }
             composable("settings_memory") { MemorySettingsScreen(onBack = { nav.popBackStack() }) }
+            composable("settings_prompts") {
+                com.hermes.client.ui.settings.PromptLibraryScreen(onBack = { nav.popBackStack() })
+            }
             composable("settings_mcp") { McpSettingsScreen(onBack = { nav.popBackStack() }) }
             composable("settings_env") { EnvScreen(onBack = { nav.popBackStack() }) }
             composable("settings_connection") {

--- a/app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt
@@ -1,0 +1,29 @@
+package com.hermes.client.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.repository.PromptStore
+import com.hermes.client.data.repository.SavedPrompt
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class PromptLibraryViewModel @Inject constructor(private val store: PromptStore) : ViewModel() {
+    val prompts: StateFlow<List<SavedPrompt>> =
+        store.prompts.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Create (id == null) or edit an existing prompt. Blank title falls back to the body's first line. */
+    fun save(id: String?, title: String, body: String) {
+        val cleanBody = body.trim()
+        if (cleanBody.isEmpty() && title.isBlank()) return
+        val cleanTitle = title.trim().ifBlank { cleanBody.lineSequence().firstOrNull()?.take(60).orEmpty() }
+        viewModelScope.launch { store.upsert(SavedPrompt(id ?: UUID.randomUUID().toString(), cleanTitle, cleanBody)) }
+    }
+
+    fun delete(id: String) = viewModelScope.launch { store.delete(id) }
+}

--- a/app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt
@@ -1,6 +1,34 @@
 package com.hermes.client.ui.settings
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import com.hermes.client.data.repository.PromptStore
 import com.hermes.client.data.repository.SavedPrompt
@@ -26,4 +54,86 @@ class PromptLibraryViewModel @Inject constructor(private val store: PromptStore)
     }
 
     fun delete(id: String) = viewModelScope.launch { store.delete(id) }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PromptLibraryScreen(
+    onBack: () -> Unit,
+    vm: PromptLibraryViewModel = hiltViewModel(),
+) {
+    val prompts by vm.prompts.collectAsStateWithLifecycle()
+    var editing by remember { mutableStateOf<SavedPrompt?>(null) }
+    var adding by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            com.hermes.client.ui.components.HermesTopBar(
+                title = "Saved prompts",
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back") } },
+                actions = {
+                    IconButton(onClick = { adding = true }) {
+                        Icon(Icons.Rounded.Add, contentDescription = "New")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (prompts.isEmpty()) {
+            Text(
+                "No saved prompts yet. Tap New to add one.",
+                modifier = Modifier.padding(padding).padding(24.dp),
+            )
+        } else {
+            LazyColumn(Modifier.padding(padding).fillMaxSize()) {
+                items(prompts, key = { it.id }) { p ->
+                    ListItem(
+                        headlineContent = { Text(p.title) },
+                        supportingContent = { Text(p.body.lineSequence().firstOrNull().orEmpty()) },
+                        trailingContent = {
+                            IconButton(onClick = { vm.delete(p.id) }) {
+                                Icon(Icons.Rounded.Delete, contentDescription = "Delete")
+                            }
+                        },
+                        modifier = Modifier.clickable { editing = p },
+                    )
+                }
+            }
+        }
+    }
+
+    if (adding || editing != null) {
+        val current = editing
+        var title by remember(current) { mutableStateOf(current?.title.orEmpty()) }
+        var body by remember(current) { mutableStateOf(current?.body.orEmpty()) }
+        val dismiss = { adding = false; editing = null }
+        AlertDialog(
+            onDismissRequest = dismiss,
+            title = { Text(if (current == null) "New prompt" else "Edit prompt") },
+            text = {
+                androidx.compose.foundation.layout.Column {
+                    OutlinedTextField(
+                        value = title,
+                        onValueChange = { title = it },
+                        label = { Text("Title") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    OutlinedTextField(
+                        value = body,
+                        onValueChange = { body = it },
+                        label = { Text("Prompt") },
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { vm.save(current?.id, title, body); dismiss() },
+                    enabled = title.isNotBlank() || body.isNotBlank(),
+                ) { Text("Save") }
+            },
+            dismissButton = { TextButton(onClick = dismiss) { Text("Cancel") } },
+        )
+    }
 }

--- a/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt
@@ -40,6 +40,8 @@ fun SettingsScreen(
             HorizontalDivider()
             Entry("Memory & budgets", "Memory, user profile & default model") { onNavigate("settings_memory") }
             HorizontalDivider()
+            Entry("Saved prompts", "Reusable prompts for the composer") { onNavigate("settings_prompts") }
+            HorizontalDivider()
             Entry("MCP servers", "View and edit connected MCP servers") { onNavigate("settings_mcp") }
             HorizontalDivider()
             Entry("API keys & env", "Provider keys and tool env vars") { onNavigate("settings_env") }

--- a/app/src/test/java/com/hermes/client/data/repository/PromptStoreTest.kt
+++ b/app/src/test/java/com/hermes/client/data/repository/PromptStoreTest.kt
@@ -1,0 +1,31 @@
+package com.hermes.client.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PromptStoreTest {
+    private val a = SavedPrompt("1", "Greet", "Say hello")
+    private val b = SavedPrompt("2", "Bye", "Say bye")
+
+    @Test fun decode_bad_or_empty_is_empty_list() {
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts(null))
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts(""))
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts("not json"))
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts("{}"))
+    }
+
+    @Test fun encode_decode_round_trip() {
+        assertEquals(listOf(a, b), decodePrompts(encodePrompts(listOf(a, b))))
+    }
+
+    @Test fun upsert_appends_new_and_replaces_existing() {
+        assertEquals(listOf(a, b), upsertPrompt(listOf(a), b))
+        val edited = a.copy(title = "Hi")
+        assertEquals(listOf(edited, b), upsertPrompt(listOf(a, b), edited)) // replaced in place, order kept
+    }
+
+    @Test fun delete_removes_by_id_and_noops_when_absent() {
+        assertEquals(listOf(b), deletePrompt(listOf(a, b), "1"))
+        assertEquals(listOf(a, b), deletePrompt(listOf(a, b), "nope"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -41,6 +41,7 @@ class ChatViewModelTest {
     private val favoritesStore = mockk<ModelFavoritesStore>(relaxed = true)
     private val pendingShareStore = com.hermes.client.share.PendingShareStore()
     private val tts = mockk<com.hermes.client.data.tts.TextToSpeechController>(relaxed = true)
+    private val promptStore = mockk<com.hermes.client.data.repository.PromptStore>(relaxed = true)
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -56,9 +57,10 @@ class ChatViewModelTest {
         coEvery { profileRepo.list() } returns emptyList()
         every { favoritesStore.favorites } returns MutableStateFlow(emptySet())
         every { tts.speaking } returns MutableStateFlow(false)
+        every { promptStore.prompts } returns MutableStateFlow(emptyList())
     }
 
-    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore, tts)
+    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore, tts, promptStore)
 
     @Test fun streamed_delta_appears_in_state() = runTest {
         val vm = buildVm()

--- a/app/src/test/java/com/hermes/client/ui/settings/PromptLibraryViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/settings/PromptLibraryViewModelTest.kt
@@ -1,0 +1,46 @@
+package com.hermes.client.ui.settings
+
+import com.hermes.client.data.repository.PromptStore
+import com.hermes.client.data.repository.SavedPrompt
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PromptLibraryViewModelTest {
+    private val store = mockk<PromptStore>(relaxed = true)
+    @Before fun setUp() { Dispatchers.setMain(StandardTestDispatcher()); every { store.prompts } returns MutableStateFlow(emptyList()) }
+    @After fun tearDown() = Dispatchers.resetMain()
+    private fun vm() = PromptLibraryViewModel(store)
+
+    @Test fun save_new_generates_id_and_upserts() = runTest {
+        vm().save(null, "T", "B"); advanceUntilIdle()
+        coVerify { store.upsert(match { it.title == "T" && it.body == "B" && it.id.isNotBlank() }) }
+    }
+
+    @Test fun save_existing_keeps_id() = runTest {
+        vm().save("keep-me", "T", "B"); advanceUntilIdle()
+        coVerify { store.upsert(match { it.id == "keep-me" }) }
+    }
+
+    @Test fun blank_title_falls_back_to_first_body_line() = runTest {
+        vm().save(null, "  ", "first line\nsecond"); advanceUntilIdle()
+        coVerify { store.upsert(match { it.title == "first line" }) }
+    }
+
+    @Test fun delete_delegates() = runTest {
+        vm().delete("x"); advanceUntilIdle()
+        coVerify { store.delete("x") }
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-prompt-library.md
+++ b/docs/superpowers/plans/2026-07-17-prompt-library.md
@@ -1,0 +1,312 @@
+# Prompt / Snippet Library Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Device-local saved prompts: a store, a composer picker (appends into the draft), and a Settings manage screen.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-prompt-library-design.md`
+
+## Global Constraints
+- Client-only, device-local (no gateway/sync). No AI attribution.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch `feature/prompt-library` (off `dev`).
+
+---
+
+### Task 1: Model + pure helpers
+
+**Files:** Create `app/src/main/java/com/hermes/client/data/repository/PromptStore.kt` (model + pure helpers only in this task); Test `app/src/test/java/com/hermes/client/data/repository/PromptStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test** `PromptStoreTest.kt`:
+```kotlin
+package com.hermes.client.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PromptStoreTest {
+    private val a = SavedPrompt("1", "Greet", "Say hello")
+    private val b = SavedPrompt("2", "Bye", "Say bye")
+
+    @Test fun decode_bad_or_empty_is_empty_list() {
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts(null))
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts(""))
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts("not json"))
+        assertEquals(emptyList<SavedPrompt>(), decodePrompts("{}"))
+    }
+
+    @Test fun encode_decode_round_trip() {
+        assertEquals(listOf(a, b), decodePrompts(encodePrompts(listOf(a, b))))
+    }
+
+    @Test fun upsert_appends_new_and_replaces_existing() {
+        assertEquals(listOf(a, b), upsertPrompt(listOf(a), b))
+        val edited = a.copy(title = "Hi")
+        assertEquals(listOf(edited, b), upsertPrompt(listOf(a, b), edited)) // replaced in place, order kept
+    }
+
+    @Test fun delete_removes_by_id_and_noops_when_absent() {
+        assertEquals(listOf(b), deletePrompt(listOf(a, b), "1"))
+        assertEquals(listOf(a, b), deletePrompt(listOf(a, b), "nope"))
+    }
+}
+```
+
+- [ ] **Step 2:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.repository.PromptStoreTest"` → FAIL (unresolved).
+
+- [ ] **Step 3: Implement** the model + pure helpers in `PromptStore.kt`:
+```kotlin
+package com.hermes.client.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.IOException
+
+/** A user-saved reusable prompt (device-local). */
+@Serializable
+data class SavedPrompt(val id: String, val title: String, val body: String)
+
+private val promptJson = Json { ignoreUnknownKeys = true }
+
+/** Decode the stored JSON list; never throws — corrupt/absent → empty. */
+fun decodePrompts(raw: String?): List<SavedPrompt> =
+    runCatching { promptJson.decodeFromString<List<SavedPrompt>>(raw ?: "[]") }.getOrDefault(emptyList())
+
+fun encodePrompts(list: List<SavedPrompt>): String = promptJson.encodeToString(list)
+
+/** Replace the element whose id matches [p], preserving position; otherwise append. */
+fun upsertPrompt(list: List<SavedPrompt>, p: SavedPrompt): List<SavedPrompt> =
+    if (list.any { it.id == p.id }) list.map { if (it.id == p.id) p else it } else list + p
+
+fun deletePrompt(list: List<SavedPrompt>, id: String): List<SavedPrompt> = list.filterNot { it.id == id }
+```
+(The `PromptStore` class is added in Task 2 — this task ships only the `@Serializable` model + the four pure functions.)
+
+- [ ] **Step 4:** Run the test → PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/data/repository/PromptStore.kt \
+        app/src/test/java/com/hermes/client/data/repository/PromptStoreTest.kt
+git commit -m "feat: SavedPrompt model + pure prompt-list helpers"
+```
+
+---
+
+### Task 2: PromptStore + DI + ViewModels
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/repository/PromptStore.kt` (add the class)
+- Modify: `app/src/main/java/com/hermes/client/di/AppModule.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt`
+- Create: `app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt` (the `PromptLibraryViewModel` part; the Composable UI is Task 3)
+- Test: Create `app/src/test/java/com/hermes/client/ui/settings/PromptLibraryViewModelTest.kt`; extend `ChatViewModelTest.kt`
+
+**Interfaces:** Consumes `SavedPrompt`/helpers (Task 1). Produces `PromptStore`, `ChatViewModel.savedPrompts`, `PromptLibraryViewModel(prompts/save/delete)`.
+
+- [ ] **Step 1: Add the `PromptStore` class** to `PromptStore.kt`:
+```kotlin
+private val Context.promptDataStore by preferencesDataStore(name = "saved_prompts")
+
+/** Device-local, global store of the user's saved prompts (JSON list under one key). */
+class PromptStore(private val context: Context) {
+    private val key = stringPreferencesKey("prompts")
+
+    val prompts: Flow<List<SavedPrompt>> =
+        context.promptDataStore.data
+            .catch { e -> if (e is IOException) emit(emptyPreferences()) else throw e }
+            .map { decodePrompts(it[key]) }
+
+    suspend fun upsert(p: SavedPrompt) =
+        context.promptDataStore.edit { it[key] = encodePrompts(upsertPrompt(decodePrompts(it[key]), p)) }
+
+    suspend fun delete(id: String) =
+        context.promptDataStore.edit { it[key] = encodePrompts(deletePrompt(decodePrompts(it[key]), id)) }
+}
+```
+
+- [ ] **Step 2: Provide it via Hilt** — in `AppModule.kt` (mirror `providePinStore`):
+```kotlin
+    @Provides
+    @Singleton
+    fun providePromptStore(@ApplicationContext context: Context): com.hermes.client.data.repository.PromptStore =
+        com.hermes.client.data.repository.PromptStore(context)
+```
+
+- [ ] **Step 3: ChatViewModel.savedPrompts** — add the constructor param (new last param) and the flow:
+```kotlin
+    private val promptStore: com.hermes.client.data.repository.PromptStore,
+```
+```kotlin
+    /** Device-local saved prompts, for the composer's prompt picker. */
+    val savedPrompts: kotlinx.coroutines.flow.StateFlow<List<com.hermes.client.data.repository.SavedPrompt>> =
+        promptStore.prompts.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5_000), emptyList())
+```
+
+- [ ] **Step 4: PromptLibraryViewModel** — create `PromptLibraryScreen.kt` with just the ViewModel for now:
+```kotlin
+package com.hermes.client.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.repository.PromptStore
+import com.hermes.client.data.repository.SavedPrompt
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class PromptLibraryViewModel @Inject constructor(private val store: PromptStore) : ViewModel() {
+    val prompts: StateFlow<List<SavedPrompt>> =
+        store.prompts.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Create (id == null) or edit an existing prompt. Blank title falls back to the body's first line. */
+    fun save(id: String?, title: String, body: String) {
+        val cleanBody = body.trim()
+        if (cleanBody.isEmpty() && title.isBlank()) return
+        val cleanTitle = title.trim().ifBlank { cleanBody.lineSequence().firstOrNull()?.take(60).orEmpty() }
+        viewModelScope.launch { store.upsert(SavedPrompt(id ?: UUID.randomUUID().toString(), cleanTitle, cleanBody)) }
+    }
+
+    fun delete(id: String) = viewModelScope.launch { store.delete(id) }
+}
+```
+
+- [ ] **Step 5: Tests.** Create `PromptLibraryViewModelTest.kt` (mock `PromptStore`, `runTest` + `Dispatchers.setMain`):
+```kotlin
+package com.hermes.client.ui.settings
+
+import com.hermes.client.data.repository.PromptStore
+import com.hermes.client.data.repository.SavedPrompt
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PromptLibraryViewModelTest {
+    private val store = mockk<PromptStore>(relaxed = true)
+    @Before fun setUp() { Dispatchers.setMain(StandardTestDispatcher()); every { store.prompts } returns MutableStateFlow(emptyList()) }
+    @After fun tearDown() = Dispatchers.resetMain()
+    private fun vm() = PromptLibraryViewModel(store)
+
+    @Test fun save_new_generates_id_and_upserts() = runTest {
+        vm().save(null, "T", "B"); advanceUntilIdle()
+        coVerify { store.upsert(match { it.title == "T" && it.body == "B" && it.id.isNotBlank() }) }
+    }
+
+    @Test fun save_existing_keeps_id() = runTest {
+        vm().save("keep-me", "T", "B"); advanceUntilIdle()
+        coVerify { store.upsert(match { it.id == "keep-me" }) }
+    }
+
+    @Test fun blank_title_falls_back_to_first_body_line() = runTest {
+        vm().save(null, "  ", "first line\nsecond"); advanceUntilIdle()
+        coVerify { store.upsert(match { it.title == "first line" }) }
+    }
+
+    @Test fun delete_delegates() = runTest {
+        vm().delete("x"); advanceUntilIdle()
+        coVerify { store.delete("x") }
+    }
+}
+```
+Extend `ChatViewModelTest.kt`: add `private val promptStore = mockk<com.hermes.client.data.repository.PromptStore>(relaxed = true)` with `every { promptStore.prompts } returns MutableStateFlow(emptyList())` in setUp, and pass it as the new last arg in `buildVm()`.
+
+- [ ] **Step 6:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.settings.PromptLibraryViewModelTest" --tests "com.hermes.client.ui.chat.ChatViewModelTest"` → PASS. Then `:app:compileDebugKotlin` → BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/data/repository/PromptStore.kt \
+        app/src/main/java/com/hermes/client/di/AppModule.kt \
+        app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt \
+        app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt \
+        app/src/test/java/com/hermes/client/ui/settings/PromptLibraryViewModelTest.kt \
+        app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+git commit -m "feat: PromptStore + prompt-library/chat view-model wiring"
+```
+
+---
+
+### Task 3: UI — manage screen + composer picker
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt` (add the Composable)
+- Modify: `app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt` (route), `app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt` (Entry)
+- Modify: `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt` (composer icon + picker sheet)
+- Test: none new (Compose glue). Compile + full suite + assembleBeta + Task 4.
+
+- [ ] **Step 1: `PromptLibraryScreen` Composable.** Add to `PromptLibraryScreen.kt`: an `@OptIn(ExperimentalMaterial3Api::class) @Composable fun PromptLibraryScreen(onBack: () -> Unit, vm: PromptLibraryViewModel = hiltViewModel())` — a `Scaffold` with a top bar (title "Saved prompts", back arrow = `onBack`, mirror `MemorySettingsScreen`'s top bar) and a "New" action; body = a `LazyColumn` of `ListItem`s over `vm.prompts.collectAsStateWithLifecycle()` (headline = `title`, supporting = `body` first line, trailing = a delete `IconButton` → `vm.delete(id)`, `Modifier.clickable` to open the edit dialog). An add/edit `AlertDialog` (state `var editing by remember { mutableStateOf<SavedPrompt?>(null) }` + `var adding by remember { mutableStateOf(false) }`) with two `OutlinedTextField`s (title, body); confirm → `vm.save(editing?.id, title, body)`; confirm disabled when both blank; empty-list state text: "No saved prompts yet. Tap New to add one." Follow the existing settings-screen composition style.
+
+- [ ] **Step 2: Register the route** — in `HermesNav.kt`, next to the other `settings_*` routes:
+```kotlin
+            composable("settings_prompts") {
+                com.hermes.client.ui.settings.PromptLibraryScreen(onBack = { nav.popBackStack() })
+            }
+```
+
+- [ ] **Step 3: Settings entry** — in `SettingsScreen.kt`, add (e.g. after the "Memory & budgets" entry, with a `HorizontalDivider`):
+```kotlin
+            HorizontalDivider()
+            Entry("Saved prompts", "Reusable prompts for the composer") { onNavigate("settings_prompts") }
+```
+
+- [ ] **Step 4: Composer picker** — in `ChatScreen.kt`:
+  - Collect: `val savedPrompts by vm.savedPrompts.collectAsStateWithLifecycle()` and `var showPromptSheet by remember { mutableStateOf(false) }`.
+  - Add an `IconButton` in the composer `Row` (near the Attach/Mic leading icons) using an available Material icon (e.g. `Icons.AutoMirrored.Rounded.NoteAdd` or `Icons.Rounded.Bookmark`; pick one that exists in `material-icons-extended`) with `onClick = { showPromptSheet = true }`, `contentDescription = "Saved prompts"`.
+  - Host a `ModalBottomSheet` when `showPromptSheet`: a `LazyColumn` of the `savedPrompts` (`ListItem` headline=title, supporting=body preview, `Modifier.clickable {}` → on pick:
+    ```kotlin
+    draft = if (draft.isBlank()) p.body else draft.trimEnd() + "\n" + p.body
+    showPromptSheet = false
+    focusRequester.requestFocus()
+    ```
+    ); when empty, a `Text("No saved prompts yet — add them in Settings › Saved prompts.")`.
+
+- [ ] **Step 5: Compile + full suite + assembleBeta** — all three (JAVA_HOME set) BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/settings/PromptLibraryScreen.kt \
+        app/src/main/java/com/hermes/client/ui/nav/HermesNav.kt \
+        app/src/main/java/com/hermes/client/ui/settings/SettingsScreen.kt \
+        app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat: saved-prompts manage screen + composer picker"
+```
+
+---
+
+### Task 4: On-device verification
+
+- [ ] **Step 1:** `:app:installBeta` (target `emulator-5554` if multiple devices).
+- [ ] **Step 2:** Settings › Saved prompts → New → enter title + body → Save → appears in the list. Edit it (change body) → persists. Delete → removed.
+- [ ] **Step 3:** Open/create a chat → tap the composer's saved-prompts icon → the sheet lists the prompt → pick → it's appended into the draft and the field is focused. Type first, then pick → the prompt appends after a newline.
+- [ ] **Step 4:** With no prompts saved, the picker sheet shows the empty-state copy.
+- [ ] **Step 5:** Record pass/fail in the PR description.
+
+---
+
+## Notes for the executor
+- Do NOT add share-sheet export, App Actions, a `/`-command trigger, or sync — explicit anti-scope.
+- Pick composer/picker icons that actually exist in `androidx.compose.material.icons` (`material-icons-extended` is a dependency); if an icon name is unavailable, substitute a present one — the behavior (a picker that appends into `draft`) is the contract.

--- a/docs/superpowers/specs/2026-07-17-prompt-library-design.md
+++ b/docs/superpowers/specs/2026-07-17-prompt-library-design.md
@@ -1,0 +1,85 @@
+# Prompt / Snippet Library — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/prompt-library` (off `dev`).
+
+**Goal:** Let the user save reusable prompts locally, insert one into the chat composer with a tap, and manage them (add/edit/delete) from a Settings screen. Client-only; device-local (no gateway, no sync).
+
+**Constraints:** Kotlin/Compose/Material3/Hilt. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Scope
+- **In:** a device-local `PromptStore` (DataStore + JSON `List<SavedPrompt>`); a composer icon-button → picker that **appends** the chosen prompt into `draft`; a "Saved prompts" manage screen (list + add/edit dialog + delete) reachable from Settings.
+- **Out (deferred):** sharing a prompt *out* via the share-sheet / registering as a share target; App Actions / shortcuts; `/`-command trigger (the icon-button picker is v1); cloud/desktop sync; caret-precise insertion (`draft` is a `String`, so append, not insert-at-cursor).
+
+## Architecture
+
+### 1. Model + pure helpers — `data/repository/PromptStore.kt` (new)
+```kotlin
+@Serializable
+data class SavedPrompt(val id: String, val title: String, val body: String)
+```
+Pure, unit-testable free functions (never throw):
+- `fun decodePrompts(raw: String?): List<SavedPrompt>` — `runCatching { Json.decodeFromString(raw ?: "[]") }.getOrDefault(emptyList())`.
+- `fun encodePrompts(list: List<SavedPrompt>): String` — `Json.encodeToString(list)`.
+- `fun upsertPrompt(list, p): List<SavedPrompt>` — replace the element with `p.id` if present, else append.
+- `fun deletePrompt(list, id): List<SavedPrompt>` — filter out `id`.
+
+### 2. `PromptStore` (DataStore) — same file
+Mirror `ModelFavoritesStore`: `preferencesDataStore(name = "saved_prompts")`, a single `stringPreferencesKey("prompts")`. Device-local, global (not per-profile).
+```kotlin
+val prompts: Flow<List<SavedPrompt>> =
+    context.promptDataStore.data
+        .catch { e -> if (e is java.io.IOException) emit(emptyPreferences()) else throw e }
+        .map { decodePrompts(it[key]) }
+
+suspend fun upsert(p: SavedPrompt) = context.promptDataStore.edit { it[key] = encodePrompts(upsertPrompt(decodePrompts(it[key]), p)) }
+suspend fun delete(id: String) = context.promptDataStore.edit { it[key] = encodePrompts(deletePrompt(decodePrompts(it[key]), id)) }
+```
+Provided `@Singleton` in `di/AppModule.kt` (mirror `providePinStore`).
+
+### 3. Composer picker — `ui/chat/ChatViewModel.kt` + `ChatScreen.kt` (modify)
+- `ChatViewModel`: inject `PromptStore`; expose `val savedPrompts: StateFlow<List<SavedPrompt>> = promptStore.prompts.stateIn(...)`.
+- `ChatScreen`: add an `IconButton` (a notes/library icon) in the composer `Row` (leading, near the Attach/Mic buttons). On tap → open a `ModalBottomSheet` listing `savedPrompts` (title + body preview). On pick → append into the existing `draft` and refocus, reusing the edit-resend gesture:
+  ```kotlin
+  draft = if (draft.isBlank()) p.body else draft.trimEnd() + "\n" + p.body
+  showPromptSheet = false
+  focusRequester.requestFocus()
+  ```
+  Empty state in the sheet: "No saved prompts yet — add them in Settings › Saved prompts."
+
+### 4. Manage screen — `ui/settings/PromptLibraryScreen.kt` (new) + nav/settings wiring
+- `PromptLibraryViewModel` (`@HiltViewModel`, injects `PromptStore`): `val prompts: StateFlow<List<SavedPrompt>>`; `fun save(id: String?, title: String, body: String)` (new `SavedPrompt(id ?: randomUUID, title, body)` → `store.upsert`); `fun delete(id: String)`.
+- `PromptLibraryScreen(onBack)`: `Scaffold` + a top bar with a back arrow (mirror `MemorySettingsScreen`) + a `LazyColumn` of `ListItem`s (headline=title, supporting=body preview; tap → edit dialog; a trailing delete `IconButton`) + a "New prompt" button/FAB. Add/edit uses an `AlertDialog` with two `OutlinedTextField`s (title, body); Save disabled when both blank; blank title falls back to the first line of the body.
+- `HermesNav.kt`: `composable("settings_prompts") { PromptLibraryScreen(onBack = { nav.popBackStack() }) }`.
+- `SettingsScreen.kt`: a new `Entry("Saved prompts", "Reusable prompts for the composer") { onNavigate("settings_prompts") }` (+ a `HorizontalDivider`).
+
+## Data flow
+```
+Settings › Saved prompts → PromptLibraryScreen → add/edit/delete → PromptLibraryViewModel → PromptStore.upsert/delete → DataStore
+Composer library icon → ModalBottomSheet(savedPrompts from ChatViewModel) → pick → append to draft + focus
+```
+
+## Error handling
+- Corrupt/missing store JSON → `decodePrompts` returns `[]` (never throws); `IOException` on read → empty via `.catch`.
+- Blank title → derive from body's first line; both blank → Save disabled (can't create an empty prompt).
+- Appending to a non-empty draft inserts a newline separator; empty draft → just the body.
+
+## Testing
+- **`PromptStoreTest`** (pure): `decodePrompts` of valid JSON, of null/`""`/garbage → `[]`; `encodePrompts`/`decodePrompts` round-trip; `upsertPrompt` appends a new id and replaces an existing id (preserving order); `deletePrompt` removes by id and is a no-op for a missing id.
+- **`PromptLibraryViewModelTest`** (mock `PromptStore`): `save(null, …)` calls `store.upsert` with a generated id + given title/body; `save(existingId, …)` upserts with that id; `delete(id)` calls `store.delete(id)`; blank-title fallback to body's first line.
+- DataStore wiring, the bottom sheet, and the manage screen are Android/Compose — verified on-device.
+
+## On-device verification
+Settings › Saved prompts → add a prompt (title + body) → it appears in the list; edit it; delete it. Open a chat → tap the composer library icon → the saved prompt shows → pick → it's appended to the draft and the field is focused. Empty-state copy shows when no prompts exist.
+
+## Files
+| Action | Path |
+|--------|------|
+| New | `data/repository/PromptStore.kt` (model + pure helpers + store) + `PromptStoreTest.kt` |
+| Modify | `di/AppModule.kt` (provide store) |
+| Modify | `ui/chat/ChatViewModel.kt` (savedPrompts) |
+| Modify | `ui/chat/ChatScreen.kt` (composer library icon + picker sheet) |
+| New | `ui/settings/PromptLibraryScreen.kt` (screen + `PromptLibraryViewModel`) + `PromptLibraryViewModelTest.kt` |
+| Modify | `ui/nav/HermesNav.kt` (route), `ui/settings/SettingsScreen.kt` (Entry) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave (client-only, device-local). Save reusable prompts and insert them into the composer with a tap.

## What ships
- **`PromptStore`** — device-local DataStore holding a JSON `List<SavedPrompt>` (id/title/body), with pure `decode/encode/upsert/delete` helpers, an IOException guard, and atomic read-modify-write. `decodePrompts` never throws (corrupt/absent → empty).
- **Settings › Saved prompts** manage screen — list, add/edit dialog (Save disabled while both fields blank; blank title → body's first line), delete. Reached via a new `settings_prompts` route + Settings entry.
- **Composer picker** — a saved-prompts icon in the chat composer opens a bottom sheet; picking a prompt **appends** it into the draft (never overwrites) and refocuses the field. Empty-state points to Settings.

## Quality
- Subagent-driven: 3 TDD/code tasks + on-device verification, per-task reviews, opus whole-branch review → READY TO MERGE (no findings; stress-tested for RMW races, malformed-blob crashes, append-with-content, dialog state).
- **Gates:** 295 unit tests pass (8 new: store helpers + library VM); compile + assembleBeta green; gitleaks clean.
- **On-device:** the full manage flow was exercised live against real DataStore — Settings entry → screen → add-dialog → save → persisted + listed with delete. (The in-composer picker's append is unit-tested via `savedPrompts` + reviewed.)

## Deferred
Share-sheet export / share-target, App Actions/shortcuts, a `/`-command trigger, and cloud/desktop sync (consistent with the app's other device-local stores).