### PR TITLE
feat: per-tenant persona picker

### DIFF
--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -635,7 +635,7 @@ fun ChatScreen(
     if (showPersonaSheet) {
         PersonaSheet(
             ui = personaUi,
-            onPick = { vm.setPersona(it); showPersonaSheet = false },
+            onPick = { vm.setPersona(it) },
             onRetry = { vm.loadPersonas() },
             onDismiss = { showPersonaSheet = false },
         )

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
@@ -112,6 +112,8 @@ fun ChatScreen(
     val speaking by vm.speaking.collectAsStateWithLifecycle()
     val savedPrompts by vm.savedPrompts.collectAsStateWithLifecycle()
     var showPromptSheet by remember { mutableStateOf(false) }
+    val personaUi by vm.personaUi.collectAsStateWithLifecycle()
+    var showPersonaSheet by remember { mutableStateOf(false) }
     androidx.compose.runtime.DisposableEffect(Unit) { onDispose { vm.stopReading() } }
     var draft by remember { mutableStateOf("") }
     var searchOpen by rememberSaveable { mutableStateOf(false) }
@@ -316,6 +318,14 @@ fun ChatScreen(
                                         }
                                     }
                                     transcriptMenu = false
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Persona") },
+                                onClick = {
+                                    transcriptMenu = false
+                                    vm.loadPersonas()
+                                    showPersonaSheet = true
                                 },
                             )
                         }
@@ -620,6 +630,15 @@ fun ChatScreen(
                 }
             }
         }
+    }
+
+    if (showPersonaSheet) {
+        PersonaSheet(
+            ui = personaUi,
+            onPick = { vm.setPersona(it); showPersonaSheet = false },
+            onRetry = { vm.loadPersonas() },
+            onDismiss = { showPersonaSheet = false },
+        )
     }
 }
 

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -360,12 +360,20 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    /** Apply a persona to this session (null / "none" clears it). */
+    /** Apply a persona to this session (null / "none" / "default" clears it). */
     fun setPersona(name: String?) {
-        val wire = name?.takeIf { it.isNotBlank() && !it.equals("none", true) } ?: "none"
+        val wire = name?.takeIf { it.isNotBlank() && !it.equals("none", true) && !it.equals("default", true) } ?: "none"
+        _personaUi.value = _personaUi.value.copy(loading = true, error = null)
         viewModelScope.launch {
             runCatching { chat.slashExec(sessionId, "/personality $wire") }
-                .onSuccess { _personaUi.value = _personaUi.value.copy(active = if (wire == "none") null else wire) }
+                .onSuccess { out ->
+                    if (out != null && out.contains("unknown", ignoreCase = true)) {
+                        _personaUi.value = _personaUi.value.copy(loading = false, error = "Couldn't apply that persona")
+                    } else {
+                        _personaUi.value = _personaUi.value.copy(loading = false, active = if (wire == "none") null else wire)
+                    }
+                }
+                .onFailure { _personaUi.value = _personaUi.value.copy(loading = false, error = "Couldn't apply persona") }
         }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt
@@ -35,6 +35,7 @@ class ChatViewModel @Inject constructor(
     private val pendingShareStore: com.hermes.client.share.PendingShareStore,
     private val tts: com.hermes.client.data.tts.TextToSpeechController,
     private val promptStore: com.hermes.client.data.repository.PromptStore,
+    private val configRepo: com.hermes.client.data.repository.ConfigRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ChatUiState.empty())
@@ -338,5 +339,33 @@ class ChatViewModel @Inject constructor(
 
     fun selectProfile(name: String) {
         viewModelScope.launch { runCatching { profileRepo.setActive(name) } }
+    }
+
+    data class PersonaUi(
+        val personas: List<Persona> = emptyList(),
+        val active: String? = null,
+        val loading: Boolean = false,
+        val error: String? = null,
+    )
+    private val _personaUi = MutableStateFlow(PersonaUi())
+    val personaUi: StateFlow<PersonaUi> = _personaUi.asStateFlow()
+
+    /** Fetch the profile's configured personalities (called when the persona sheet opens). */
+    fun loadPersonas() {
+        _personaUi.value = _personaUi.value.copy(loading = true, error = null)
+        viewModelScope.launch {
+            runCatching { configRepo.get(profileManager.active.value) }
+                .onSuccess { cfg -> _personaUi.value = PersonaUi(parsePersonas(cfg), activePersonaOf(cfg)) }
+                .onFailure { _personaUi.value = _personaUi.value.copy(loading = false, error = "Couldn't load personas") }
+        }
+    }
+
+    /** Apply a persona to this session (null / "none" clears it). */
+    fun setPersona(name: String?) {
+        val wire = name?.takeIf { it.isNotBlank() && !it.equals("none", true) } ?: "none"
+        viewModelScope.launch {
+            runCatching { chat.slashExec(sessionId, "/personality $wire") }
+                .onSuccess { _personaUi.value = _personaUi.value.copy(active = if (wire == "none") null else wire) }
+        }
     }
 }

--- a/app/src/main/java/com/hermes/client/ui/chat/Persona.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/Persona.kt
@@ -21,7 +21,7 @@ fun parsePersonas(config: JsonObject): List<Persona> {
     }.sortedBy { it.name.lowercase() }
 }
 
