### PR TITLE
feat: record-to-task (voice note → transcribe → new prefilled chat)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/app/src/main/java/com/hermes/client/data/audio/AudioDataUrl.kt
+++ b/app/src/main/java/com/hermes/client/data/audio/AudioDataUrl.kt
@@ -1,0 +1,5 @@
+package com.hermes.client.data.audio
+
+/** Build a base64 data URL the gateway's transcribe endpoint accepts: data:<mime>;base64,<b64>. */
+fun audioDataUrl(bytes: ByteArray, mime: String): String =
+    "data:$mime;base64," + java.util.Base64.getEncoder().encodeToString(bytes)

--- a/app/src/main/java/com/hermes/client/data/audio/AudioRecorder.kt
+++ b/app/src/main/java/com/hermes/client/data/audio/AudioRecorder.kt
@@ -1,0 +1,69 @@
+package com.hermes.client.data.audio
+
+import android.content.Context
+import android.media.MediaRecorder
+import android.os.Build
+import java.io.File
+
+/** A captured voice note. */
+data class Recording(val bytes: ByteArray, val mime: String) {
+    override fun equals(other: Any?) =
+        other is Recording && mime == other.mime && bytes.contentEquals(other.bytes)
+    override fun hashCode() = 31 * bytes.contentHashCode() + mime.hashCode()
+}
+
+/** Records a single voice note. Interface so RecordTaskViewModel is testable with a fake. */
+interface AudioRecorder {
+    fun start()
+    fun stop(): Recording?
+    fun cancel()
+}
+
+/** MediaRecorder-backed recorder writing audio/mp4 (AAC) to an app-cache temp file. */
+class MediaAudioRecorder(private val context: Context) : AudioRecorder {
+    private var recorder: MediaRecorder? = null
+    private var outputFile: File? = null
+
+    override fun start() {
+        if (recorder != null) return
+        val file = File.createTempFile("rec_", ".m4a", context.cacheDir)
+        val rec = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) MediaRecorder(context)
+                  else @Suppress("DEPRECATION") MediaRecorder()
+        rec.setAudioSource(MediaRecorder.AudioSource.MIC)
+        rec.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+        rec.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+        rec.setAudioEncodingBitRate(96_000)
+        rec.setAudioSamplingRate(44_100)
+        rec.setOutputFile(file.absolutePath)
+        rec.prepare()
+        rec.start()
+        recorder = rec
+        outputFile = file
+    }
+
+    override fun stop(): Recording? {
+        val rec = recorder ?: return null
+        val file = outputFile
+        recorder = null
+        outputFile = null
+        val stopped = runCatching { rec.stop() }.isSuccess
+        runCatching { rec.release() }
+        if (!stopped || file == null || !file.exists() || file.length() == 0L) {
+            file?.delete()
+            return null
+        }
+        val bytes = file.readBytes()
+        file.delete()
+        return Recording(bytes, "audio/mp4")
+    }
+
+    override fun cancel() {
+        val rec = recorder ?: return
+        val file = outputFile
+        recorder = null
+        outputFile = null
+        runCatching { rec.stop() }
+        runCatching { rec.release() }
+        file?.delete()
+    }
+}

--- a/app/src/main/java/com/hermes/client/data/audio/AudioRecorder.kt
+++ b/app/src/main/java/com/hermes/client/data/audio/AudioRecorder.kt
@@ -35,8 +35,14 @@ class MediaAudioRecorder(private val context: Context) : AudioRecorder {
         rec.setAudioEncodingBitRate(96_000)
         rec.setAudioSamplingRate(44_100)
         rec.setOutputFile(file.absolutePath)
-        rec.prepare()
-        rec.start()
+        try {
+            rec.prepare()
+            rec.start()
+        } catch (e: Exception) {
+            runCatching { rec.release() }
+            file.delete()
+            throw e
+        }
         recorder = rec
         outputFile = file
     }
@@ -52,9 +58,9 @@ class MediaAudioRecorder(private val context: Context) : AudioRecorder {
             file?.delete()
             return null
         }
-        val bytes = file.readBytes()
+        val bytes = runCatching { file.readBytes() }.getOrNull()
         file.delete()
-        return Recording(bytes, "audio/mp4")
+        return bytes?.let { Recording(it, "audio/mp4") }
     }
 
     override fun cancel() {

--- a/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
@@ -4,6 +4,7 @@ import com.hermes.client.data.auth.GatewayConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -304,7 +305,10 @@ class HermesRestApi(
         okHttp.newCall(builder("/api/audio/transcribe").post(payload).build()).execute().use { resp ->
             val body = resp.body?.string().orEmpty()
             if (!resp.isSuccessful) throw HermesApiException(resp.code, "transcription failed")
-            json.decodeFromString<JsonObject>(body)["transcript"]?.jsonPrimitive?.content?.trim() ?: ""
+            // Treat an explicit JSON null (out-of-contract, but guards against a phantom "null"
+            // transcript) the same as a missing field → "".
+            val el = json.decodeFromString<JsonObject>(body)["transcript"]
+            if (el == null || el is JsonNull) "" else el.jsonPrimitive.content.trim()
         }
     }
 

--- a/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
+++ b/app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt
@@ -292,6 +292,22 @@ class HermesRestApi(
         }
     }
 
+    /**
+     * Transcribe a recorded voice note. [dataUrl] is a base64 data URL (data:<mime>;base64,<b64>)
+     * the gateway's POST /api/audio/transcribe accepts; returns the trimmed transcript ("" if the
+     * STT backend returned nothing). Throws HermesApiException on a non-2xx (e.g. no STT configured).
+     */
+    suspend fun transcribe(dataUrl: String, mimeType: String): String = withContext(Dispatchers.IO) {
+        val obj = buildJsonObject { put("data_url", dataUrl); put("mime_type", mimeType) }
+        val payload = json.encodeToString(JsonObject.serializer(), obj)
+            .toRequestBody("application/json".toMediaType())
+        okHttp.newCall(builder("/api/audio/transcribe").post(payload).build()).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw HermesApiException(resp.code, "transcription failed")
+            json.decodeFromString<JsonObject>(body)["transcript"]?.jsonPrimitive?.content?.trim() ?: ""
+        }
+    }
+
     suspend fun skills(): List<SkillDto> = get("/api/skills")
 
     suspend fun toggleSkill(name: String, enabled: Boolean) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/hermes/client/di/AppModule.kt
+++ b/app/src/main/java/com/hermes/client/di/AppModule.kt
@@ -224,4 +224,9 @@ object AppModule {
     @Singleton
     fun providePromptStore(@ApplicationContext context: Context): com.hermes.client.data.repository.PromptStore =
         com.hermes.client.data.repository.PromptStore(context)
+
+    @Provides
+    @Singleton
+    fun provideAudioRecorder(@ApplicationContext context: Context): com.hermes.client.data.audio.AudioRecorder =
+        com.hermes.client.data.audio.MediaAudioRecorder(context)
 }

