### PR TITLE
feat: export/share a chat transcript

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
 import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.Mic
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.AlertDialog
@@ -56,7 +57,9 @@ import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.rememberModalBottomSheetState
 import com.hermes.client.ui.theme.LocalProfileAccent
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.launch
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -159,6 +162,8 @@ fun ChatScreen(
 
     // Image attach: read picked/captured bytes and stage them onto the session.
     val context = androidx.compose.ui.platform.LocalContext.current
+    val clipboard = LocalClipboardManager.current
+    var transcriptMenu by remember { mutableStateOf(false) }
     val attachScope = androidx.compose.runtime.rememberCoroutineScope()
 
     fun readBytes(uri: Uri): ByteArray? =
@@ -266,6 +271,47 @@ fun ChatScreen(
                         ),
                     )
                     StatusDot(connState)
+                    Box {
+                        IconButton(onClick = { transcriptMenu = true }) {
+                            Icon(
+                                Icons.Rounded.MoreVert,
+                                contentDescription = "More",
+                                tint = com.hermes.client.ui.components.AccentChrome.onBar,
+                            )
+                        }
+                        DropdownMenu(expanded = transcriptMenu, onDismissRequest = { transcriptMenu = false }) {
+                            DropdownMenuItem(
+                                text = { Text("Copy transcript") },
+                                onClick = {
+                                    val t = transcriptText(state.messages)
+                                    if (t.isBlank()) {
+                                        android.widget.Toast.makeText(context, "Nothing to export yet", android.widget.Toast.LENGTH_SHORT).show()
+                                    } else {
+                                        clipboard.setText(AnnotatedString(t))
+                                        android.widget.Toast.makeText(context, "Transcript copied", android.widget.Toast.LENGTH_SHORT).show()
+                                    }
+                                    transcriptMenu = false
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Share transcript") },
+                                onClick = {
+                                    val t = transcriptText(state.messages)
+                                    if (t.isBlank()) {
+                                        android.widget.Toast.makeText(context, "Nothing to export yet", android.widget.Toast.LENGTH_SHORT).show()
+                                    } else {
+                                        val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                                            type = "text/plain"
+                                            putExtra(android.content.Intent.EXTRA_SUBJECT, "Hermes chat transcript")
+                                            putExtra(android.content.Intent.EXTRA_TEXT, t)
+                                        }
+                                        context.startActivity(android.content.Intent.createChooser(send, "Share transcript"))
+                                    }
+                                    transcriptMenu = false
+                                },
+                            )
+                        }
+                    }
                 },
             )
         },

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -287,8 +287,12 @@ fun ChatScreen(
                                     if (t.isBlank()) {
                                         android.widget.Toast.makeText(context, "Nothing to export yet", android.widget.Toast.LENGTH_SHORT).show()
                                     } else {
-                                        clipboard.setText(AnnotatedString(t))
-                                        android.widget.Toast.makeText(context, "Transcript copied", android.widget.Toast.LENGTH_SHORT).show()
+                                        runCatching {
+                                            clipboard.setText(AnnotatedString(t))
+                                            android.widget.Toast.makeText(context, "Transcript copied", android.widget.Toast.LENGTH_SHORT).show()
+                                        }.onFailure {
+                                            android.widget.Toast.makeText(context, "Couldn't copy transcript", android.widget.Toast.LENGTH_SHORT).show()
+                                        }
                                     }
                                     transcriptMenu = false
                                 },
@@ -305,7 +309,11 @@ fun ChatScreen(
                                             putExtra(android.content.Intent.EXTRA_SUBJECT, "Hermes chat transcript")
                                             putExtra(android.content.Intent.EXTRA_TEXT, t)
                                         }
-                                        context.startActivity(android.content.Intent.createChooser(send, "Share transcript"))
+                                        runCatching {
+                                            context.startActivity(android.content.Intent.createChooser(send, "Share transcript"))
+                                        }.onFailure {
+                                            android.widget.Toast.makeText(context, "Couldn't share transcript", android.widget.Toast.LENGTH_SHORT).show()
+                                        }
                                     }
                                     transcriptMenu = false
                                 },