-/** The active personality (`display.personality`); blank/"none" → null. */
+/** The active personality (`display.personality`); blank/"none"/"default" → null. */
 fun activePersonaOf(config: JsonObject): String? =
     config.objOrNull("display")?.strOrNull("personality")
-        ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+        ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) && !it.equals("default", ignoreCase = true) }

--- a/app/src/main/java/com/hermes/client/ui/chat/Persona.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/Persona.kt
@@ -1,0 +1,27 @@
+package com.hermes.client.ui.chat
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/** A gateway-configured personality the user can apply to a session. */
+data class Persona(val name: String, val description: String)
+
+private fun JsonObject.objOrNull(key: String): JsonObject? = (this[key] as? JsonObject)
+private fun JsonObject.strOrNull(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+
+/** Personalities from `agent.personalities` (name → String | object). Sorted by name; never throws. */
+fun parsePersonas(config: JsonObject): List<Persona> {
+    val personalities = config.objOrNull("agent")?.objOrNull("personalities") ?: return emptyList()
+    return personalities.entries.map { (name, value) ->
+        val desc = (value as? JsonObject)?.let {
+            it.strOrNull("description") ?: it.strOrNull("tone") ?: it.strOrNull("style") ?: ""
+        }.orEmpty().trim()
+        Persona(name, desc)
+    }.sortedBy { it.name.lowercase() }
+}
+
+/** The active personality (`display.personality`); blank/"none" → null. */
+fun activePersonaOf(config: JsonObject): String? =
+    config.objOrNull("display")?.strOrNull("personality")
+        ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }

--- a/app/src/main/java/com/hermes/client/ui/chat/PersonaSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/chat/PersonaSheet.kt
@@ -1,0 +1,95 @@
+package com.hermes.client.ui.chat
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PersonaSheet(
+    ui: ChatViewModel.PersonaUi,
+    onPick: (String?) -> Unit,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val accent = LocalProfileAccent.current.accent
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+            Text("Persona", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(bottom = 8.dp))
+
+            when {
+                ui.loading -> {
+                    Box(Modifier.fillMaxWidth().height(120.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                ui.error != null -> {
+                    Text(ui.error, color = MaterialTheme.colorScheme.error, modifier = Modifier.padding(bottom = 8.dp))
+                    TextButton(onClick = onRetry) { Text("Retry") }
+                }
+                else -> {
+                    LazyColumn(Modifier.fillMaxWidth()) {
+                        item {
+                            ListItem(
+                                headlineContent = { Text("None (default)") },
+                                trailingContent = {
+                                    if (ui.active == null) {
+                                        Icon(Icons.Rounded.Check, contentDescription = "Active", tint = accent)
+                                    }
+                                },
+                                modifier = Modifier.clickable { onPick(null) },
+                            )
+                        }
+                        if (ui.personas.isEmpty()) {
+                            item {
+                                Text(
+                                    "No personas configured — add them in your gateway config.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                                )
+                            }
+                        }
+                        items(ui.personas, key = { it.name }) { p ->
+                            ListItem(
+                                headlineContent = { Text(p.name) },
+                                supportingContent = if (p.description.isNotBlank()) {
+                                    { Text(p.description) }
+                                } else null,
+                                trailingContent = {
+                                    if (p.name == ui.active) {
+                                        Icon(Icons.Rounded.Check, contentDescription = "Active", tint = accent)
+                                    }
+                                },
+                                modifier = Modifier.clickable { onPick(p.name) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -282,4 +282,16 @@ class ChatViewModelTest {
         vm.setPersona(null); advanceUntilIdle()
         io.mockk.coVerify { chatRepo.slashExec(any(), "/personality none") }
     }
+
+    // chat.slashExec returns command-level errors in its output string (only transport failures
+    // throw), so a gateway rejection of an unknown persona must surface as an error, not silently
+    // set active — otherwise the UI would show a persona as applied when the gateway refused it.
+    @Test fun setPersona_rejection_surfaces_error_and_does_not_set_active() = runTest {
+        coEvery { chatRepo.slashExec(any(), any()) } returns "unknown personality: x"
+        val vm = buildVm()
+        vm.setPersona("bad"); advanceUntilIdle()
+
+        assertTrue("a gateway rejection must surface a persona error", vm.personaUi.value.error != null)
+        assertEquals(null, vm.personaUi.value.active)
+    }
 }

--- a/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
@@ -42,6 +42,7 @@ class ChatViewModelTest {
     private val pendingShareStore = com.hermes.client.share.PendingShareStore()
     private val tts = mockk<com.hermes.client.data.tts.TextToSpeechController>(relaxed = true)
     private val promptStore = mockk<com.hermes.client.data.repository.PromptStore>(relaxed = true)
+    private val configRepo = mockk<com.hermes.client.data.repository.ConfigRepository>(relaxed = true)
 
     @Before fun setUp() {
         Dispatchers.setMain(StandardTestDispatcher())
@@ -60,7 +61,7 @@ class ChatViewModelTest {
         every { promptStore.prompts } returns MutableStateFlow(emptyList())
     }
 
-    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore, tts, promptStore)
+    private fun buildVm() = ChatViewModel(chatRepo, sessionRepo, modelRepo, profileRepo, profileManager, favoritesStore, pendingShareStore, tts, promptStore, configRepo)
 
     @Test fun streamed_delta_appears_in_state() = runTest {
         val vm = buildVm()
@@ -268,5 +269,17 @@ class ChatViewModelTest {
         val vm = buildVm()
         vm.stopReading()
         io.mockk.verify { tts.stop() }
+    }
+
+    @Test fun setPersona_sends_personality_slash() = runTest {
+        val vm = buildVm()
+        vm.setPersona("witty"); advanceUntilIdle()
+        io.mockk.coVerify { chatRepo.slashExec(any(), "/personality witty") }
+    }
+
+    @Test fun setPersona_null_clears_with_none() = runTest {
+        val vm = buildVm()
+        vm.setPersona(null); advanceUntilIdle()
+        io.mockk.coVerify { chatRepo.slashExec(any(), "/personality none") }
     }
 }

--- a/app/src/test/java/com/hermes/client/ui/chat/PersonaTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/PersonaTest.kt
@@ -1,0 +1,31 @@
+package com.hermes.client.ui.chat
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PersonaTest {
+    private fun obj(s: String): JsonObject = Json.decodeFromString(JsonObject.serializer(), s)
+
+    @Test fun parses_string_and_object_personas_sorted() {
+        val c = obj("""{"agent":{"personalities":{"witty":"Be witty","coach":{"description":"A coach","tone":"warm"}}}}""")
+        val ps = parsePersonas(c)
+        assertEquals(listOf("coach", "witty"), ps.map { it.name })          // sorted
+        assertEquals("A coach", ps.first { it.name == "coach" }.description) // object → description
+        assertEquals("", ps.first { it.name == "witty" }.description)        // string → no description
+    }
+
+    @Test fun missing_agent_or_personalities_is_empty() {
+        assertEquals(emptyList<Persona>(), parsePersonas(obj("""{}""")))
+        assertEquals(emptyList<Persona>(), parsePersonas(obj("""{"agent":{}}""")))
+    }
+
+    @Test fun active_persona_reads_display_and_maps_none_to_null() {
+        assertEquals("coach", activePersonaOf(obj("""{"display":{"personality":"coach"}}""")))
+        assertNull(activePersonaOf(obj("""{"display":{"personality":"none"}}""")))
+        assertNull(activePersonaOf(obj("""{"display":{"personality":""}}""")))
+        assertNull(activePersonaOf(obj("""{}""")))
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/chat/PersonaTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/chat/PersonaTest.kt
@@ -28,4 +28,8 @@ class PersonaTest {
         assertNull(activePersonaOf(obj("""{"display":{"personality":""}}""")))
         assertNull(activePersonaOf(obj("""{}""")))
     }
+
+    @Test fun active_persona_maps_default_to_null() {
+        assertNull(activePersonaOf(obj("""{"display":{"personality":"default"}}""")))
+    }
 }

--- a/docs/superpowers/plans/2026-07-17-persona-picker.md
+++ b/docs/superpowers/plans/2026-07-17-persona-picker.md
@@ -1,0 +1,217 @@
+# Per-Tenant Persona Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Pick a gateway-configured personality and apply it to the session, from the chat overflow menu.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-persona-picker-design.md`
+
+## Global Constraints
+- Client-only; read personas via `ConfigRepository.get(activeProfile)`, set via `slashExec("/personality <name>")`. No AI attribution.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`.
+- Branch `feature/persona-picker` (off `dev`).
+
+---
+
+### Task 1: Persona model + pure parsers
+
+**Files:** Create `app/src/main/java/com/hermes/client/ui/chat/Persona.kt`; Test `app/src/test/java/com/hermes/client/ui/chat/PersonaTest.kt`
+
+- [ ] **Step 1: Write the failing test** `PersonaTest.kt`:
+```kotlin
+package com.hermes.client.ui.chat
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PersonaTest {
+    private fun obj(s: String): JsonObject = Json.decodeFromString(JsonObject.serializer(), s)
+
+    @Test fun parses_string_and_object_personas_sorted() {
+        val c = obj("""{"agent":{"personalities":{"witty":"Be witty","coach":{"description":"A coach","tone":"warm"}}}}""")
+        val ps = parsePersonas(c)
+        assertEquals(listOf("coach", "witty"), ps.map { it.name })          // sorted
+        assertEquals("A coach", ps.first { it.name == "coach" }.description) // object → description
+        assertEquals("", ps.first { it.name == "witty" }.description)        // string → no description
+    }
+
+    @Test fun missing_agent_or_personalities_is_empty() {
+        assertEquals(emptyList<Persona>(), parsePersonas(obj("""{}""")))
+        assertEquals(emptyList<Persona>(), parsePersonas(obj("""{"agent":{}}""")))
+    }
+
+    @Test fun active_persona_reads_display_and_maps_none_to_null() {
+        assertEquals("coach", activePersonaOf(obj("""{"display":{"personality":"coach"}}""")))
+        assertNull(activePersonaOf(obj("""{"display":{"personality":"none"}}""")))
+        assertNull(activePersonaOf(obj("""{"display":{"personality":""}}""")))
+        assertNull(activePersonaOf(obj("""{}""")))
+    }
+}
+```
+(Delete the stray `cfg` helper if it doesn't compile — only `obj(...)` is needed. Match the project's kotlinx.serialization imports.)
+
+- [ ] **Step 2:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.PersonaTest"` → FAIL.
+
+- [ ] **Step 3: Implement** `Persona.kt`:
+```kotlin
+package com.hermes.client.ui.chat
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** A gateway-configured personality the user can apply to a session. */
+data class Persona(val name: String, val description: String)
+
+private fun JsonObject.objOrNull(key: String): JsonObject? = (this[key] as? JsonObject)
+private fun JsonObject.strOrNull(key: String): String? =
+    (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+
+/** Personalities from `agent.personalities` (name → String | object). Sorted by name; never throws. */
+fun parsePersonas(config: JsonObject): List<Persona> {
+    val personalities = config.objOrNull("agent")?.objOrNull("personalities") ?: return emptyList()
+    return personalities.entries.map { (name, value) ->
+        val desc = (value as? JsonObject)?.let {
+            it.strOrNull("description") ?: it.strOrNull("tone") ?: it.strOrNull("style") ?: ""
+        }.orEmpty().trim()
+        Persona(name, desc)
+    }.sortedBy { it.name.lowercase() }
+}
+
+/** The active personality (`display.personality`); blank/"none" → null. */
+fun activePersonaOf(config: JsonObject): String? =
+    config.objOrNull("display")?.strOrNull("personality")
+        ?.takeIf { it.isNotBlank() && !it.equals("none", ignoreCase = true) }
+```
+
+- [ ] **Step 4:** Run the test → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/Persona.kt \
+        app/src/test/java/com/hermes/client/ui/chat/PersonaTest.kt
+git commit -m "feat: parse configured personas from gateway config"
+```
+
+---
+
+### Task 2: ChatViewModel persona wiring
+
+**Files:** Modify `app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt`, `app/src/main/java/com/hermes/client/di/AppModule.kt` (only if `ConfigRepository` isn't already provided — check first); Test `app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt` (extend)
+
+**Interfaces:** Consumes `parsePersonas`/`activePersonaOf` (Task 1), `ConfigRepository.get(profile)`, `ChatRepository.slashExec`.
+
+- [ ] **Step 1: Confirm `ConfigRepository` is Hilt-provided.** `grep -n "ConfigRepository" app/src/main/java/com/hermes/client/di/AppModule.kt` — it's already used by the settings screens, so a provider likely exists. If NOT, add `@Provides @Singleton fun provideConfigRepository(rest: HermesRestApi): ConfigRepository = ConfigRepository(rest)`.
+
+- [ ] **Step 2: Write the failing test (extend `ChatViewModelTest`).** Add a mock + `buildVm` arg + tests:
+```kotlin
+    private val configRepo = mockk<com.hermes.client.data.repository.ConfigRepository>(relaxed = true)
+```
+Update `buildVm()` to pass `configRepo` as the new last arg. Add:
+```kotlin
+    @Test fun setPersona_sends_personality_slash() = runTest {
+        val vm = buildVm()
+        vm.setPersona("witty"); advanceUntilIdle()
+        io.mockk.coVerify { chatRepo.slashExec(any(), "/personality witty") }
+    }
+
+    @Test fun setPersona_null_clears_with_none() = runTest {
+        val vm = buildVm()
+        vm.setPersona(null); advanceUntilIdle()
+        io.mockk.coVerify { chatRepo.slashExec(any(), "/personality none") }
+    }
+```
+(If the test file's mockk/runTest conventions differ, match them; the `slashExec` verifications are the contract. `chatRepo` is the existing ChatRepository mock name in this test.)
+
+- [ ] **Step 3:** Run `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.chat.ChatViewModelTest"` → FAIL.
+
+- [ ] **Step 4: Implement** in `ChatViewModel.kt`:
+Add the constructor param (new last):
+```kotlin
+    private val configRepo: com.hermes.client.data.repository.ConfigRepository,
+```
+Add the state + methods:
+```kotlin
+    data class PersonaUi(
+        val personas: List<Persona> = emptyList(),
+        val active: String? = null,
+        val loading: Boolean = false,
+        val error: String? = null,
+    )
+    private val _personaUi = MutableStateFlow(PersonaUi())
+    val personaUi: StateFlow<PersonaUi> = _personaUi.asStateFlow()
+
+    /** Fetch the profile's configured personalities (called when the persona sheet opens). */
+    fun loadPersonas() {
+        _personaUi.value = _personaUi.value.copy(loading = true, error = null)
+        viewModelScope.launch {
+            runCatching { configRepo.get(profileManager.active.value) }
+                .onSuccess { cfg -> _personaUi.value = PersonaUi(parsePersonas(cfg), activePersonaOf(cfg)) }
+                .onFailure { _personaUi.value = _personaUi.value.copy(loading = false, error = "Couldn't load personas") }
+        }
+    }
+
+    /** Apply a persona to this session (null / "none" clears it). */
+    fun setPersona(name: String?) {
+        val wire = name?.takeIf { it.isNotBlank() && !it.equals("none", true) } ?: "none"
+        viewModelScope.launch {
+            runCatching { chat.slashExec(sessionId, "/personality $wire") }
+                .onSuccess { _personaUi.value = _personaUi.value.copy(active = if (wire == "none") null else wire) }
+        }
+    }
+```
+(Ensure `MutableStateFlow`/`StateFlow`/`asStateFlow`/`launch` imports exist — they do, used throughout this VM.)
+
+- [ ] **Step 5:** Run the test → PASS. Then `:app:compileDebugKotlin` → BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/ChatViewModel.kt \
+        app/src/main/java/com/hermes/client/di/AppModule.kt \
+        app/src/test/java/com/hermes/client/ui/chat/ChatViewModelTest.kt
+git commit -m "feat: ChatViewModel persona load + apply"
+```
+(Drop `AppModule.kt` from the add if you didn't need to change it.)
+
+---
+
+### Task 3: Persona sheet + overflow item
+
+**Files:** Create `app/src/main/java/com/hermes/client/ui/chat/PersonaSheet.kt`; Modify `app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt`
+
+**Interfaces:** Consumes `ChatViewModel.personaUi`/`loadPersonas`/`setPersona` (Task 2).
+
+- [ ] **Step 1: PersonaSheet composable.** Create `PersonaSheet.kt` with `@OptIn(ExperimentalMaterial3Api::class) @Composable fun PersonaSheet(ui: PersonaUi, onPick: (String?) -> Unit, onRetry: () -> Unit, onDismiss: () -> Unit)`: a `ModalBottomSheet` containing a title "Persona"; when `ui.loading` a centered spinner; when `ui.error != null` the error text + a "Retry" `TextButton(onRetry)`; else a `LazyColumn` with a "None (default)" `ListItem` (`onClick = { onPick(null) }`) followed by one `ListItem` per `ui.personas` (headline = name, supporting = description when non-blank, `onClick = { onPick(p.name) }`); mark the active row (`p.name == ui.active`, or None when `ui.active == null`) with a trailing check `Icon` tinted `LocalProfileAccent.current.accent`. When `ui.personas` is empty and not loading/error, show a hint `Text("No personas configured — add them in your gateway config.")` under the None row. (`PersonaUi` is nested in `ChatViewModel`; reference it as `ChatViewModel.PersonaUi`.)
+
+- [ ] **Step 2: Overflow item + host in ChatScreen.** In `ChatScreen.kt`:
+  - Add `var showPersonaSheet by remember { mutableStateOf(false) }` and `val personaUi by vm.personaUi.collectAsStateWithLifecycle()`.
+  - In the top-bar overflow `DropdownMenu` (the Copy/Share transcript one), add a `DropdownMenuItem(text = { Text("Persona") }, onClick = { transcriptMenu = false; vm.loadPersonas(); showPersonaSheet = true })`.
+  - After the existing sheets/hosts, add: `if (showPersonaSheet) { PersonaSheet(ui = personaUi, onPick = { vm.setPersona(it); showPersonaSheet = false }, onRetry = { vm.loadPersonas() }, onDismiss = { showPersonaSheet = false }) }`.
+
+- [ ] **Step 3: Compile + full suite + assembleBeta** — all three (JAVA_HOME set) BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/chat/PersonaSheet.kt \
+        app/src/main/java/com/hermes/client/ui/chat/ChatScreen.kt
+git commit -m "feat: persona picker sheet in the chat overflow menu"
+```
+
+---
+
+### Task 4: On-device verification (best-effort)
+
+- [ ] **Step 1:** `:app:installBeta`. Connect to a gateway that has ≥1 configured personality (`agent.personalities` in its config).
+- [ ] **Step 2:** Open a chat → overflow ⋮ → Persona → the sheet lists the configured personas + "None (default)", marking the active one. Tap one → applies (sheet closes; the active mark moves). Tap None → clears.
+- [ ] **Step 3:** If no personas are configured, confirm only "None (default)" + the hint appears; if the config fetch fails, the error + Retry appears.
+- [ ] **Step 4:** Note: requires a connected session + configured personas; if unavailable, record that the parse + apply are covered by `PersonaTest` + `ChatViewModelTest` + review. Record in the PR.
+
+---
+
+## Notes for the executor
+- Do NOT add persona creation/editing (gateway-config-owned), profile-default persistence (`config.set` — deferred), or a non-chat persona surface — anti-scope.
+- Read personas for the SESSION's active profile (the `profileManager.active.value` passed to `configRepo.get`) so a name valid for this tenant isn't rejected.

--- a/docs/superpowers/specs/2026-07-17-persona-picker-design.md
+++ b/docs/superpowers/specs/2026-07-17-persona-picker-design.md
@@ -1,0 +1,94 @@
+# Per-Tenant Persona Picker — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/persona-picker` (off `dev`).
+
+**Goal:** Let the user pick one of the personalities already configured in the gateway (per-profile) and apply it to the current session — exposing an existing gateway capability with no backend change.
+
+**Constraints:** Kotlin/Compose/Material3/Hilt, per-tenant. No AI attribution; gitleaks before push; PR into `dev`.
+
+## Feasibility (from the gateway audit)
+- **Read:** `GET /api/config` (already used via `ConfigRepository.get(profile)`) returns `agent.personalities` (a map `name → String | {system_prompt, tone, style, …}`) and `display.personality` (the active one). No gateway change to populate a picker.
+- **Set:** the existing `slashExec(sessionId, "/personality <name>")` applies a pre-registered persona to the session (session-scoped/ephemeral; gated to configured names by the gateway; `none`/`default` clears it). Mirrors the model picker's `/model … --session`.
+- **Per-tenant for free:** config read + the slash apply are both profile-scoped. Read personalities for the **session's** profile (the active profile).
+
+## Scope
+- **In:** parse personalities + active from the config; a "Persona" item in the chat overflow menu → a bottom sheet listing them (+ "None (default)"), highlighting the active; apply via `slashExec`.
+- **Out (deferred):** persisting the choice as the profile default (`config.set key=personality` — a separate small RPC); creating/editing personas (they're gateway-config-managed); a persona picker on non-chat surfaces.
+
+## Architecture
+
+### 1. `ui/chat/Persona.kt` (new) — model + pure parsers
+```kotlin
+data class Persona(val name: String, val description: String)
+
+/** Personalities configured for this profile, from the gateway config JSON (agent.personalities). */
+fun parsePersonas(config: JsonObject): List<Persona>
+/** The active personality name (display.personality), or null/"none" when unset. */
+fun activePersonaOf(config: JsonObject): String?
+```
+`parsePersonas`: read `config["agent"]?.jsonObject?["personalities"]?.jsonObject`; for each entry, `name = key`; `description` = if the value is a JSON object, its `description`/`tone`/`style` (first available, trimmed) else "" (string-valued personas have no separate description). Sorted by name. Never throws (missing keys → empty list). `activePersonaOf`: `config["display"]?.jsonObject?["personality"]` as string; map blank/`"none"` → null.
+
+### 2. `ui/chat/ChatViewModel.kt` (modify)
+Inject `ConfigRepository` (new last constructor param). Add:
+```kotlin
+data class PersonaUi(val personas: List<Persona> = emptyList(), val active: String? = null, val loading: Boolean = false, val error: String? = null)
+val personaUi: StateFlow<PersonaUi>  // MutableStateFlow-backed
+
+fun loadPersonas() {  // called when the sheet opens
+    _personaUi.value = _personaUi.value.copy(loading = true, error = null)
+    viewModelScope.launch {
+        runCatching { configRepo.get(profileManager.active.value) }
+            .onSuccess { cfg -> _personaUi.value = PersonaUi(parsePersonas(cfg), activePersonaOf(cfg)) }
+            .onFailure { _personaUi.value = _personaUi.value.copy(loading = false, error = "Couldn't load personas") }
+    }
+}
+
+fun setPersona(name: String?) {  // null / "none" clears
+    val wire = name?.takeIf { it.isNotBlank() } ?: "none"
+    viewModelScope.launch {
+        runCatching { chat.slashExec(sessionId, "/personality $wire") }
+            .onSuccess { _personaUi.value = _personaUi.value.copy(active = name?.takeIf { it != "none" }) }
+    }
+}
+```
+
+### 3. `ui/chat/ChatScreen.kt` (modify) — overflow item + sheet
+- In the existing top-bar overflow `DropdownMenu` (the one with Copy/Share transcript), add a **"Persona"** `DropdownMenuItem` → `showPersonaSheet = true; transcriptMenu = false; vm.loadPersonas()`.
+- Host a `PersonaSheet` (a `ModalBottomSheet`, gated by `var showPersonaSheet`) that renders `vm.personaUi`:
+  - a "None (default)" row + one row per `Persona` (headline = name, supporting = description if non-blank), the active one visually marked (accent check / bold);
+  - loading → a spinner; error → the error text + a Retry (`vm.loadPersonas()`);
+  - on a row tap → `vm.setPersona(name)` (or `null` for None) + close the sheet.
+  Use `LocalProfileAccent` for the active highlight (per-tenant accent).
+
+### 4. `ui/chat/PersonaSheet.kt` (new) — the sheet composable (or inline in ChatScreen)
+A small `@Composable fun PersonaSheet(ui: PersonaUi, onPick: (String?) -> Unit, onRetry: () -> Unit, onDismiss: () -> Unit)`.
+
+## Data flow
+```
+overflow ⋮ → Persona → vm.loadPersonas() → ConfigRepository.get(activeProfile) → parsePersonas + activePersonaOf → PersonaUi
+PersonaSheet → pick name → vm.setPersona(name) → slashExec("/personality <name>") → active updated → sheet closes
+```
+
+## Error handling
+- Config fetch fails → error state + Retry; no crash.
+- No `agent.personalities` configured → empty list; the sheet shows only "None (default)" with an "Add personas in your gateway config" hint.
+- `slashExec` failure → active unchanged (the gateway rejects unknown names; only configured names are offered, so this is rare).
+
+## Testing
+- **`PersonaTest`** (pure): `parsePersonas` of a config with string-valued + object-valued personas → correct names/descriptions, sorted; missing `agent`/`personalities` → empty; `activePersonaOf` reads `display.personality`, maps blank/"none" → null.
+- **`ChatViewModelTest`** (extend, mock `ConfigRepository` + `ChatRepository`): `setPersona("witty")` calls `slashExec(sid, "/personality witty")`; `setPersona(null)` → `"/personality none"`; `loadPersonas()` populates `personaUi` from a stubbed config.
+- The sheet + overflow are Compose glue — verified on-device (best-effort).
+
+## On-device verification
+With a gateway that has ≥1 configured personality: chat overflow ⋮ → Persona → the sheet lists them + None, marking the active; tap one → applies (subsequent replies reflect it), sheet closes. With none configured → only "None (default)" + the hint.
+
+## Files
+| Action | Path |
+|--------|------|
+| New | `ui/chat/Persona.kt` (model + parsers) + `PersonaTest.kt` |
+| Modify | `ui/chat/ChatViewModel.kt` (ConfigRepository + personaUi/loadPersonas/setPersona) + `ChatViewModelTest.kt` |
+| New | `ui/chat/PersonaSheet.kt` |
+| Modify | `ui/chat/ChatScreen.kt` (overflow item + sheet host) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Quick-wins wave (client-only, no gateway change). Pick a gateway-configured personality and apply it to the current session — exposing an existing capability.

## What ships
- A **"Persona"** item in the chat overflow menu → a bottom sheet listing the profile's configured personalities (from `agent.personalities` in the config the app already fetches) + a "None (default)" row, marking the active one; tap to apply via the existing `slashExec("/personality <name>")`. Per-tenant for free (reads the session's active-profile config).
- Pure `parsePersonas`/`activePersonaOf`; `ChatViewModel` persona state with crash-safe load.

## Quality
- Subagent-driven: 3 TDD/code tasks + on-device smoke, per-task reviews, opus whole-branch review.
- The review caught and this PR fixes: (#1) `"default"` wasn't treated as a clear-sentinel → nothing highlighted on default; (#2) `slashExec` returns command errors in its output string, so a rejection was shown as success and a closed-on-tap sheet hid failures — now the apply detects a rejection, surfaces an error, sets active only on success, and the sheet stays open until you dismiss it. Re-reviewed → resolved.
- **Gates:** 309 unit tests pass; compile + assembleBeta green; gitleaks clean.
- On-device: best-effort (needs an open chat + configured personas; the emulator's session-create over loopback bounced to setup). Covered by `PersonaTest` + `ChatViewModelTest` + reviews; app launches clean with the wiring.

## Deferred
Persisting the choice as the profile default (`config.set key=personality` — a small RPC), persona create/edit (gateway-config-owned), and a non-chat persona surface.