### PR TITLE
feat: richer approval-sheet context (grants + owner-override)

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
@@ -59,6 +59,23 @@ fun ApprovalSheet(req: ApprovalRequest, onRespond: (ApprovalChoice) -> Unit, onD
                 Text(req.description, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(bottom = 16.dp))
             }
 
+            if (req.patternKeys.isNotEmpty()) {
+                Text(
+                    "Grants: ${req.patternKeys.joinToString(", ")}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+            if (req.smartDenied) {
+                Text(
+                    "Owner override — approve only this one operation.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+
             if (tier == ApprovalTier.STANDARD) {
                 Button(
                     onClick = { onRespond(ApprovalChoice.ONCE) },

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt
@@ -14,6 +14,7 @@ data class ApprovalRequest(
     val description: String,
     val patternKeys: List<String>,
     val allowPermanent: Boolean,
+    val smartDenied: Boolean = false,
 )
 data class ClarifyRequest(val question: String, val options: List<String>, val requestId: String = "")
 
@@ -98,6 +99,7 @@ fun ChatUiState.reduce(event: ServerEvent): ChatUiState {
                 patternKeys = event.strList("pattern_keys")
                     .ifEmpty { event.str("pattern_key")?.let { listOf(it) } ?: emptyList() },
                 allowPermanent = event.bool("allow_permanent") ?: false,
+                smartDenied = event.bool("smart_denied") ?: false,
             ),
         )
         "clarify.request" -> state.copy(

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
@@ -103,6 +103,23 @@ class ChatReducerTest {
         assertEquals("rm -rf?", s.pendingApproval?.command)
     }
 
+    @Test fun approval_request_extracts_smart_denied_and_all_keys() {
+        var s = ChatUiState.empty()
+        s = s.reduce(ev("approval.request") {
+            put("command", "rm -rf?")
+            put("smart_denied", true)
+            putJsonArray("pattern_keys") { add("shell.rm"); add("shell.dangerous") }
+        })
+        assertEquals(true, s.pendingApproval?.smartDenied)
+        assertEquals(listOf("shell.rm", "shell.dangerous"), s.pendingApproval?.patternKeys)
+    }
+
+    @Test fun approval_request_smart_denied_defaults_false() {
+        var s = ChatUiState.empty()
+        s = s.reduce(ev("approval.request") { put("command", "ls") })
+        assertEquals(false, s.pendingApproval?.smartDenied)
+    }
+
     @Test fun clarify_request_captures_request_id() {
         var s = ChatUiState.empty()
         s = s.reduce(ev("clarify.request") { put("question", "Which repo?"); put("request_id", "req-9") })

--- a/docs/superpowers/plans/2026-07-17-approval-context.md
+++ b/docs/superpowers/plans/2026-07-17-approval-context.md
@@ -1,0 +1,117 @@
+# Approval Context Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Surface the full allowlist keys + the `smart_denied` signal (already in the event) on the approval sheet.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-approval-context-design.md`
+
+## Global Constraints
+- Client-only (reads existing payload keys; no gateway change). No AI attribution.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch `feature/approval-context` (off `dev`).
+
+---
+
+### Task 1: `smartDenied` field + reducer extraction
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt`; Test `app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt` (extend)
+
+- [ ] **Step 1: Write the failing test.** Add to `ChatReducerTest.kt` (mirror the existing `approval_request_sets_pending` test's `ev("approval.request") { put(...) }` pattern):
+```kotlin
+    @Test fun approval_request_extracts_smart_denied_and_all_keys() {
+        var s = ChatUiState.empty()
+        s = s.reduce(ev("approval.request") {
+            put("command", "rm -rf?")
+            put("smart_denied", true)
+            putJsonArray("pattern_keys") { add("shell.rm"); add("shell.dangerous") }
+        })
+        assertEquals(true, s.pendingApproval?.smartDenied)
+        assertEquals(listOf("shell.rm", "shell.dangerous"), s.pendingApproval?.patternKeys)
+    }
+
+    @Test fun approval_request_smart_denied_defaults_false() {
+        var s = ChatUiState.empty()
+        s = s.reduce(ev("approval.request") { put("command", "ls") })
+        assertEquals(false, s.pendingApproval?.smartDenied)
+    }
+```
+(If `putJsonArray`/`add` require imports — `kotlinx.serialization.json.putJsonArray`, `kotlinx.serialization.json.add` — add them, or match however the existing tests build a JSON array. If the existing `ev` helper's builder differs, follow its exact shape; the assertions are the contract.)
+
+- [ ] **Step 2:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ChatReducerTest"` → FAIL (unresolved `smartDenied`).
+
+- [ ] **Step 3: Implement.** In `ChatUiState.kt`, add the field to `ApprovalRequest`:
+```kotlin
+data class ApprovalRequest(
+    val command: String,
+    val description: String,
+    val patternKeys: List<String>,
+    val allowPermanent: Boolean,
+    val smartDenied: Boolean = false,
+)
+```
+And extract it in the `"approval.request"` reducer branch (add after the `allowPermanent = …` line):
+```kotlin
+                allowPermanent = event.bool("allow_permanent") ?: false,
+                smartDenied = event.bool("smart_denied") ?: false,
+```
+
+- [ ] **Step 4:** Run the test → PASS (existing approval tests + the 2 new ones).
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatUiState.kt \
+        app/src/test/java/com/hermes/client/ui/chat/ChatReducerTest.kt
+git commit -m "feat: extract smart_denied from approval.request events"
+```
+
+---
+
+### Task 2: Approval sheet enrichment
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt`
+
+**Interfaces:** Consumes `ApprovalRequest.smartDenied` + `patternKeys` (Task 1).
+
+- [ ] **Step 1: Add the Grants row + warning.** In `ApprovalSheet.kt`, after the `description` block (the `if (req.description.isNotBlank()) { … }`) and BEFORE `if (tier == ApprovalTier.STANDARD) { … }`, insert:
+```kotlin
+            if (req.patternKeys.isNotEmpty()) {
+                Text(
+                    "Grants: ${req.patternKeys.joinToString(", ")}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+            if (req.smartDenied) {
+                Text(
+                    "Owner override — approve only this one operation.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+            }
+```
+No other change (tier logic + buttons unchanged).
+
+- [ ] **Step 2: Compile + full suite + assembleBeta.** Run each (JAVA_HOME set): `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta` — all BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ApprovalSheet.kt
+git commit -m "feat: show full allowlist grants + smart-denied warning on the approval sheet"
+```
+
+---
+
+### Task 3: On-device verification (best-effort)
+
+- [ ] **Step 1:** `:app:installBeta`.
+- [ ] **Step 2:** If a standard tool approval with multiple allowlist keys can be triggered, confirm the sheet shows "Grants: k1, k2" under the command/description; a `smart_denied` approval shows the red "Owner override…" caption.
+- [ ] **Step 3:** Note: approvals require an agent tool call under manual-approval mode and can't be forced on demand — if none arises, record that the render is covered by the reducer tests + code review. Record pass/fail in the PR.
+
+---
+
+## Notes for the executor
+- Do NOT try to add tool name / args / cwd / diff — those aren't in the `approval.request` payload (a gateway change, explicit anti-scope).
+- Keep the tier logic and buttons untouched; this is purely additive display.

--- a/docs/superpowers/specs/2026-07-17-approval-context-design.md
+++ b/docs/superpowers/specs/2026-07-17-approval-context-design.md
@@ -1,0 +1,86 @@
+# Approval Context Enrichment — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/approval-context` (off `dev`).
+
+**Goal:** Surface more of the context the `approval.request` event already carries on the approval sheet, so the user decides without opening the thread. Client-only — reads existing payload keys; no gateway change.
+
+**Constraints:** Kotlin/Compose/Material3. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Reality check (from the gateway audit)
+The `approval.request` event carries only: `command`, `description`, `pattern_keys`/`pattern_key`, `allow_permanent`, `smart_denied`, `choices`. There is **no** tool name, args, cwd, or diff in the payload (those would need a gateway change — out of scope). The sheet already shows the (redacted) `command` (monospace) + `description`. So the client-only enrichment is small:
+1. Show **all** allowlist keys a permanent approval would grant (today only the first is shown, in the title).
+2. Surface the `smart_denied` owner-override signal (currently discarded) as a distinct warning.
+
+## Scope
+- **In:** add `smartDenied` to `ApprovalRequest` + extract it in the reducer; render a "Grants:" all-keys row and a `smart_denied` warning caption on `ApprovalSheet`.
+- **Out (needs gateway):** tool name, arguments, working directory, diff/preview.
+
+## Architecture
+
+### 1. `ui/chat/ChatUiState.kt` (modify)
+Add a field to `ApprovalRequest`:
+```kotlin
+data class ApprovalRequest(
+    val command: String,
+    val description: String,
+    val patternKeys: List<String>,
+    val allowPermanent: Boolean,
+    val smartDenied: Boolean = false,
+)
+```
+Extract it in the `"approval.request"` reducer branch:
+```kotlin
+                allowPermanent = event.bool("allow_permanent") ?: false,
+                smartDenied = event.bool("smart_denied") ?: false,
+```
+
+### 2. `ui/chat/ApprovalSheet.kt` (modify)
+After the `description` block and before the tier buttons, add:
+- **Grants row** — when `req.patternKeys.size > 0`, a `bodySmall` labeled line listing every key (so the user sees the full allowlist scope a Session/Always approval covers), styled `onSurfaceVariant`:
+  ```kotlin
+  if (req.patternKeys.isNotEmpty()) {
+      Text(
+          "Grants: ${req.patternKeys.joinToString(", ")}",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+          modifier = Modifier.padding(bottom = 8.dp),
+      )
+  }
+  ```
+- **smart_denied warning** — when `req.smartDenied`, an `error`-colored caption above the buttons:
+  ```kotlin
+  if (req.smartDenied) {
+      Text(
+          "Owner override — approve only this one operation.",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.error,
+          modifier = Modifier.padding(bottom = 8.dp),
+      )
+  }
+  ```
+No change to the tier logic or buttons.
+
+## Data flow
+```
+approval.request event → reducer extracts command/description/patternKeys/allowPermanent/smartDenied → ApprovalRequest
+ApprovalSheet → title (first key) + command (mono) + description + "Grants: <all keys>" + [smart_denied warning] + tier buttons
+```
+
+## Error handling
+- Missing `smart_denied` → false (no warning). Empty `patternKeys` → no Grants row. All fields default-safe; the reducer already tolerates absent keys.
+
+## Testing
+- **`ChatReducerTest`** (extend): `approval.request` with `smart_denied=true` → `pendingApproval.smartDenied == true`; without it → false; with `pattern_keys` → `patternKeys` holds all keys.
+- `ApprovalSheet` rendering is Compose glue — verified on-device (best-effort; approvals can't be forced on demand — the render logic is a straightforward conditional over the new fields).
+
+## On-device verification
+When a standard approval with multiple allowlist keys arrives, the sheet shows "Grants: k1, k2"; a `smart_denied` (owner-override) approval shows the red warning caption. (Approvals require an agent tool call gated by manual-approval mode; best-effort — covered by the reducer tests + reviewed render.)
+
+## Files
+| Action | Path |
+|--------|------|
+| Modify | `ui/chat/ChatUiState.kt` (`smartDenied` field + reducer) + `ChatReducerTest.kt` |
+| Modify | `ui/chat/ApprovalSheet.kt` (Grants row + warning) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave (client-only, no gateway change). Surfaces more of what the `approval.request` event already carries, so the user can decide from the sheet.

## What ships
- The approval sheet now shows a **"Grants: <all allowlist keys>"** row (previously only the first key appeared, in the title) — so a Session/Always approval's full scope is visible.
- A distinct **error-colored "Owner override — approve only this one operation."** caption when the event's `smart_denied` flag is set (previously discarded).
- `ApprovalRequest.smartDenied` extracted in the reducer.

## Reality-check / scope
The `approval.request` payload carries only command / description / pattern_keys / allow_permanent / smart_denied. There is **no** tool name, args, cwd, or diff — surfacing those would need a gateway change (deferred). The command + description were already shown, so this is the small, honest client-only enrichment.

## Quality
- Subagent-driven: 2 TDD/code tasks, per-task reviews, opus whole-branch review → READY TO MERGE (purely additive display; decision flow untouched; no secret leak — pattern keys, not the command).
- **Gates:** 302 unit tests pass (2 new reducer tests for `smart_denied`/all-keys); compile + assembleBeta green; gitleaks clean.
- On-device: not separately exercised (approvals require an agent tool call under manual-approval mode, can't be forced); covered by the reducer tests + reviews.

## Deferred (non-blocking)
`verticalScroll` on the sheet Column (pre-existing overflow risk for very long content); reconciling the smart_denied caption with STANDARD-tier Allow buttons; and any richer fields (tool/args/cwd/diff) that need a gateway payload change.