--- a/app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt
@@ -16,7 +16,8 @@ fun transcriptText(messages: List<ChatMessage>): String =
         .filter { it.text.isNotBlank() }
         .joinToString("\n\n") { m ->
             val label = when {
-                m.isError || m.role == Role.SYSTEM -> "Error"
+                m.isError -> "Error"
+                m.role == Role.SYSTEM -> "System"
                 m.role == Role.USER -> "You"
                 else -> "Assistant"
             }

--- a/app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt
@@ -6,3 +6,19 @@ import com.hermes.client.domain.Role
 /** The text of the most recent USER message, or null if there is none (used to re-ask). */
 fun lastUserMessageText(messages: List<ChatMessage>): String? =
     messages.lastOrNull { it.role == Role.USER }?.text?.takeIf { it.isNotBlank() }
+
+/**
+ * Render the conversation to a plain-text, role-labeled transcript. Body text is verbatim
+ * (markdown preserved). Blank-text turns (tool-only / still-streaming stubs) are skipped.
+ */
+fun transcriptText(messages: List<ChatMessage>): String =
+    messages
+        .filter { it.text.isNotBlank() }
+        .joinToString("\n\n") { m ->
+            val label = when {
+                m.isError || m.role == Role.SYSTEM -> "Error"
+                m.role == Role.USER -> "You"
+                else -> "Assistant"
+            }
+            "$label:\n${m.text}"
+        }

--- a/app/src/test/java/com/hermes/client/ui/chat/MessageActionsTranscriptTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/MessageActionsTranscriptTest.kt
@@ -24,9 +24,10 @@ class MessageActionsTranscriptTest {
         assertEquals("You:\nq\n\nAssistant:\na", t)
     }
 
-    @Test fun error_and_system_labelled_error() {
+    @Test fun error_labelled_error_and_system_labelled_system() {
         assertTrue(transcriptText(listOf(msg(Role.ASSISTANT, "boom", isError = true))).startsWith("Error:"))
-        assertTrue(transcriptText(listOf(msg(Role.SYSTEM, "sys"))).startsWith("Error:"))
+        assertTrue(transcriptText(listOf(msg(Role.SYSTEM, "note"))).startsWith("System:"))
+        assertTrue(transcriptText(listOf(msg(Role.USER, "boom", isError = true))).startsWith("Error:"))
     }
 
     @Test fun markdown_preserved_verbatim() {

--- a/app/src/test/java/com/hermes/client/ui/chat/MessageActionsTranscriptTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/MessageActionsTranscriptTest.kt
@@ -1,0 +1,37 @@
+package com.hermes.client.ui.chat
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageActionsTranscriptTest {
+    private fun msg(role: Role, text: String, isError: Boolean = false) =
+        ChatMessage(id = "x", role = role, text = text, isError = isError)
+
+    @Test fun empty_is_empty() {
+        assertEquals("", transcriptText(emptyList()))
+    }
+
+    @Test fun labels_user_and_assistant() {
+        val t = transcriptText(listOf(msg(Role.USER, "hi"), msg(Role.ASSISTANT, "hello")))
+        assertEquals("You:\nhi\n\nAssistant:\nhello", t)
+    }
+
+    @Test fun skips_blank_turns() {
+        val t = transcriptText(listOf(msg(Role.USER, "q"), msg(Role.ASSISTANT, "   "), msg(Role.ASSISTANT, "a")))
+        assertEquals("You:\nq\n\nAssistant:\na", t)
+    }
+
+    @Test fun error_and_system_labelled_error() {
+        assertTrue(transcriptText(listOf(msg(Role.ASSISTANT, "boom", isError = true))).startsWith("Error:"))
+        assertTrue(transcriptText(listOf(msg(Role.SYSTEM, "sys"))).startsWith("Error:"))
+    }
+
+    @Test fun markdown_preserved_verbatim() {
+        val t = transcriptText(listOf(msg(Role.ASSISTANT, "```kotlin\nval x = 1\n```")))
+        assertTrue(t.contains("```kotlin"))
+        assertTrue(t.contains("val x = 1"))
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-thread-export.md
+++ b/docs/superpowers/plans/2026-07-17-thread-export.md
@@ -1,0 +1,182 @@
+# Thread Export / Share Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Copy or share a chat as a plain-text transcript via a chat top-bar overflow menu.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-thread-export-design.md`
+
+## Global Constraints
+- Client-only; reuse loaded history + existing clipboard/`ACTION_SEND` patterns. No AI attribution.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch `feature/thread-export` (off `dev`).
+
+---
+
+### Task 1: `transcriptText` pure helper
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt`; Test `app/src/test/java/com/hermes/client/ui/chat/MessageActionsTest.kt` (extend if it exists, else create)
+
+- [ ] **Step 1: Write the failing test.** Add to (or create) `MessageActionsTest.kt`:
+```kotlin
+package com.hermes.client.ui.chat
+
+import com.hermes.client.domain.ChatMessage
+import com.hermes.client.domain.Role
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageActionsTranscriptTest {
+    private fun msg(role: Role, text: String, isError: Boolean = false) =
+        ChatMessage(id = "x", role = role, text = text, isError = isError)
+
+    @Test fun empty_is_empty() {
+        assertEquals("", transcriptText(emptyList()))
+    }
+
+    @Test fun labels_user_and_assistant() {
+        val t = transcriptText(listOf(msg(Role.USER, "hi"), msg(Role.ASSISTANT, "hello")))
+        assertEquals("You:\nhi\n\nAssistant:\nhello", t)
+    }
+
+    @Test fun skips_blank_turns() {
+        val t = transcriptText(listOf(msg(Role.USER, "q"), msg(Role.ASSISTANT, "   "), msg(Role.ASSISTANT, "a")))
+        assertEquals("You:\nq\n\nAssistant:\na", t)
+    }
+
+    @Test fun error_and_system_labelled_error() {
+        assertTrue(transcriptText(listOf(msg(Role.ASSISTANT, "boom", isError = true))).startsWith("Error:"))
+        assertTrue(transcriptText(listOf(msg(Role.SYSTEM, "sys"))).startsWith("Error:"))
+    }
+
+    @Test fun markdown_preserved_verbatim() {
+        val t = transcriptText(listOf(msg(Role.ASSISTANT, "```kotlin\nval x = 1\n```")))
+        assertTrue(t.contains("```kotlin"))
+        assertTrue(t.contains("val x = 1"))
+    }
+}
+```
+(If `MessageActionsTest.kt` already exists, add these as a new class in the same file or a new file `MessageActionsTranscriptTest.kt` — either is fine; keep the existing tests intact.)
+
+- [ ] **Step 2:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.MessageActionsTranscriptTest"` → FAIL (unresolved `transcriptText`).
+
+- [ ] **Step 3: Implement** — append to `MessageActions.kt` (it already imports `ChatMessage` and `Role`):
+```kotlin
+/**
+ * Render the conversation to a plain-text, role-labeled transcript. Body text is verbatim
+ * (markdown preserved). Blank-text turns (tool-only / still-streaming stubs) are skipped.
+ */
+fun transcriptText(messages: List<ChatMessage>): String =
+    messages
+        .filter { it.text.isNotBlank() }
+        .joinToString("\n\n") { m ->
+            val label = when {
+                m.isError || m.role == Role.SYSTEM -> "Error"
+                m.role == Role.USER -> "You"
+                else -> "Assistant"
+            }
+            "$label:\n${m.text}"
+        }
+```
+
+- [ ] **Step 4:** Run the test → PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/MessageActions.kt \
+        app/src/test/java/com/hermes/client/ui/chat/MessageActionsTranscriptTest.kt
+git commit -m "feat: add transcriptText conversation formatter"
+```
+(Adjust the `git add` test path if you extended the existing `MessageActionsTest.kt` instead.)
+
+---
+
+### Task 2: Chat top-bar overflow menu
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `transcriptText` (Task 1).
+
+- [ ] **Step 1: Add imports + state.** Ensure these imports exist in `ChatScreen.kt` (add any missing):
+```kotlin
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+```
+Near the other composer/UI state (e.g. by `val context = LocalContext.current` at line ~161), add:
+```kotlin
+    val clipboard = LocalClipboardManager.current
+    var transcriptMenu by remember { mutableStateOf(false) }
+```
+
+- [ ] **Step 2: Add the overflow to the top-bar `actions`.** In the `HermesTopBar(...) { actions = { … } }` block, after `StatusDot(connState)`, add:
+```kotlin
+                    Box {
+                        IconButton(onClick = { transcriptMenu = true }) {
+                            Icon(
+                                Icons.Rounded.MoreVert,
+                                contentDescription = "More",
+                                tint = com.hermes.client.ui.components.AccentChrome.onBar,
+                            )
+                        }
+                        DropdownMenu(expanded = transcriptMenu, onDismissRequest = { transcriptMenu = false }) {
+                            DropdownMenuItem(
+                                text = { Text("Copy transcript") },
+                                onClick = {
+                                    val t = transcriptText(state.messages)
+                                    if (t.isBlank()) {
+                                        android.widget.Toast.makeText(context, "Nothing to export yet", android.widget.Toast.LENGTH_SHORT).show()
+                                    } else {
+                                        clipboard.setText(AnnotatedString(t))
+                                        android.widget.Toast.makeText(context, "Transcript copied", android.widget.Toast.LENGTH_SHORT).show()
+                                    }
+                                    transcriptMenu = false
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Share transcript") },
+                                onClick = {
+                                    val t = transcriptText(state.messages)
+                                    if (t.isBlank()) {
+                                        android.widget.Toast.makeText(context, "Nothing to export yet", android.widget.Toast.LENGTH_SHORT).show()
+                                    } else {
+                                        val send = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                                            type = "text/plain"
+                                            putExtra(android.content.Intent.EXTRA_SUBJECT, "Hermes chat transcript")
+                                            putExtra(android.content.Intent.EXTRA_TEXT, t)
+                                        }
+                                        context.startActivity(android.content.Intent.createChooser(send, "Share transcript"))
+                                    }
+                                    transcriptMenu = false
+                                },
+                            )
+                        }
+                    }
+```
+NOTE: use the actual name of the chat UI-state variable in this file for `state.messages` — read the file to confirm whether it's `state`, `uiState`, or similar (the same variable already rendered by `ChatMessageList(...)`). `DropdownMenu`/`DropdownMenuItem` are already imported (lines 47-48). If `IconButton`/`Icon`/`Box`/`Text`/`remember`/`mutableStateOf` aren't imported, add them (they're standard and almost certainly already present).
+
+- [ ] **Step 3: Compile + full suite + assembleBeta.** Run each (JAVA_HOME set): `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta` — all BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat: Copy/Share transcript overflow menu in the chat top bar"
+```
+
+---
+
+### Task 3: On-device verification
+
+- [ ] **Step 1:** `:app:installBeta` (target `emulator-5554` if multiple devices). The app should be configured/connected; open a chat that has a few turns (or create one and send a message).
+- [ ] **Step 2:** Chat top bar → ⋮ → **Copy transcript** → confirm a "Transcript copied" toast; paste into another field/app and confirm the role-labeled transcript ("You:" / "Assistant:").
+- [ ] **Step 3:** ⋮ → **Share transcript** → confirm the system share chooser opens with the transcript as text.
+- [ ] **Step 4:** On a brand-new empty chat, ⋮ → either item → confirm "Nothing to export yet" and no chooser/clipboard change.
+- [ ] **Step 5:** Record pass/fail in the PR description.
+
+---
+
+## Notes for the executor
+- Do NOT add file export (FileProvider/.txt), include `thinking`/tool output, or add ViewModel/Activity changes — explicit anti-scope. Everything is wired inline in `ChatScreen`.
+- Confirm the in-file chat-state variable name before using `state.messages`.

--- a/docs/superpowers/specs/2026-07-17-thread-export-design.md
+++ b/docs/superpowers/specs/2026-07-17-thread-export-design.md
@@ -1,0 +1,66 @@
+# Thread Export / Share — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/thread-export` (off `dev`).
+
+**Goal:** Let the user copy or share a whole chat conversation as a plain-text transcript, from an overflow menu in the chat top bar. Client-only; reuses the already-loaded history + existing clipboard/`ACTION_SEND` patterns.
+
+**Constraints:** Kotlin/Compose/Material3. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Scope
+- **In:** a pure `transcriptText(messages)` formatter; a `MoreVert` overflow menu in the chat top bar with **Copy transcript** (clipboard) and **Share transcript** (`ACTION_SEND` text/plain chooser).
+- **Out (deferred):** file export (`.txt`/`.md` via FileProvider/`EXTRA_STREAM`); including reasoning (`thinking`)/tool output in the transcript; per-selection/range export; import.
+
+## Architecture
+
+### 1. `ui/chat/MessageActions.kt` (modify) — pure helper
+```kotlin
+/**
+ * Render the conversation to a plain-text, role-labeled transcript. Body text is verbatim
+ * (markdown preserved). Blank-text turns (tool-only / still-streaming stubs) are skipped.
+ */
+fun transcriptText(messages: List<ChatMessage>): String =
+    messages
+        .filter { it.text.isNotBlank() }
+        .joinToString("\n\n") { m ->
+            val label = when {
+                m.isError || m.role == Role.SYSTEM -> "Error"
+                m.role == Role.USER -> "You"
+                else -> "Assistant"
+            }
+            "$label:\n${m.text}"
+        }
+```
+
+### 2. `ui/chat/ChatScreen.kt` (modify) — overflow menu
+In the `HermesTopBar` `actions` slot (after `StatusDot(connState)`), add a `MoreVert` `IconButton` + a `DropdownMenu` (`var transcriptMenu by remember { mutableStateOf(false) }`). Two items:
+- **"Copy transcript"** → `val t = transcriptText(uiState.messages); if (t.isBlank()) toast("Nothing to export yet") else { clipboard.setText(AnnotatedString(t)); toast("Transcript copied") }; transcriptMenu = false`.
+- **"Share transcript"** → `val t = transcriptText(uiState.messages); if (t.isBlank()) toast("Nothing to export yet") else context.startActivity(Intent.createChooser(Intent(ACTION_SEND).apply { type = "text/plain"; putExtra(EXTRA_SUBJECT, "Hermes chat transcript"); putExtra(EXTRA_TEXT, t) }, "Share transcript")); transcriptMenu = false`.
+
+`uiState.messages`, `LocalContext.current` (already `val context` at line 161) are in scope; add `val clipboard = LocalClipboardManager.current`. Icon tint uses `AccentChrome.onBar` like the existing Search icon. No ViewModel/Activity changes.
+
+## Data flow
+```
+chat top bar ⋮ → Copy transcript  → transcriptText(messages) → clipboard.setText + toast
+              → Share transcript → transcriptText(messages) → ACTION_SEND text/plain chooser
+(empty transcript → "Nothing to export yet" toast, no clipboard/chooser)
+```
+
+## Error handling
+- Empty conversation / all-blank → both items toast "Nothing to export yet" and do nothing.
+- `transcriptText` is pure and total (never throws).
+
+## Testing
+- **`MessageActionsTest`** (extend, pure): empty list → `""`; a USER+ASSISTANT pair → `"You:\n…\n\nAssistant:\n…"`; a blank-text turn is skipped; an `isError`/SYSTEM turn → `"Error:\n…"`; markdown in a body is preserved verbatim.
+- The top-bar menu, clipboard, and share chooser are Android/Compose glue — verified on-device.
+
+## On-device verification
+Open a chat with a few turns → top-bar ⋮ → **Copy transcript** → paste elsewhere shows the role-labeled transcript; **Share transcript** → the system chooser opens with the transcript text. On an empty chat, both show "Nothing to export yet".
+
+## Files
+| Action | Path |
+|--------|------|
+| Modify | `ui/chat/MessageActions.kt` (`transcriptText`) + `MessageActionsTest.kt` |
+| Modify | `ui/chat/ChatScreen.kt` (overflow menu) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave (client-only). Copy or share a whole conversation as a plain-text transcript from the chat top bar.

## What ships
- Pure `transcriptText(messages)` — role-labeled (You / Assistant / System / Error), body **verbatim** (markdown preserved), blank/tool-only turns skipped.
- A `MoreVert` overflow in the chat top bar with **Copy transcript** (clipboard) and **Share transcript** (`ACTION_SEND` text/plain chooser); empty chat → "Nothing to export yet". All inline in `ChatScreen` (no ViewModel/Activity changes), reusing the existing clipboard + share patterns.

## Quality
- Subagent-driven: 2 TDD/code tasks + on-device, per-task reviews, opus whole-branch review.
- The review caught and this PR fixes: (a) an unbounded transcript could throw `TransactionTooLargeException` on Copy/Share of a very long chat → now `runCatching`-guarded with a failure toast; (b) benign SYSTEM notices were mislabeled "Error" → now labeled "System" (only `isError` → "Error").
- **Gates:** 300 unit tests pass; compile + assembleBeta green; gitleaks clean.
- **On-device:** best-effort — app installs/launches/connects with the changes (no crash); the in-chat overflow wasn't exercised live because the emulator's WS session-create over loopback kept bouncing to setup. Covered by the exact-format formatter tests + reviewed menu wiring.

## Deferred
File export (`.txt`/`.md` via FileProvider), including reasoning/tool output, range/selection export.