--- a/app/src/main/java/com/hermes/client/ui/record/RecordTaskSheet.kt
+++ b/app/src/main/java/com/hermes/client/ui/record/RecordTaskSheet.kt
@@ -1,0 +1,91 @@
+package com.hermes.client.ui.record
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.hermes.client.ui.theme.LocalProfileAccent
+
+/**
+ * Bottom sheet driving the record -> transcribe -> new-chat flow. The host (SessionsScreen) owns
+ * showing/hiding this sheet and starts recording when it opens; this composable only renders
+ * [RecordUi] and forwards taps.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecordTaskSheet(
+    ui: RecordUi,
+    onStop: () -> Unit,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val accent = LocalProfileAccent.current.accent
+    val sheetState = rememberModalBottomSheetState()
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            val error = ui.error
+            when {
+                error != null -> {
+                    Text(
+                        error,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(bottom = 16.dp),
+                    )
+                    Button(onClick = onRetry, modifier = Modifier.padding(bottom = 8.dp)) {
+                        Text("Try again")
+                    }
+                    TextButton(onClick = onDismiss) { Text("Close") }
+                }
+                ui.phase == RecordPhase.RECORDING -> {
+                    Box(
+                        modifier = Modifier
+                            .size(72.dp)
+                            .padding(bottom = 16.dp)
+                            .background(accent, CircleShape)
+                            .semantics { contentDescription = "Recording in progress" },
+                    )
+                    Text("Recording…", modifier = Modifier.padding(bottom = 16.dp))
+                    Button(onClick = onStop, modifier = Modifier.padding(bottom = 8.dp)) {
+                        Text("Stop")
+                    }
+                    TextButton(onClick = onCancel) { Text("Cancel") }
+                }
+                ui.phase == RecordPhase.TRANSCRIBING -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .padding(bottom = 16.dp)
+                            .semantics { contentDescription = "Transcribing recording" },
+                    )
+                    Text("Transcribing…")
+                }
+                else -> {
+                    Text("Getting ready…")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/record/RecordTaskViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/record/RecordTaskViewModel.kt
@@ -1,0 +1,131 @@
+package com.hermes.client.ui.record
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.audio.AudioRecorder
+import com.hermes.client.data.audio.audioDataUrl
+import com.hermes.client.data.network.HermesRestApi
+import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.share.PendingShare
+import com.hermes.client.share.PendingShareStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+enum class RecordPhase { IDLE, RECORDING, TRANSCRIBING }
+
+data class RecordUi(val phase: RecordPhase = RecordPhase.IDLE, val error: String? = null)
+
+/**
+ * Orchestrates the record -> transcribe -> new prefilled chat flow: capture a voice note,
+ * send it to the gateway's transcribe endpoint, create a fresh session for the active profile,
+ * stash the transcript as a [PendingShare] keyed by the new session id, and signal navigation
+ * to it via [navigateTo].
+ *
+ * The primary constructor takes function-typed collaborators (rather than the concrete
+ * [HermesRestApi]/[ChatRepository] types) so this class is unit-testable with fakes; the
+ * secondary `@Inject` constructor adapts the real dependencies to those function shapes.
+ */
+@HiltViewModel
+class RecordTaskViewModel(
+    private val recorder: AudioRecorder,
+    private val transcribe: suspend (dataUrl: String, mime: String) -> String,
+    private val createSession: suspend (profile: String?) -> String,
+    private val activeProfile: StateFlow<String?>,
+    private val refreshProfiles: suspend () -> Unit,
+    private val pendingShareStore: PendingShareStore,
+    // Where the blocking MediaRecorder start()/stop() calls run. Defaults to the real IO
+    // dispatcher in production; tests override it with their TestDispatcher so
+    // advanceUntilIdle() can deterministically drive the recorder calls (Dispatchers.IO is a
+    // real thread pool the test scheduler has no visibility into).
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ViewModel() {
+
+    @Inject constructor(
+        recorder: AudioRecorder,
+        api: HermesRestApi,
+        chat: ChatRepository,
+        profileManager: ProfileManager,
+        pendingShareStore: PendingShareStore,
+    ) : this(
+        recorder = recorder,
+        transcribe = { url, mime -> api.transcribe(url, mime) },
+        createSession = { profile -> chat.connect(); chat.createSession(profile) },
+        activeProfile = profileManager.active,
+        refreshProfiles = { profileManager.refresh() },
+        pendingShareStore = pendingShareStore,
+    )
+
+    private val _ui = MutableStateFlow(RecordUi())
+    val ui: StateFlow<RecordUi> = _ui.asStateFlow()
+
+    private val _navigateTo = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val navigateTo: SharedFlow<String> = _navigateTo.asSharedFlow()
+
+    // Tracks the most recently launched pipeline coroutine so cancel() can abort it before its
+    // (async, IO-dispatched) work has a chance to write a stale phase over IDLE.
+    private var activeJob: Job? = null
+
+    fun startRecording() {
+        if (_ui.value.phase != RecordPhase.IDLE) return
+        activeJob = viewModelScope.launch {
+            try {
+                withContext(ioDispatcher) { recorder.start() }
+                _ui.value = RecordUi(RecordPhase.RECORDING)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _ui.value = RecordUi(RecordPhase.IDLE, error = "Couldn't start recording")
+            }
+        }
+    }
+
+    fun stopAndTranscribe() {
+        activeJob = viewModelScope.launch {
+            try {
+                val clip = withContext(ioDispatcher) { recorder.stop() }
+                if (clip == null) {
+                    _ui.value = RecordUi(RecordPhase.IDLE, error = "Nothing recorded")
+                    return@launch
+                }
+                _ui.value = RecordUi(RecordPhase.TRANSCRIBING)
+                val text = transcribe(audioDataUrl(clip.bytes, clip.mime), clip.mime).trim()
+                if (text.isBlank()) {
+                    _ui.value = RecordUi(RecordPhase.IDLE, error = "Couldn't transcribe that")
+                    return@launch
+                }
+                refreshProfiles()
+                val id = createSession(activeProfile.value)
+                pendingShareStore.put(id, PendingShare(text = text))
+                _navigateTo.emit(id)
+                _ui.value = RecordUi(RecordPhase.IDLE)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _ui.value = RecordUi(RecordPhase.IDLE, error = "Transcription failed")
+            }
+        }
+    }
+
+    fun cancel() {
+        activeJob?.cancel()
+        recorder.cancel()
+        _ui.value = RecordUi(RecordPhase.IDLE)
+    }
+
+    fun dismissError() {
+        if (_ui.value.error != null) _ui.value = _ui.value.copy(error = null)
+    }
+}

--- a/app/src/main/java/com/hermes/client/ui/record/RecordTaskViewModel.kt
+++ b/app/src/main/java/com/hermes/client/ui/record/RecordTaskViewModel.kt
@@ -78,30 +78,49 @@ class RecordTaskViewModel(
     // (async, IO-dispatched) work has a chance to write a stale phase over IDLE.
     private var activeJob: Job? = null
 
+    // Tracks the in-flight recorder.start() coroutine so stopAndTranscribe() can wait for it to
+    // finish before calling recorder.stop() - otherwise a stop() that lands during the start
+    // window could run before start() ever executed, stranding the recorder state.
+    private var startJob: Job? = null
+
     fun startRecording() {
         if (_ui.value.phase != RecordPhase.IDLE) return
-        activeJob = viewModelScope.launch {
+        // Set RECORDING synchronously (not after the IO hop) so a stop tap that races the start
+        // call sees the correct phase immediately instead of IDLE.
+        _ui.value = RecordUi(RecordPhase.RECORDING)
+        startJob = viewModelScope.launch {
             try {
                 withContext(ioDispatcher) { recorder.start() }
-                _ui.value = RecordUi(RecordPhase.RECORDING)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 _ui.value = RecordUi(RecordPhase.IDLE, error = "Couldn't start recording")
             }
         }
+        activeJob = startJob
     }
 
     fun stopAndTranscribe() {
+        // Guards both a double stop-tap (second call sees TRANSCRIBING/IDLE, not RECORDING) and
+        // a stop with nothing recording. TRANSCRIBING is set synchronously below so a
+        // back-to-back second call is rejected here even before the first call's coroutine runs.
+        if (_ui.value.phase != RecordPhase.RECORDING) return
+        _ui.value = RecordUi(RecordPhase.TRANSCRIBING)
         activeJob = viewModelScope.launch {
             try {
-                val clip = withContext(ioDispatcher) { recorder.stop() }
-                if (clip == null) {
+                // Never let stop() precede a still-running start() - wait for it first.
+                startJob?.join()
+                // Recorder stop + base64 encoding are both blocking/CPU work; keep them off Main.
+                val encoded = withContext(ioDispatcher) {
+                    val clip = recorder.stop()
+                    clip?.let { audioDataUrl(it.bytes, it.mime) to it.mime }
+                }
+                if (encoded == null) {
                     _ui.value = RecordUi(RecordPhase.IDLE, error = "Nothing recorded")
                     return@launch
                 }
-                _ui.value = RecordUi(RecordPhase.TRANSCRIBING)
-                val text = transcribe(audioDataUrl(clip.bytes, clip.mime), clip.mime).trim()
+                val (dataUrl, mime) = encoded
+                val text = transcribe(dataUrl, mime).trim()
                 if (text.isBlank()) {
                     _ui.value = RecordUi(RecordPhase.IDLE, error = "Couldn't transcribe that")
                     return@launch

--- a/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
@@ -1,5 +1,10 @@
 package com.hermes.client.ui.sessions
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,6 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Archive
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Mic
 import androidx.compose.material.icons.rounded.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
@@ -49,13 +55,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
+import androidx.core.content.ContextCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hermes.client.domain.Session
+import com.hermes.client.ui.record.RecordPhase
+import com.hermes.client.ui.record.RecordTaskSheet
+import com.hermes.client.ui.record.RecordTaskViewModel
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -76,10 +88,44 @@ fun SessionsScreen(
     val viewMode by vm.viewMode.collectAsStateWithLifecycle()
     val projectsState by vm.projectsState.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     // I1: route to Setup when a 401 is received
     LaunchedEffect(state.unauthorized) {
         if (state.unauthorized) onUnauthorized()
+    }
+
+    // Record-a-task: mic entry point on the home session list. The sheet's own show/hide state
+    // lives here (not in the VM) so it survives recomposition without coupling the VM to
+    // navigation visibility; recordVm drives the actual record/transcribe pipeline.
+    val recordVm: RecordTaskViewModel = hiltViewModel()
+    var showRecord by rememberSaveable { mutableStateOf(false) }
+    val recordUi by recordVm.ui.collectAsStateWithLifecycle()
+    val micPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            showRecord = true
+            recordVm.startRecording()
+        } else {
+            Toast.makeText(context, "Microphone needed to record a task", Toast.LENGTH_SHORT).show()
+        }
+    }
+    fun onMicTap() {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            showRecord = true
+            recordVm.startRecording()
+        } else {
+            micPermission.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+    LaunchedEffect(Unit) {
+        recordVm.navigateTo.collect { id ->
+            showRecord = false
+            onOpen(id)
+        }
     }
 
     // Re-fetch on every resume — notably when returning from a chat. The "sessions" nav entry
@@ -96,6 +142,9 @@ fun SessionsScreen(
                 com.hermes.client.ui.components.HermesTopBar(
                     title = "Chats",
                     actions = {
+                        IconButton(onClick = { onMicTap() }) {
+                            Icon(Icons.Rounded.Mic, contentDescription = "Record a task")
+                        }
                         TextButton(
                             onClick = onOpenArchived,
                             colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
@@ -287,6 +336,20 @@ fun SessionsScreen(
                 }
             }
         }
+    }
+
+    if (showRecord) {
+        RecordTaskSheet(
+            ui = recordUi,
+            onStop = { recordVm.stopAndTranscribe() },
+            onCancel = { recordVm.cancel(); showRecord = false },
+            onRetry = { recordVm.dismissError(); recordVm.startRecording() },
+            onDismiss = {
+                if (recordUi.phase == RecordPhase.RECORDING) recordVm.cancel()
+                recordVm.dismissError()
+                showRecord = false
+            },
+        )
     }
 }
 

--- a/app/src/test/java/com/hermes/client/data/audio/AudioDataUrlTest.kt
+++ b/app/src/test/java/com/hermes/client/data/audio/AudioDataUrlTest.kt
@@ -1,0 +1,19 @@
+package com.hermes.client.data.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioDataUrlTest {
+    @Test fun builds_base64_data_url_with_mime_prefix() {
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val url = audioDataUrl(bytes, "audio/mp4")
+        assertTrue(url.startsWith("data:audio/mp4;base64,"))
+        val b64 = url.removePrefix("data:audio/mp4;base64,")
+        assertEquals(bytes.toList(), java.util.Base64.getDecoder().decode(b64).toList())
+    }
+
+    @Test fun empty_bytes_still_valid() {
+        assertEquals("data:audio/mp4;base64,", audioDataUrl(ByteArray(0), "audio/mp4"))
+    }
+}

--- a/app/src/test/java/com/hermes/client/data/network/HermesRestApiTranscribeTest.kt
+++ b/app/src/test/java/com/hermes/client/data/network/HermesRestApiTranscribeTest.kt
@@ -1,0 +1,53 @@
+package com.hermes.client.data.network
+
+import com.hermes.client.data.auth.GatewayConfig
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit4.MockWebServerRule
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class HermesRestApiTranscribeTest {
+    @get:Rule val serverRule = MockWebServerRule()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun api(server: MockWebServer) = HermesRestApi(OkHttpClient(), json) {
+        GatewayConfig(baseUrl = server.url("/").toString().trimEnd('/'), token = "secret")
+    }
+
+    @Test fun transcribe_returns_trimmed_transcript_and_posts_data_url() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body(
+            """{"ok":true,"transcript":"  book the flight  ","provider":"local"}"""
+        ).build())
+
+        val text = api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4")
+        assertEquals("book the flight", text)
+
+        val recorded = serverRule.server.takeRequest()
+        assertEquals("/api/audio/transcribe", recorded.target)
+        assertEquals("secret", recorded.headers["X-Hermes-Session-Token"])
+        val sent = recorded.body?.utf8().orEmpty()
+        assertTrue(sent.contains("\"data_url\":\"data:audio/mp4;base64,AAA\""))
+        assertTrue(sent.contains("\"mime_type\":\"audio/mp4\""))
+    }
+
+    @Test fun transcribe_blank_transcript_returns_empty() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body("""{"ok":true}""").build())
+        assertEquals("", api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4"))
+    }
+
+    @Test fun transcribe_error_throws() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(400).body("""{"detail":"no stt"}""").build())
+        try {
+            api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4")
+            org.junit.Assert.fail("expected HermesApiException")
+        } catch (e: HermesApiException) {
+            assertEquals(400, e.code)
+        }
+    }
+}

--- a/app/src/test/java/com/hermes/client/data/network/HermesRestApiTranscribeTest.kt
+++ b/app/src/test/java/com/hermes/client/data/network/HermesRestApiTranscribeTest.kt
@@ -41,6 +41,13 @@ class HermesRestApiTranscribeTest {
         assertEquals("", api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4"))
     }
 
+    @Test fun transcribe_explicit_null_transcript_returns_empty() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body(
+            """{"ok":true,"transcript":null}"""
+        ).build())
+        assertEquals("", api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4"))
+    }
+
     @Test fun transcribe_error_throws() = runTest {
         serverRule.server.enqueue(MockResponse.Builder().code(400).body("""{"detail":"no stt"}""").build())
         try {

--- a/app/src/test/java/com/hermes/client/ui/record/RecordTaskViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/record/RecordTaskViewModelTest.kt
@@ -1,0 +1,104 @@
+package com.hermes.client.ui.record
+
+import com.hermes.client.data.audio.AudioRecorder
+import com.hermes.client.data.audio.Recording
+import com.hermes.client.share.PendingShare
+import com.hermes.client.share.PendingShareStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecordTaskViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private class FakeRecorder(var result: Recording?) : AudioRecorder {
+        var started = false; var cancelled = false
+        override fun start() { started = true }
+        override fun stop() = result
+        override fun cancel() { cancelled = true }
+    }
+
+    private fun vm(
+        recorder: AudioRecorder,
+        transcribe: suspend (String, String) -> String = { _, _ -> "hi" },
+        createSession: suspend (String?) -> String = { "sess-1" },
+        store: PendingShareStore = PendingShareStore(),
+        refresh: suspend () -> Unit = {},
+    ) = RecordTaskViewModel(
+        recorder = recorder,
+        transcribe = transcribe,
+        createSession = createSession,
+        activeProfile = MutableStateFlow<String?>("personal"),
+        refreshProfiles = refresh,
+        pendingShareStore = store,
+        // Route the recorder's blocking-call dispatch through the same TestDispatcher as this
+        // test's scheduler, so advanceUntilIdle() deterministically drives it (Dispatchers.IO,
+        // the production default, is a real thread pool the test scheduler can't see).
+        ioDispatcher = dispatcher,
+    )
+
+    @Test fun happy_path_transcribes_creates_session_and_stashes_prefill() = runTest {
+        val store = PendingShareStore()
+        val nav = mutableListOf<String>()
+        val model = vm(FakeRecorder(Recording(byteArrayOf(1,2,3), "audio/mp4")),
+            transcribe = { _, _ -> "  book the flight  " }, createSession = { "sess-1" }, store = store)
+        val job = CoroutineScope(dispatcher).launch { model.navigateTo.collect { nav.add(it) } }
+        model.startRecording(); advanceUntilIdle()
+        assertEquals(RecordPhase.RECORDING, model.ui.value.phase)
+        model.stopAndTranscribe(); advanceUntilIdle()
+        assertEquals(listOf("sess-1"), nav)
+        assertEquals("book the flight", store.take("sess-1")?.text)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+        assertNull(model.ui.value.error)
+        job.cancel()
+    }
+
+    @Test fun nothing_recorded_sets_error_and_skips_transcribe() = runTest {
+        var called = false
+        val model = vm(FakeRecorder(null), transcribe = { _, _ -> called = true; "x" })
+        model.startRecording(); model.stopAndTranscribe(); advanceUntilIdle()
+        assertEquals(false, called)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+        org.junit.Assert.assertNotNull(model.ui.value.error)
+    }
+
+    @Test fun blank_transcript_sets_error_and_creates_no_session() = runTest {
+        var created = false
+        val model = vm(FakeRecorder(Recording(byteArrayOf(1), "audio/mp4")),
+            transcribe = { _, _ -> "   " }, createSession = { created = true; "s" })
+        model.startRecording(); model.stopAndTranscribe(); advanceUntilIdle()
+        assertEquals(false, created)
+        org.junit.Assert.assertNotNull(model.ui.value.error)
+    }
+
+    @Test fun transcribe_failure_sets_error() = runTest {
+        val model = vm(FakeRecorder(Recording(byteArrayOf(1), "audio/mp4")),
+            transcribe = { _, _ -> throw RuntimeException("boom") })
+        model.startRecording(); model.stopAndTranscribe(); advanceUntilIdle()
+        org.junit.Assert.assertNotNull(model.ui.value.error)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+    }
+
+    @Test fun cancel_stops_recorder_and_returns_idle() = runTest {
+        val rec = FakeRecorder(Recording(byteArrayOf(1), "audio/mp4"))
+        val model = vm(rec)
+        model.startRecording(); model.cancel(); advanceUntilIdle()
+        assertEquals(true, rec.cancelled)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+    }
+}

--- a/app/src/test/java/com/hermes/client/ui/record/RecordTaskViewModelTest.kt
+++ b/app/src/test/java/com/hermes/client/ui/record/RecordTaskViewModelTest.kt
@@ -101,4 +101,26 @@ class RecordTaskViewModelTest {
         assertEquals(true, rec.cancelled)
         assertEquals(RecordPhase.IDLE, model.ui.value.phase)
     }
+
+    @Test fun double_stop_does_not_clobber_transcribing() = runTest {
+        val nav = mutableListOf<String>()
+        var sessionCount = 0
+        val model = vm(
+            FakeRecorder(Recording(byteArrayOf(1, 2, 3), "audio/mp4")),
+            transcribe = { _, _ -> "book the flight" },
+            createSession = { sessionCount++; "sess-1" },
+        )
+        val job = CoroutineScope(dispatcher).launch { model.navigateTo.collect { nav.add(it) } }
+        model.startRecording()
+        // Two stop taps back-to-back, before the scheduler runs either coroutine body: the
+        // second call must be rejected by the synchronous TRANSCRIBING guard, not race the first.
+        model.stopAndTranscribe()
+        model.stopAndTranscribe()
+        advanceUntilIdle()
+        assertEquals(1, sessionCount)
+        assertEquals(listOf("sess-1"), nav)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+        assertNull(model.ui.value.error)
+        job.cancel()
+    }
 }

--- a/docs/superpowers/plans/2026-07-17-record-to-task.md
+++ b/docs/superpowers/plans/2026-07-17-record-to-task.md
@@ -1,0 +1,620 @@
+# Record-to-Task (v2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox syntax.
+
+**Goal:** Record a spoken task → transcribe it via the gateway → open a new chat prefilled with the transcript.
+
+**Architecture:** A framework `MediaRecorder` (behind an `AudioRecorder` interface) captures `audio/mp4`; a pure `audioDataUrl` encodes it; `HermesRestApi.transcribe` POSTs to the existing `/api/audio/transcribe`; `RecordTaskViewModel` orchestrates record→transcribe→create-session→prefill; a `RecordTaskSheet` on the home session list drives it. Prefill reuses the existing `PendingShareStore` share rail.
+
+**Tech Stack:** Kotlin, Compose/Material3, Hilt, OkHttp (hand-rolled), kotlinx.serialization, `MediaRecorder`, `java.util.Base64`.
+
+## Global Constraints
+- Client-only; no gateway change. Gateway must have an STT backend — the app surfaces its absence as an error, never crashes.
+- Kotlin/Compose/Material3/Hilt. Per-tenant accent (`LocalProfileAccent`) for chrome/active affordances; semantic `colorScheme.error` for error states — never the accent for errors.
+- No AI/assistant attribution in commits, files, or PRs.
+- Build env: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`. Gates per task: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`.
+- Branch `feature/record-to-task` (off `dev`). gitleaks before push; PR into `dev`.
+- `runCatching` blocks must rethrow `kotlinx.coroutines.CancellationException` (repo convention — see `SessionsViewModel.createSession`).
+
+---
+
+### Task 1: `HermesRestApi.transcribe` + MockWebServer test
+
+**Files:**
+- Modify: `app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt`
+- Test: `app/src/test/java/com/hermes/client/data/network/HermesRestApiTranscribeTest.kt`
+
+**Interfaces:**
+- Produces: `suspend fun HermesRestApi.transcribe(dataUrl: String, mimeType: String): String` — returns the trimmed transcript (may be `""`); throws `HermesApiException(code, …)` on a non-2xx response.
+
+- [ ] **Step 1: Write the failing test.** Create `HermesRestApiTranscribeTest.kt` (mirror `HermesRestApiTest.kt`'s `MockWebServerRule` + `api(server)` helper):
+```kotlin
+package com.hermes.client.data.network
+
+import com.hermes.client.data.auth.GatewayConfig
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.junit4.MockWebServerRule
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class HermesRestApiTranscribeTest {
+    @get:Rule val serverRule = MockWebServerRule()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun api(server: MockWebServer) = HermesRestApi(OkHttpClient(), json) {
+        GatewayConfig(baseUrl = server.url("/").toString().trimEnd('/'), token = "secret")
+    }
+
+    @Test fun transcribe_returns_trimmed_transcript_and_posts_data_url() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body(
+            """{"ok":true,"transcript":"  book the flight  ","provider":"local"}"""
+        ).build())
+
+        val text = api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4")
+        assertEquals("book the flight", text)
+
+        val recorded = serverRule.server.takeRequest()
+        assertEquals("/api/audio/transcribe", recorded.target)
+        assertEquals("secret", recorded.headers["X-Hermes-Session-Token"])
+        val sent = recorded.body?.utf8().orEmpty()
+        assertTrue(sent.contains("\"data_url\":\"data:audio/mp4;base64,AAA\""))
+        assertTrue(sent.contains("\"mime_type\":\"audio/mp4\""))
+    }
+
+    @Test fun transcribe_blank_transcript_returns_empty() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(200).body("""{"ok":true}""").build())
+        assertEquals("", api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4"))
+    }
+
+    @Test fun transcribe_error_throws() = runTest {
+        serverRule.server.enqueue(MockResponse.Builder().code(400).body("""{"detail":"no stt"}""").build())
+        try {
+            api(serverRule.server).transcribe("data:audio/mp4;base64,AAA", "audio/mp4")
+            org.junit.Assert.fail("expected HermesApiException")
+        } catch (e: HermesApiException) {
+            assertEquals(400, e.code)
+        }
+    }
+}
+```
+(If `recorded.body?.utf8()` differs from the repo's recorded-body accessor, match however `HermesRestApiTest` reads a POST body; the assertions are the contract. If no POST-body test exists there, `recorded.body?.utf8()` is correct for `mockwebserver3`.)
+
+- [ ] **Step 2: Run → FAIL** (unresolved `transcribe`):
+`./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.network.HermesRestApiTranscribeTest"`
+
+- [ ] **Step 3: Implement.** In `HermesRestApi.kt`, add (next to `revealEnv`):
+```kotlin
+    /**
+     * Transcribe a recorded voice note. [dataUrl] is a base64 data URL (data:<mime>;base64,<b64>)
+     * the gateway's POST /api/audio/transcribe accepts; returns the trimmed transcript ("" if the
+     * STT backend returned nothing). Throws HermesApiException on a non-2xx (e.g. no STT configured).
+     */
+    suspend fun transcribe(dataUrl: String, mimeType: String): String = withContext(Dispatchers.IO) {
+        val obj = buildJsonObject { put("data_url", dataUrl); put("mime_type", mimeType) }
+        val payload = json.encodeToString(JsonObject.serializer(), obj)
+            .toRequestBody("application/json".toMediaType())
+        okHttp.newCall(builder("/api/audio/transcribe").post(payload).build()).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) throw HermesApiException(resp.code, "transcription failed")
+            json.decodeFromString<JsonObject>(body)["transcript"]?.jsonPrimitive?.content?.trim() ?: ""
+        }
+    }
+```
+(If `encodeToString(JsonObject.serializer(), obj)` isn't the form used nearby, match `revealEnv`'s exact encode call. `JsonObject.serializer()` + `jsonPrimitive` are already imported.)
+
+- [ ] **Step 4: Run → PASS** (all 3 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/data/network/HermesRestApi.kt \
+        app/src/test/java/com/hermes/client/data/network/HermesRestApiTranscribeTest.kt
+git commit -m "feat: add transcribe() REST call for /api/audio/transcribe"
+```
+
+---
+
+### Task 2: `audioDataUrl` pure encoder + RECORD_AUDIO manifest permission
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/data/audio/AudioDataUrl.kt`
+- Test: `app/src/test/java/com/hermes/client/data/audio/AudioDataUrlTest.kt`
+- Modify: `app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Produces: `fun audioDataUrl(bytes: ByteArray, mime: String): String`.
+
+- [ ] **Step 1: Write the failing test.** Create `AudioDataUrlTest.kt`:
+```kotlin
+package com.hermes.client.data.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioDataUrlTest {
+    @Test fun builds_base64_data_url_with_mime_prefix() {
+        val bytes = byteArrayOf(1, 2, 3, 4)
+        val url = audioDataUrl(bytes, "audio/mp4")
+        assertTrue(url.startsWith("data:audio/mp4;base64,"))
+        val b64 = url.removePrefix("data:audio/mp4;base64,")
+        assertEquals(bytes.toList(), java.util.Base64.getDecoder().decode(b64).toList())
+    }
+
+    @Test fun empty_bytes_still_valid() {
+        assertEquals("data:audio/mp4;base64,", audioDataUrl(ByteArray(0), "audio/mp4"))
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL:** `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.data.audio.AudioDataUrlTest"`
+
+- [ ] **Step 3: Implement.** Create `AudioDataUrl.kt`:
+```kotlin
+package com.hermes.client.data.audio
+
+/** Build a base64 data URL the gateway's transcribe endpoint accepts: data:<mime>;base64,<b64>. */
+fun audioDataUrl(bytes: ByteArray, mime: String): String =
+    "data:$mime;base64," + java.util.Base64.getEncoder().encodeToString(bytes)
+```
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Add the permission.** In `AndroidManifest.xml`, add alongside the existing `<uses-permission>` lines:
+```xml
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+```
+
+- [ ] **Step 6: Compile check** (manifest merges): `./gradlew :app:compileDebugKotlin`
+
+- [ ] **Step 7: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/data/audio/AudioDataUrl.kt \
+        app/src/test/java/com/hermes/client/data/audio/AudioDataUrlTest.kt \
+        app/src/main/AndroidManifest.xml
+git commit -m "feat: audio data-url encoder + RECORD_AUDIO permission"
+```
+
+---
+
+### Task 3: `AudioRecorder` interface + `MediaAudioRecorder` + Hilt provider
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/data/audio/AudioRecorder.kt`
+- Modify: `app/src/main/java/com/hermes/client/di/AppModule.kt`
+
+**Interfaces:**
+- Produces: `interface AudioRecorder { fun start(); fun stop(): Recording?; fun cancel() }` and `data class Recording(val bytes: ByteArray, val mime: String)`.
+- Consumes: nothing from prior tasks.
+
+No unit test — `MediaRecorder` is device-bound (covered on-device). This task's gate is compile + the ViewModel test in Task 4 exercising a fake `AudioRecorder`.
+
+- [ ] **Step 1: Implement.** Create `AudioRecorder.kt`:
+```kotlin
+package com.hermes.client.data.audio
+
+import android.content.Context
+import android.media.MediaRecorder
+import android.os.Build
+import java.io.File
+
+/** A captured voice note. */
+data class Recording(val bytes: ByteArray, val mime: String) {
+    override fun equals(other: Any?) =
+        other is Recording && mime == other.mime && bytes.contentEquals(other.bytes)
+    override fun hashCode() = 31 * bytes.contentHashCode() + mime.hashCode()
+}
+
+/** Records a single voice note. Interface so RecordTaskViewModel is testable with a fake. */
+interface AudioRecorder {
+    fun start()
+    fun stop(): Recording?
+    fun cancel()
+}
+
+/** MediaRecorder-backed recorder writing audio/mp4 (AAC) to an app-cache temp file. */
+class MediaAudioRecorder(private val context: Context) : AudioRecorder {
+    private var recorder: MediaRecorder? = null
+    private var outputFile: File? = null
+
+    override fun start() {
+        if (recorder != null) return
+        val file = File.createTempFile("rec_", ".m4a", context.cacheDir)
+        val rec = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) MediaRecorder(context)
+                  else @Suppress("DEPRECATION") MediaRecorder()
+        rec.setAudioSource(MediaRecorder.AudioSource.MIC)
+        rec.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+        rec.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+        rec.setAudioEncodingBitRate(96_000)
+        rec.setAudioSamplingRate(44_100)
+        rec.setOutputFile(file.absolutePath)
+        rec.prepare()
+        rec.start()
+        recorder = rec
+        outputFile = file
+    }
+
+    override fun stop(): Recording? {
+        val rec = recorder ?: return null
+        val file = outputFile
+        recorder = null
+        outputFile = null
+        val stopped = runCatching { rec.stop() }.isSuccess
+        runCatching { rec.release() }
+        if (!stopped || file == null || !file.exists() || file.length() == 0L) {
+            file?.delete()
+            return null
+        }
+        val bytes = file.readBytes()
+        file.delete()
+        return Recording(bytes, "audio/mp4")
+    }
+
+    override fun cancel() {
+        val rec = recorder ?: return
+        val file = outputFile
+        recorder = null
+        outputFile = null
+        runCatching { rec.stop() }
+        runCatching { rec.release() }
+        file?.delete()
+    }
+}
+```
+
+- [ ] **Step 2: Provide via Hilt.** In `AppModule.kt`, add a provider (match the module's existing `@Provides`/`@Singleton` + `@ApplicationContext` style):
+```kotlin
+    @Provides
+    @Singleton
+    fun provideAudioRecorder(
+        @dagger.hilt.android.qualifiers.ApplicationContext context: android.content.Context,
+    ): com.hermes.client.data.audio.AudioRecorder =
+        com.hermes.client.data.audio.MediaAudioRecorder(context)
+```
+(If `AppModule` already imports `@ApplicationContext`/`Context`/`Singleton`, use the short names to match the file.)
+
+- [ ] **Step 3: Compile:** `./gradlew :app:compileDebugKotlin` → SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/data/audio/AudioRecorder.kt \
+        app/src/main/java/com/hermes/client/di/AppModule.kt
+git commit -m "feat: MediaRecorder-backed AudioRecorder + Hilt provider"
+```
+
+---
+
+### Task 4: `RecordTaskViewModel` + orchestration test
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/record/RecordTaskViewModel.kt`
+- Test: `app/src/test/java/com/hermes/client/ui/record/RecordTaskViewModelTest.kt`
+
+**Interfaces:**
+- Consumes: `AudioRecorder`/`Recording` (Task 3), `HermesRestApi.transcribe` (Task 1), `audioDataUrl` (Task 2), `ChatRepository.createSession(profile: String?): String`, `ProfileManager.active: StateFlow<String?>` + `refresh()`, `PendingShareStore.put(id, PendingShare(text=…))`.
+- Produces: `RecordTaskViewModel` with `ui: StateFlow<RecordUi>`, `navigateTo: SharedFlow<String>`, and `startRecording()`, `stopAndTranscribe()`, `cancel()`, `dismissError()`.
+
+- [ ] **Step 1: Write the failing test.** Create `RecordTaskViewModelTest.kt`. Fakes implement the real interfaces; `HermesRestApi` and `ChatRepository` are open enough to fake via their public methods — if a class is `final`, wrap the two calls the VM needs behind small interfaces is OUT OF SCOPE; instead construct real instances with fakes is OUT OF SCOPE. Use these fakes (the VM must take its collaborators as constructor params typed to allow these fakes — see Step 3; if `HermesRestApi`/`ChatRepository` are final classes, the VM takes function-typed params `transcribe: suspend (String,String)->String` and `createSession: suspend (String?)->String` instead, and the real wiring passes `api::transcribe` / `chat::createSession`):
+```kotlin
+package com.hermes.client.ui.record
+
+import com.hermes.client.data.audio.AudioRecorder
+import com.hermes.client.data.audio.Recording
+import com.hermes.client.share.PendingShare
+import com.hermes.client.share.PendingShareStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecordTaskViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    @Before fun setUp() = Dispatchers.setMain(dispatcher)
+    @After fun tearDown() = Dispatchers.resetMain()
+
+    private class FakeRecorder(var result: Recording?) : AudioRecorder {
+        var started = false; var cancelled = false
+        override fun start() { started = true }
+        override fun stop() = result
+        override fun cancel() { cancelled = true }
+    }
+
+    private fun vm(
+        recorder: AudioRecorder,
+        transcribe: suspend (String, String) -> String = { _, _ -> "hi" },
+        createSession: suspend (String?) -> String = { "sess-1" },
+        store: PendingShareStore = PendingShareStore(),
+        refresh: suspend () -> Unit = {},
+    ) = RecordTaskViewModel(
+        recorder = recorder,
+        transcribe = transcribe,
+        createSession = createSession,
+        activeProfile = MutableStateFlow<String?>("personal"),
+        refreshProfiles = refresh,
+        pendingShareStore = store,
+    )
+
+    @Test fun happy_path_transcribes_creates_session_and_stashes_prefill() = runTest {
+        val store = PendingShareStore()
+        val nav = mutableListOf<String>()
+        val model = vm(FakeRecorder(Recording(byteArrayOf(1,2,3), "audio/mp4")),
+            transcribe = { _, _ -> "  book the flight  " }, createSession = { "sess-1" }, store = store)
+        val job = kotlinx.coroutines.CoroutineScope(dispatcher).launch { model.navigateTo.collect { nav.add(it) } }
+        model.startRecording(); advanceUntilIdle()
+        assertEquals(RecordPhase.RECORDING, model.ui.value.phase)
+        model.stopAndTranscribe(); advanceUntilIdle()
+        assertEquals(listOf("sess-1"), nav)
+        assertEquals("book the flight", store.take("sess-1")?.text)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+        assertNull(model.ui.value.error)
+        job.cancel()
+    }
+
+    @Test fun nothing_recorded_sets_error_and_skips_transcribe() = runTest {
+        var called = false
+        val model = vm(FakeRecorder(null), transcribe = { _, _ -> called = true; "x" })
+        model.startRecording(); model.stopAndTranscribe(); advanceUntilIdle()
+        assertEquals(false, called)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+        org.junit.Assert.assertNotNull(model.ui.value.error)
+    }
+
+    @Test fun blank_transcript_sets_error_and_creates_no_session() = runTest {
+        var created = false
+        val model = vm(FakeRecorder(Recording(byteArrayOf(1), "audio/mp4")),
+            transcribe = { _, _ -> "   " }, createSession = { created = true; "s" })
+        model.startRecording(); model.stopAndTranscribe(); advanceUntilIdle()
+        assertEquals(false, created)
+        org.junit.Assert.assertNotNull(model.ui.value.error)
+    }
+
+    @Test fun transcribe_failure_sets_error() = runTest {
+        val model = vm(FakeRecorder(Recording(byteArrayOf(1), "audio/mp4")),
+            transcribe = { _, _ -> throw RuntimeException("boom") })
+        model.startRecording(); model.stopAndTranscribe(); advanceUntilIdle()
+        org.junit.Assert.assertNotNull(model.ui.value.error)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+    }
+
+    @Test fun cancel_stops_recorder_and_returns_idle() = runTest {
+        val rec = FakeRecorder(Recording(byteArrayOf(1), "audio/mp4"))
+        val model = vm(rec)
+        model.startRecording(); model.cancel(); advanceUntilIdle()
+        assertEquals(true, rec.cancelled)
+        assertEquals(RecordPhase.IDLE, model.ui.value.phase)
+    }
+}
+```
+(Import `kotlinx.coroutines.launch`/`CoroutineScope` as needed. If the repo has an existing `MainDispatcherRule`, use it instead of the manual `setMain`/`resetMain` — match the sibling ViewModel tests.)
+
+- [ ] **Step 2: Run → FAIL:** `./gradlew :app:testDebugUnitTest --tests "com.hermes.client.ui.record.RecordTaskViewModelTest"`
+
+- [ ] **Step 3: Implement.** Create `RecordTaskViewModel.kt`. Use function-typed collaborators for `transcribe`/`createSession` so the VM is unit-testable and Hilt wiring binds the real methods:
+```kotlin
+package com.hermes.client.ui.record
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hermes.client.data.audio.AudioRecorder
+import com.hermes.client.data.audio.audioDataUrl
+import com.hermes.client.data.network.HermesRestApi
+import com.hermes.client.data.repository.ChatRepository
+import com.hermes.client.data.repository.ProfileManager
+import com.hermes.client.share.PendingShare
+import com.hermes.client.share.PendingShareStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class RecordPhase { IDLE, RECORDING, TRANSCRIBING }
+
+data class RecordUi(val phase: RecordPhase = RecordPhase.IDLE, val error: String? = null)
+
+class RecordTaskViewModel(
+    private val recorder: AudioRecorder,
+    private val transcribe: suspend (dataUrl: String, mime: String) -> String,
+    private val createSession: suspend (profile: String?) -> String,
+    private val activeProfile: StateFlow<String?>,
+    private val refreshProfiles: suspend () -> Unit,
+    private val pendingShareStore: PendingShareStore,
+) : ViewModel() {
+
+    private val _ui = MutableStateFlow(RecordUi())
+    val ui: StateFlow<RecordUi> = _ui.asStateFlow()
+
+    private val _navigateTo = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val navigateTo: SharedFlow<String> = _navigateTo.asSharedFlow()
+
+    fun startRecording() {
+        if (_ui.value.phase != RecordPhase.IDLE) return
+        runCatching { recorder.start() }
+            .onSuccess { _ui.value = RecordUi(RecordPhase.RECORDING) }
+            .onFailure { _ui.value = RecordUi(RecordPhase.IDLE, error = "Couldn't start recording") }
+    }
+
+    fun stopAndTranscribe() {
+        if (_ui.value.phase != RecordPhase.RECORDING) return
+        val clip = recorder.stop()
+        if (clip == null) {
+            _ui.value = RecordUi(RecordPhase.IDLE, error = "Nothing recorded")
+            return
+        }
+        _ui.value = RecordUi(RecordPhase.TRANSCRIBING)
+        viewModelScope.launch {
+            try {
+                val text = transcribe(audioDataUrl(clip.bytes, clip.mime), clip.mime)
+                if (text.isBlank()) {
+                    _ui.value = RecordUi(RecordPhase.IDLE, error = "Couldn't transcribe that")
+                    return@launch
+                }
+                refreshProfiles()
+                val id = createSession(activeProfile.value)
+                pendingShareStore.put(id, PendingShare(text = text))
+                _navigateTo.emit(id)
+                _ui.value = RecordUi(RecordPhase.IDLE)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _ui.value = RecordUi(RecordPhase.IDLE, error = "Transcription failed")
+            }
+        }
+    }
+
+    fun cancel() {
+        recorder.cancel()
+        _ui.value = RecordUi(RecordPhase.IDLE)
+    }
+
+    fun dismissError() { if (_ui.value.phase == RecordPhase.IDLE) _ui.value = RecordUi(RecordPhase.IDLE) }
+}
+
+/** Hilt factory binding the function-typed collaborators to the real repositories. */
+@HiltViewModel
+class RecordTaskViewModelHilt @Inject constructor(
+    recorder: AudioRecorder,
+    api: HermesRestApi,
+    chat: ChatRepository,
+    profileManager: ProfileManager,
+    pendingShareStore: PendingShareStore,
+) : ViewModel() {
+    val delegate = RecordTaskViewModel(
+        recorder = recorder,
+        transcribe = { url, mime -> api.transcribe(url, mime) },
+        createSession = { profile -> chat.connect(); chat.createSession(profile) },
+        activeProfile = profileManager.active,
+        refreshProfiles = { profileManager.refresh() },
+        pendingShareStore = pendingShareStore,
+    )
+}
+```
+NOTE for the implementer: the `RecordTaskViewModelHilt` wrapper above is a starting point — if the codebase's `hiltViewModel()` call sites expect a single VM, prefer making `RecordTaskViewModel` itself the `@HiltViewModel` with an `@Inject constructor` that takes the real `HermesRestApi`/`ChatRepository`/`ProfileManager` and adapts them internally to the function types (keep a **second, non-Hilt** constructor — or a test-only secondary constructor — that takes the function-typed params for the unit test). Choose whichever matches the repo's other ViewModels; the unit test in Step 1 only requires that a `RecordTaskViewModel` can be built from the fakes/function-types shown. Confirm `ChatRepository.connect()` exists (it's used by `SessionsViewModel`/`MainActivity`); if `createSession` already connects, drop the `chat.connect()`.
+
+- [ ] **Step 4: Run → PASS** (all VM tests).
+- [ ] **Step 5: Full gates:** `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta` — all SUCCESSFUL.
+- [ ] **Step 6: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/record/RecordTaskViewModel.kt \
+        app/src/test/java/com/hermes/client/ui/record/RecordTaskViewModelTest.kt
+git commit -m "feat: RecordTaskViewModel orchestrating record→transcribe→new prefilled chat"
+```
+
+---
+
+### Task 5: `RecordTaskSheet` + SessionsScreen mic action + RECORD_AUDIO request
+
+**Files:**
+- Create: `app/src/main/java/com/hermes/client/ui/record/RecordTaskSheet.kt`
+- Modify: `app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt`
+
+**Interfaces:**
+- Consumes: `RecordTaskViewModel` (`ui`, `navigateTo`, `startRecording`, `stopAndTranscribe`, `cancel`, `dismissError`), `RecordPhase`, `RecordUi`; `SessionsScreen`'s existing `onOpen: (String) -> Unit`.
+
+Compose glue — no unit test; gate is compile + assembleBeta + on-device (best-effort).
+
+- [ ] **Step 1: Create `RecordTaskSheet.kt`.** A `ModalBottomSheet` rendering `RecordUi`. Use `LocalProfileAccent` for the record/active button (match how other sheets read the accent — grep `LocalProfileAccent` in the repo); `MaterialTheme.colorScheme.error` for the error text. Contract:
+```kotlin
+@androidx.compose.material3.ExperimentalMaterial3Api
+@androidx.compose.runtime.Composable
+fun RecordTaskSheet(
+    ui: RecordUi,
+    onStop: () -> Unit,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+)
+```
+Body: a `ModalBottomSheet(onDismissRequest = onDismiss)` with a centered column:
+- `ui.error != null` → the error text (`color = MaterialTheme.colorScheme.error`) + a "Try again" button (`onRetry`) + a "Close" text button (`onDismiss`).
+- else by `ui.phase`:
+  - `RECORDING` → a large filled circular record indicator (accent), a caption "Recording…", a filled **Stop** button (`onStop`) and a text **Cancel** (`onCancel`).
+  - `TRANSCRIBING` → a `CircularProgressIndicator` + "Transcribing…".
+  - `IDLE` → a caption "Getting ready…" (transient; the host starts recording on open). 
+Keep it small and dependency-free (Material3 only). Provide `contentDescription`s.
+
+- [ ] **Step 2: Wire SessionsScreen.** In `SessionsScreen.kt`:
+  1. Get the VM: `val recordVm: RecordTaskViewModel = hiltViewModel()` (match the file's other `hiltViewModel()` usage; if using the Hilt-wrapper pattern from Task 4, expose `.delegate`).
+  2. State + permission launcher near the top of the composable:
+```kotlin
+    var showRecord by rememberSaveable { mutableStateOf(false) }
+    val recordUi by recordVm.ui.collectAsStateWithLifecycle()
+    val micPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) { showRecord = true; recordVm.startRecording() }
+        else android.widget.Toast.makeText(context,
+            "Microphone needed to record a task", android.widget.Toast.LENGTH_SHORT).show()
+    }
+    fun onMicTap() {
+        val ctx = context
+        if (androidx.core.content.ContextCompat.checkSelfPermission(ctx, Manifest.permission.RECORD_AUDIO)
+                == android.content.pm.PackageManager.PERMISSION_GRANTED) {
+            showRecord = true; recordVm.startRecording()
+        } else micPermission.launch(Manifest.permission.RECORD_AUDIO)
+    }
+    LaunchedEffect(Unit) { recordVm.navigateTo.collect { showRecord = false; onOpen(it) } }
+```
+   (Use the file's existing `context`/`LocalContext` handle; add imports: `androidx.activity.compose.rememberLauncherForActivityResult`, `androidx.activity.result.contract.ActivityResultContracts`, `android.Manifest`, `androidx.lifecycle.compose.collectAsStateWithLifecycle`, `androidx.hilt.navigation.compose.hiltViewModel` — match repo conventions.)
+  3. Add a **mic** `IconButton` to the `TopAppBar` `actions` (the block at ~line 98, beside the archived action):
+```kotlin
+                        IconButton(onClick = { onMicTap() }) {
+                            Icon(Icons.Rounded.Mic, contentDescription = "Record a task")
+                        }
+```
+   (Import `androidx.compose.material.icons.rounded.Mic` + `Icon` if not already present.)
+  4. Host the sheet (near the FAB / end of the Scaffold content):
+```kotlin
+    if (showRecord) {
+        RecordTaskSheet(
+            ui = recordUi,
+            onStop = { recordVm.stopAndTranscribe() },
+            onCancel = { recordVm.cancel(); showRecord = false },
+            onRetry = { recordVm.dismissError(); recordVm.startRecording() },
+            onDismiss = {
+                if (recordUi.phase == RecordPhase.RECORDING) recordVm.cancel()
+                recordVm.dismissError(); showRecord = false
+            },
+        )
+    }
+```
+
+- [ ] **Step 3: Gates:** `:app:compileDebugKotlin`, `:app:testDebugUnitTest` (0 failures), `:app:assembleBeta` — all SUCCESSFUL.
+
+- [ ] **Step 4: On-device (best-effort).** `:app:installBeta`. Home → tap the mic action → grant RECORD_AUDIO → sheet shows "Recording…" → speak → **Stop** → "Transcribing…" → a new chat opens with the transcript in the composer. If the gateway has no STT, confirm the sheet shows an error and no chat is created (no crash). Record pass/fail + the STT caveat in the PR.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/hermes/client/ui/record/RecordTaskSheet.kt \
+        app/src/main/java/com/hermes/client/ui/sessions/SessionsScreen.kt
+git commit -m "feat: record-a-task mic action + sheet on the home session list"
+```
+
+---
+
+## Notes for the executor
+- Prefill (not auto-send): the transcript lands in the new chat's composer via `PendingShareStore` — do NOT auto-submit.
+- Per-tenant accent for the record/active affordances; `colorScheme.error` for errors — never the accent for errors.
+- Do NOT touch the composer's existing `RecognizerIntent` dictation mic (`ChatScreen.kt`) — this is a separate home-screen entry point.
+- The gateway STT backend is a runtime prerequisite, not a client concern — surface its absence as the transcribe error path; never crash.
+- If `HermesRestApi`/`ChatRepository`/`ProfileManager` differ from the assumed signatures, the ground truth is the code — adapt the wiring, keep the VM's function-typed seam so the unit test holds.

--- a/docs/superpowers/specs/2026-07-17-record-to-task-design.md
+++ b/docs/superpowers/specs/2026-07-17-record-to-task-design.md
@@ -1,0 +1,120 @@
+# Record-to-Task (v2) — Design
+
+**Wave:** Quick-wins (client-only). **Branch:** `feature/record-to-task` (off `dev`).
+
+**Goal:** Capture a spoken task as a longer voice note, transcribe it server-side, and open a **new** chat prefilled with the transcript — turning a voice note into a task without typing.
+
+**Constraints:** Kotlin/Compose/Material3/Hilt, per-tenant accent for chrome (semantic colors for error). No AI attribution; gitleaks before push; PR into `dev`.
+
+## Feasibility (from the gateway + app audit)
+- **Transcribe endpoint exists:** `POST /api/audio/transcribe` (`hermes_cli/web_server.py:3743`) takes JSON `{ data_url, mime_type? }` where `data_url` is a base64 data URL (`data:<mime>;base64,<b64>`). Accepts `audio/*` (incl. `audio/mp4`/m4a, aac, webm, wav…); 25 MB cap. Returns `{ ok, transcript, provider }`; failures are non-2xx with a `{detail}` body.
+- **Gateway prerequisite (not client-controlled):** transcription needs an STT backend on the gateway host — default `local` (faster-whisper), or a cloud STT key + `stt.provider`. If none is configured the endpoint returns an error; the app surfaces it gracefully.
+- **Authenticated REST client ready:** `HermesRestApi` (hand-rolled OkHttp) already attaches the gateway base URL + `X-Hermes-Session-Token` on every call. A new `transcribe(...)` method just POSTs.
+- **New-chat + prefill rail ready:** `ChatRepository.createSession(profile)` + the existing `PendingShareStore.put(id, PendingShare(text=…))` → `ChatViewModel` picks it up as `initialDraft` → the composer draft. This is exactly how text-share opens a prefilled chat today.
+- **No new Gradle deps:** `MediaRecorder` + Base64 are framework; OkHttp already present; `okhttp-mockwebserver` is already a test dep.
+
+## Scope
+- **In:** a "Record a task" mic action on the home session list → RECORD_AUDIO runtime permission → record (MediaRecorder, `audio/mp4`/AAC) → stop → base64 data URL → `POST /api/audio/transcribe` → on success, create a new chat and **prefill** the transcript into its composer (review-before-send). Recording/transcribing/error UX in a bottom sheet.
+- **Out (deferred):** auto-submit without review; in-chat "record note into this thread"; audio playback/waveform; on-device offline transcription; a settings toggle for STT provider (gateway-config-owned).
+
+## Why prefill, not auto-send
+STT is imperfect and the note may be long. Prefilling the new chat's composer lets the user glance/fix before sending — and reuses the existing share rail verbatim (zero new navigation plumbing). Auto-send is the deferred variant.
+
+## Architecture
+
+### 1. `data/network/HermesRestApi.kt` (modify) — transcribe
+```kotlin
+suspend fun transcribe(dataUrl: String, mimeType: String): String = withContext(Dispatchers.IO) {
+    val obj = buildJsonObject { put("data_url", dataUrl); put("mime_type", mimeType) }
+    val payload = json.encodeToString(JsonObject.serializer(), obj)
+        .toRequestBody("application/json".toMediaType())
+    okHttp.newCall(builder("/api/audio/transcribe").post(payload).build()).execute().use { resp ->
+        val body = resp.body?.string().orEmpty()
+        if (!resp.isSuccessful) throw HermesApiException(resp.code, "transcription failed")
+        json.decodeFromString<JsonObject>(body)["transcript"]?.jsonPrimitive?.content?.trim() ?: ""
+    }
+}
+```
+Mirrors `revealEnv`. Tested with MockWebServer (already a test dep).
+
+### 2. `data/audio/AudioDataUrl.kt` (new, pure) — encoding
+```kotlin
+/** Build a base64 data URL the gateway accepts: data:<mime>;base64,<b64>. */
+fun audioDataUrl(bytes: ByteArray, mime: String): String =
+    "data:$mime;base64," + java.util.Base64.getEncoder().encodeToString(bytes)
+```
+Uses `java.util.Base64` (JVM — unit-testable without Robolectric), not `android.util.Base64`.
+
+### 3. `data/audio/AudioRecorder.kt` (new) — recorder abstraction + MediaRecorder impl
+```kotlin
+data class Recording(val bytes: ByteArray, val mime: String)
+
+/** Records a single voice note. Injected so the ViewModel is testable with a fake. */
+interface AudioRecorder {
+    fun start()                 // begin capture (no-op if already recording)
+    fun stop(): Recording?      // stop + return the clip (null on failure/empty)
+    fun cancel()                // stop + discard
+}
+```
+`MediaAudioRecorder(@ApplicationContext ctx)` — MediaRecorder `MPEG_4`/`AAC` to a cache temp file, `stop()` reads bytes + returns mime `audio/mp4`, `cancel()` deletes. Device-bound → covered on-device, not unit-tested. Provided via Hilt.
+
+### 4. `ui/record/RecordTaskViewModel.kt` (new) — orchestration
+Injects `AudioRecorder`, `HermesRestApi`, `ChatRepository`, `ProfileManager`, `PendingShareStore`.
+```kotlin
+enum class RecordPhase { IDLE, RECORDING, TRANSCRIBING }
+data class RecordUi(val phase: RecordPhase = RecordPhase.IDLE, val error: String? = null)
+val ui: StateFlow<RecordUi>
+val navigateTo: SharedFlow<String>            // created session id → host navigates
+
+fun startRecording()                          // recorder.start(); phase=RECORDING
+fun stopAndTranscribe()                       // recorder.stop() → encode → transcribe → new chat
+fun cancel()                                  // recorder.cancel(); phase=IDLE
+fun dismissError()                            // phase=IDLE, error=null
+```
+`stopAndTranscribe`: `recorder.stop()` → null ⇒ error "Nothing recorded"; else `audioDataUrl(bytes,mime)` → phase=TRANSCRIBING → `runCatching { api.transcribe(url, mime) }`; blank ⇒ error "Couldn't transcribe that"; failure ⇒ error "Transcription failed"; success ⇒ `chat.connect()`, `profileManager.refresh()`, `id = chat.createSession(profileManager.active.value)`, `pendingShareStore.put(id, PendingShare(text=transcript))`, emit `id`, phase=IDLE. All `runCatching` rethrows `CancellationException`.
+
+### 5. `ui/record/RecordTaskSheet.kt` (new) + `ui/sessions/SessionsScreen.kt` (modify)
+- **Sheet** (`ModalBottomSheet`): IDLE → a large record button + hint; RECORDING → a pulsing record indicator + a **Stop** button + Cancel; TRANSCRIBING → spinner "Transcribing…"; `error != null` → the message (in `colorScheme.error`) + Retry (→ IDLE) / Dismiss. Record/active accents use `LocalProfileAccent`; error uses the semantic error color.
+- **SessionsScreen:** add a **mic** `IconButton` ("Record a task") in the existing `TopAppBar` `actions`. Tap → check `RECORD_AUDIO` (a `RequestPermission()` launcher); granted ⇒ open the sheet + `recordVm.startRecording()`; else request, and open+start on grant. Collect `recordVm.navigateTo` → `onOpen(id)` (the existing nav callback) → the new chat opens prefilled.
+
+### 6. `AndroidManifest.xml` (modify) + Hilt
+- Add `<uses-permission android:name="android.permission.RECORD_AUDIO" />`.
+- `AppModule`: `@Provides fun provideAudioRecorder(@ApplicationContext ctx): AudioRecorder = MediaAudioRecorder(ctx)`.
+
+## Data flow
+```
+home ⋮ mic → RECORD_AUDIO grant → sheet + recorder.start
+Stop → recorder.stop() bytes/mime → audioDataUrl → POST /api/audio/transcribe → transcript
+     → createSession(active) → PendingShareStore.put(id, PendingShare(text=transcript)) → onOpen(id)
+     → ChatViewModel.open() takes the share → composer prefilled with the transcript
+```
+
+## Error handling
+- Permission denied → sheet not opened (or a toast "Microphone needed to record a task").
+- Nothing recorded / empty clip → error state, no chat created.
+- Blank transcript (STT returned nothing) / endpoint error (no STT configured, 4xx/5xx/413) → error state + Retry; no chat created; no crash.
+- `createSession` failure after a good transcript → error "Couldn't start a chat" (transcript preserved for Retry is out of scope; Retry re-records).
+
+## Testing
+- **`AudioDataUrlTest`** (pure): known bytes + mime → exact `data:<mime>;base64,<b64>` (verify prefix + round-trip decode).
+- **`HermesRestApiTranscribeTest`** (MockWebServer): 200 `{transcript:"hi"}` → "hi" (trimmed); 400 → `HermesApiException(400)`; 200 with missing/blank transcript → "".
+- **`RecordTaskViewModelTest`** (fakes): stop→transcribe→createSession→stash `PendingShare(text)`→emit id (phase returns IDLE); null recording → error, no api call; blank transcript → error, no session; transcribe throws → error; createSession throws → error.
+- `MediaAudioRecorder`, the sheet, and SessionsScreen wiring are device/Compose glue — verified on-device (best-effort; needs mic + a gateway with STT).
+
+## On-device verification
+Home → mic → grant RECORD_AUDIO → record a short spoken task → Stop → "Transcribing…" → a new chat opens with the transcript in the composer. With no STT on the gateway → an error state, no chat, no crash. (Best-effort: the emulator mic + a gateway STT backend are required; covered by the unit tests + reviews otherwise.)
+
+## Files
+| Action | Path |
+|--------|------|
+| Modify | `data/network/HermesRestApi.kt` (`transcribe`) + `HermesRestApiTranscribeTest.kt` |
+| New | `data/audio/AudioDataUrl.kt` + `AudioDataUrlTest.kt` |
+| New | `data/audio/AudioRecorder.kt` (interface + `MediaAudioRecorder`) |
+| Modify | `di/AppModule.kt` (provide `AudioRecorder`) |
+| New | `ui/record/RecordTaskViewModel.kt` + `RecordTaskViewModelTest.kt` |
+| New | `ui/record/RecordTaskSheet.kt` |
+| Modify | `ui/sessions/SessionsScreen.kt` (mic action + sheet host + permission) |
+| Modify | `AndroidManifest.xml` (RECORD_AUDIO) |
+
+## Build & gates
+`JAVA_HOME=…`: `:app:compileDebugKotlin`, `:app:testDebugUnitTest`, `:app:assembleBeta`. gitleaks before push; PR into `dev`.


### PR DESCRIPTION
Final quick-wins wave (client-only, no gateway change). Capture a spoken task, transcribe it via the gateway's existing `POST /api/audio/transcribe`, and open a **new** chat prefilled with the transcript — a voice note becomes a task without typing.

## What ships
- A **mic action** on the home session list → `RECORD_AUDIO` runtime permission → a record bottom sheet (Recording → Stop/Cancel; Transcribing spinner; error + Retry). `MediaRecorder` captures `audio/mp4`/AAC.
- `HermesRestApi.transcribe(dataUrl, mime)` POSTs a base64 data URL to `/api/audio/transcribe`; `RecordTaskViewModel` orchestrates record → transcribe → `createSession(active)` → **prefill** the transcript via the existing `PendingShareStore` share rail → navigate to the new chat.
- Kept distinct from the composer's on-device `RecognizerIntent` dictation mic (untouched).

## Design notes
- **Prefill, not auto-send:** the transcript lands in the new chat's composer (review-before-send — safer given STT is imperfect), reusing the text-share rail verbatim.
- **Gateway prerequisite:** transcription needs an STT backend on the gateway host (default `local`/faster-whisper, or a cloud STT key). Its absence surfaces as a graceful error — never a crash.

## Quality
- Subagent-driven: 5 TDD tasks, per-task reviews + an **opus whole-branch review = READY TO MERGE** (put/take session-id invariant confirmed end-to-end; prefill-not-autosend confirmed).
- Two Important findings caught & fixed mid-branch: a `MediaRecorder` temp-file/resource leak on start/read failure; a `stopAndTranscribe` reentrancy + start-window race (now synchronous phase + guard + `startJob.join()`, base64 off the main thread). Plus a post-review guard so an explicit `"transcript": null` can't produce a phantom "null" chat.
- **Gates:** 321 unit tests pass (incl. transcribe MockWebServer, `audioDataUrl` round-trip, VM orchestration incl. double-stop reentrancy); compile + assembleBeta green; gitleaks clean.
- On-device (emulator-5554, best-effort): installs + launches clean, `RECORD_AUDIO` declared. The full record→transcribe→prefill path needs a mic + gateway STT the emulator can't supply — carried by the unit tests + reviews.

## Deferred (follow-ups, non-blocking)
Auto-submit variant; in-chat "record into this thread"; audio playback/waveform; `onCleared()→recorder.cancel()` belt-and-braces; Cancel-path sheet slide animation.